### PR TITLE
Fix #102 - Workaround for windows missing 'pkg_resources'

### DIFF
--- a/svir/__init__.py
+++ b/svir/__init__.py
@@ -32,5 +32,7 @@ def classFactory(iface):
     from svir.irmt import Irmt
     return Irmt(iface)
 
-
-__import__('pkg_resources').declare_namespace(__name__)
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    __path__ = __import__('pkgutil').extend_path(__path__, __name__)


### PR DESCRIPTION
I've tested this on a windows laptop with QGIS 2.12 that wasn't able to load the plugin (see https://github.com/gem/oq-irmt-qgis/issues/102) and it seems to solve the problem.
The issue seems related to a missing dependency (no setuptools installed).