### PR TITLE
Fix style generation for QGIS version >= 2.12

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.4
 description=Tools for the development of composite indicators measuring societal characteristics and the integration of these with physical risk estimations
 about=<p>Tools for creating and editing indicators and composite indices to measure social characteristics and for combining these with estimates of physical earthquake risk (i.e. estimates of human or infrastructure loss).</p><p>The plugin enables users to directly interact with the <ahref='https://platform.openquake.org'>OpenQuake Platform</a>, in order to browse and download socioeconomic data or existing projects, to edit projects locally in QGIS, then to upload and share them through the Platform.</p><p>This plugin was designed as a collaborative effort between the <a href='http://www.globalquakemodel.org'>GEM Foundation</a> and the <a href='http://www.cedim.de/english/'>Center for Disaster Management and Risk Reduction Technology</a>, and it has been developed by the GEM Foundation. It was formerly named GEM OpenQuake Social Vulnerability and Integrated Risk (SVIR)</p>
-version=1.7.1
+version=1.7.2
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,13 +23,9 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    1.7.1
-    New features:
-    * Refactoring of the 'supplemental information' structure, to hold also variables shared by all project definitions
-    * Re-organization of plugin's modules
-    * Count layer's vertices and write the count into the supplemental information before uploading project to the OQ-Platform
-    * Show a warning when attempting to add a node to the project definition and no more numeric fields are available
-    * Additional checkbox to toggle on-the-fly calculations while building the weighting tree
+    1.7.2
+    * Fix importation of QPyNullVariant, to work also from QGIS v2.12
+    * Fix style generation on uploading a project to the OQ-Platform, to work also from QGIS v2.12
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -339,7 +339,8 @@ def getStyleAsSld(layer, styleName):
 
 
 def rule_to_sld(rule, document, element, props):
-    if rule.symbols():
+    if (hasattr(rule, 'symbols') and rule.symbols
+            or hasattr(rule, 'symbols2') and rule.symbols2()):
         if rule.filterExpression():
             if filter in props:
                 props['filter'] += " AND "

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -339,7 +339,7 @@ def getStyleAsSld(layer, styleName):
 
 
 def rule_to_sld(rule, document, element, props):
-    if (hasattr(rule, 'symbols') and rule.symbols  # working before QGIS 2.12
+    if (hasattr(rule, 'symbols') and rule.symbols()  # working before QGIS 2.12
             or hasattr(rule, 'symbols2') and rule.symbols2()):  # working after
                                                                 # QGIS 2.12
         if rule.filterExpression():

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -339,8 +339,9 @@ def getStyleAsSld(layer, styleName):
 
 
 def rule_to_sld(rule, document, element, props):
-    if (hasattr(rule, 'symbols') and rule.symbols
-            or hasattr(rule, 'symbols2') and rule.symbols2()):
+    if (hasattr(rule, 'symbols') and rule.symbols  # working before QGIS 2.12
+            or hasattr(rule, 'symbols2') and rule.symbols2()):  # working after
+                                                                # QGIS 2.12
         if rule.filterExpression():
             if filter in props:
                 props['filter'] += " AND "

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -450,7 +450,8 @@ def encodeSldUom(outputUnit, scaleFactor):
 
 
 def symbolLayer_to_sld(symbolLayer, document, element, props):
-    if (symbolLayer.brushStyle() == Qt.Qt.NoBrush
+    if (not hasattr(symbolLayer, 'brushStyle')
+            or symbolLayer.brushStyle() == Qt.Qt.NoBrush
             and symbolLayer.borderStyle() == Qt.Qt.NoPen):
         return
     symbolizerElem = document.createElement('sld:PolygonSymbolizer')


### PR DESCRIPTION
Before QGIS version 2.12, `Rule` has the method `symbols()`,
which is replaced by `symbols2()` in QGIS version 2.12.
Also, before version 2.12, QgsSimpleLineSymbolLayerV2 always has the method `brushStyle`, but from version 2.12 this is not always true.
With this PR, the plugin should work with both QGIS versions.
Fixes https://github.com/gem/oq-irmt-qgis/issues/96