### PR TITLE
Fix import error raised by QGIS 2.12 when importing QPyNullVariant

### DIFF
--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -23,7 +23,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 """
-from qgis import QPyNullVariant
 from qgis.core import (QgsVectorLayer,
                        QgsMapLayerRegistry,
                        QgsField,
@@ -34,7 +33,7 @@ from qgis.core import (QgsVectorLayer,
 from qgis.gui import QgsMessageBar
 from qgis.analysis import QgsZonalStatistics
 
-from PyQt4.QtCore import QVariant
+from PyQt4.QtCore import QVariant, QPyNullVariant
 from PyQt4.QtGui import QProgressDialog
 
 import processing

--- a/svir/calculations/calculate_utils.py
+++ b/svir/calculations/calculate_utils.py
@@ -24,11 +24,10 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 """
 from copy import deepcopy
-from qgis import QPyNullVariant
 from qgis.core import QgsField
 from qgis.gui import QgsMessageBar
 
-from PyQt4.QtCore import QVariant
+from PyQt4.QtCore import QVariant, QPyNullVariant
 
 from svir.utilities.shared import (DOUBLE_FIELD_TYPE_NAME, DEBUG,
                                    SUM_BASED_OPERATORS,

--- a/svir/calculations/process_layer.py
+++ b/svir/calculations/process_layer.py
@@ -27,7 +27,7 @@ import uuid
 from numpy.testing import assert_almost_equal
 from pprint import pprint
 from types import NoneType
-import qgis
+from PyQt4.QtCore import QPyNullVariant
 from qgis.core import (QgsMapLayer,
                        QGis,
                        QgsVectorLayer,
@@ -269,7 +269,7 @@ class ProcessLayer():
             for feat in self.layer.getFeatures():
                 feat_id = feat.id()
                 value = transformed_dict[feat_id]
-                if type(value) not in (qgis.QPyNullVariant, NoneType):
+                if type(value) not in (QPyNullVariant, NoneType):
                     value = float(value)
                 self.layer.changeAttributeValue(feat_id, new_attr_id, value)
         return actual_new_attr_name, invalid_input_values

--- a/svir/calculations/transformation_algs.py
+++ b/svir/calculations/transformation_algs.py
@@ -26,7 +26,7 @@
 import math
 from numpy import mean, std, argwhere, amax, amin, log10, log
 from types import NoneType
-import qgis
+from PyQt4.QtCore import QPyNullVariant
 
 from svir.utilities.utils import Register
 
@@ -50,7 +50,7 @@ def transform(features_dict, algorithm, variant_name="", inverse=False):
     # re-added afterwards
     dict_of_null_values = {}
     for key, value in f_dict_copy.iteritems():
-        if type(value) in (qgis.QPyNullVariant, NoneType):
+        if type(value) in (QPyNullVariant, NoneType):
             dict_of_null_values[key] = value
     for key in dict_of_null_values.keys():
         del f_dict_copy[key]
@@ -247,7 +247,7 @@ def log10_(input_list,
             output_list = []
             for input_value in input_list:
                 if input_value == 0:
-                    output_value = qgis.QPyNullVariant(float)
+                    output_value = QPyNullVariant(float)
                     output_list.append(output_value)
                 else:
                     output_list.append(log10(input_value))
@@ -307,7 +307,7 @@ def sigmoid(input_list, variant_name="", inverse=False):
             try:
                 output = log(y / (1 - y))
             except:
-                output = qgis.QPyNullVariant(float)
+                output = QPyNullVariant(float)
                 invalid_input_values.append(y)
             output_list.append(output)
     else:  # direct
@@ -315,7 +315,7 @@ def sigmoid(input_list, variant_name="", inverse=False):
             try:
                 output = 1 / (1 + math.exp(-x))
             except:
-                output = qgis.QPyNullVariant(float)
+                output = QPyNullVariant(float)
                 invalid_input_values.append(x)
             output_list.append(output)
     return output_list, invalid_input_values

--- a/svir/test/test_transformations.py
+++ b/svir/test/test_transformations.py
@@ -25,11 +25,11 @@
 """
 
 import unittest
-import qgis
 
 from svir.calculations.transformation_algs import (
     transform,
     TRANSFORMATION_ALGS)
+from PyQt4.QtCore import QPyNullVariant
 
 
 class MissingValuesTestCase(unittest.TestCase):
@@ -39,7 +39,7 @@ class MissingValuesTestCase(unittest.TestCase):
         # NULL in case of missing values, where the type of those NULL elements
         # is QPyNullVariant
         # Here we test that case and the case of simple None elements
-        null_values = (qgis.QPyNullVariant(float), None)
+        null_values = (QPyNullVariant(float), None)
         for null_value in null_values:
             features_dict = {'0': 7,
                              '1': 6,
@@ -245,8 +245,8 @@ class Log10TestCase(unittest.TestCase):
             input_list, variant_name='IGNORE ZEROS')
         expected_list = [5.005391,
                          4.973507,
-                         qgis.QPyNullVariant(float),
-                         qgis.QPyNullVariant(float),
+                         QPyNullVariant(float),
+                         QPyNullVariant(float),
                          5.241965]
         for i in range(len(input_list)):
             self.assertAlmostEqual(log10_list[i], expected_list[i], places=6)
@@ -357,12 +357,12 @@ class SigmoidTestCase(unittest.TestCase):
         sigmoid_list, invalid_input_values = self.alg(input_list, inverse=True)
         expected_list = [-1,
                          0,
-                         qgis.QPyNullVariant(float),
+                         QPyNullVariant(float),
                          -0.3,
                          0.3]
         self.assertEqual(invalid_input_values, [1])
         for i in range(len(input_list)):
-            if expected_list[i] != qgis.QPyNullVariant(float):
+            if expected_list[i] != QPyNullVariant(float):
                 self.assertAlmostEqual(
                     sigmoid_list[i], expected_list[i], places=4)
 


### PR DESCRIPTION
Importing `QPyNullVariant` from `qgis` doesn't work anymore.
It has to be imported from `PyQt4.QtCore` instead.