### PR TITLE
Fix uploading on windows

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,7 @@ email=staff.it@globalquakemodel.org
 changelog=
     1.7.4
     * Fix uploading issue on windows
+    * Don't attempt to update project definitions after a transformation if no project definitions are available
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.4
 description=Tools for the development of composite indicators measuring societal characteristics and the integration of these with physical risk estimations
 about=Tools for creating and editing indicators and composite indices to measure social characteristics and for combining these with estimates of physical earthquake risk (i.e. estimates of human or infrastructure loss). The plugin enables users to directly interact with the OpenQuake Platform (https://platform.openquake.org), in order to browse and download socioeconomic data or existing projects, to edit projects locally in QGIS, then to upload and share them through the Platform. This plugin was designed as a collaborative effort between the GEM Foundation (http://www.globalquakemodel.org) and the Center for Disaster Management and Risk Reduction Technology (http://www.cedim.de/english/), and it has been developed by the GEM Foundation. It was formerly named GEM OpenQuake Social Vulnerability and Integrated Risk (SVIR).
-version=1.7.3
+version=1.7.4
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,10 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    1.7.3
-    * Don't break when OpenSSL has SSLv3_METHOD disabled
-    * Fix windows missing 'pkg_resources' (no setuptools installed)
-    * Remove html tags from the 'about' property in metadata.txt
+    1.7.4
+    * Fix uploading issue on windows
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk
@@ -36,7 +34,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=True
+experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False

--- a/svir/thread_worker/upload_worker.py
+++ b/svir/thread_worker/upload_worker.py
@@ -93,7 +93,7 @@ class UploadWorker(AbstractWorker):
                 'dbf_file': open('%s.dbf' % self.file_stem, 'rb'),
                 'shx_file': open('%s.shx' % self.file_stem, 'rb'),
                 'prj_file': open('%s.prj' % self.file_stem, 'rb'),
-                'xml_file': open('%s.xml' % self.file_stem, 'r'),
+                'xml_file': open('%s.xml' % self.file_stem, 'rb'),
                 'charset': 'UTF-8',
                 'permissions': json.dumps(permissions)
                 }


### PR DESCRIPTION
For some strange reason, if the xml attached to the shapefile is opened in `'r'` mode instead of `'rb'`, the uploading does not work on windows (but it still works on ubuntu).
Changing it to `'rb'` make it works on both systems.