### PR TITLE
Don't break when OpenSSL has SSLv3_METHOD disabled.

### DIFF
--- a/svir/third_party/requests/packages/urllib3/contrib/pyopenssl.py
+++ b/svir/third_party/requests/packages/urllib3/contrib/pyopenssl.py
@@ -70,9 +70,14 @@ HAS_SNI = SUBJ_ALT_NAME_SUPPORT
 # Map from urllib3 to PyOpenSSL compatible parameter-values.
 _openssl_versions = {
     ssl.PROTOCOL_SSLv23: OpenSSL.SSL.SSLv23_METHOD,
-    ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD,
     ssl.PROTOCOL_TLSv1: OpenSSL.SSL.TLSv1_METHOD,
 }
+
+try:
+    _openssl_versions.update({ssl.PROTOCOL_SSLv3: OpenSSL.SSL.SSLv3_METHOD})
+except AttributeError:
+    pass
+
 _openssl_verify = {
     ssl.CERT_NONE: OpenSSL.SSL.VERIFY_NONE,
     ssl.CERT_OPTIONAL: OpenSSL.SSL.VERIFY_PEER,


### PR DESCRIPTION

Don't break when OpenSSL has SSLv3_METHOD disabled.
this is needed at least for ubuntu 15.10

see http://stackoverflow.com/questions/28987891/#answer-29081240