### PR TITLE
Fix memory issue in weighting dialog (and more)

### DIFF
--- a/svir/calculations/calculate_utils.py
+++ b/svir/calculations/calculate_utils.py
@@ -196,7 +196,7 @@ def calculate_node(
         node, node_attr_name, node_attr_id, layer, discarded_feats):
     operator = node.get('operator', DEFAULT_OPERATOR)
     children = node['children']  # the existance of children should
-    # already be checked
+                                 # already be checked
     with LayerEditingManager(layer,
                              'Calculating %s' % node_attr_name,
                              DEBUG):

--- a/svir/dialogs/weight_data_dialog.py
+++ b/svir/dialogs/weight_data_dialog.py
@@ -70,6 +70,11 @@ class WeightDataDialog(QDialog):
         self.added_attrs_ids = set()
         self.discarded_feats = set()
         self.any_changes_made = False
+
+        # keep track of changes made to the tree while on-the-fly calculations
+        # are off (the tree has changed, but indices haven't been recalculated)
+        self.modified_project_definition = None
+
         self.active_layer_numeric_fields = []
         self.update_active_layer_numeric_fields()
         # keep track of the fact that the user has explicitly selected a field
@@ -155,6 +160,13 @@ class WeightDataDialog(QDialog):
             self.project_definition = self.clean_json([data])
             self._manage_style_by_field()
             self.json_cleaned.emit(self.project_definition)
+
+            # nothing has changed since the last recalculation
+            self.modified_project_definition = None
+        else:
+            # keep track of the current status of the project definition
+            # as it is in the d3 tree, so it can be used when OK is pressed
+            self.modified_project_definition = self.clean_json([data])
 
     def _manage_style_by_field(self):
         if self.style_by_field_selected:

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -697,9 +697,11 @@ class Irmt:
 
         if self.is_iri_computable(project_definition):
             iri_node = deepcopy(project_definition)
-            (added_attrs_ids, discarded_feats,
-             iri_node, was_iri_computed) = calculate_composite_variable(
-                self.iface, self.iface.activeLayer(), iri_node)
+            msg = 'Calculating %s' % iri_node['field']
+            with WaitCursorManager(msg, self.iface):
+                (added_attrs_ids, discarded_feats,
+                 iri_node, was_iri_computed) = calculate_composite_variable(
+                    self.iface, self.iface.activeLayer(), iri_node)
             project_definition = deepcopy(iri_node)
             return added_attrs_ids, discarded_feats, project_definition
 
@@ -711,17 +713,21 @@ class Irmt:
         was_svi_computed = False
         if self.is_svi_computable(project_definition):
             svi_node = deepcopy(project_definition['children'][1])
-            (svi_added_attrs_ids, svi_discarded_feats,
-             svi_node, was_svi_computed) = calculate_composite_variable(
-                self.iface, self.iface.activeLayer(), svi_node)
+            msg = 'Calculating %s' % svi_node['field']
+            with WaitCursorManager(msg, self.iface):
+                (svi_added_attrs_ids, svi_discarded_feats,
+                 svi_node, was_svi_computed) = calculate_composite_variable(
+                    self.iface, self.iface.activeLayer(), svi_node)
             project_definition['children'][1] = deepcopy(svi_node)
 
         was_ri_computed = False
         if self.is_ri_computable(project_definition):
             ri_node = deepcopy(project_definition['children'][0])
-            (ri_added_attrs_ids, ri_discarded_feats,
-             ri_node, was_ri_computed) = calculate_composite_variable(
-                self.iface, self.iface.activeLayer(), ri_node)
+            msg = 'Calculating %s' % ri_node['field']
+            with WaitCursorManager(msg, self.iface):
+                (ri_added_attrs_ids, ri_discarded_feats,
+                 ri_node, was_ri_computed) = calculate_composite_variable(
+                    self.iface, self.iface.activeLayer(), ri_node)
             project_definition['children'][0] = deepcopy(ri_node)
 
         if not was_svi_computed and not was_ri_computed:
@@ -952,8 +958,9 @@ class Irmt:
                 else:
                     target_attr_name = ('_' + input_attr_name)[:10]
                 try:
-                    with WaitCursorManager("Applying transformation",
-                                           self.iface):
+                    msg = "Applying '%s' transformation to field '%s'" % (
+                        algorithm_name, input_attr_name)
+                    with WaitCursorManager(msg, self.iface):
                         res_attr_name, invalid_input_values = ProcessLayer(
                             layer).transform_attribute(input_attr_name,
                                                        algorithm_name,

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -697,7 +697,7 @@ class Irmt:
 
         if self.is_iri_computable(project_definition):
             iri_node = deepcopy(project_definition)
-            msg = 'Calculating %s' % iri_node['field']
+            msg = 'Calculating %s' % iri_node['name']
             with WaitCursorManager(msg, self.iface):
                 (added_attrs_ids, discarded_feats,
                  iri_node, was_iri_computed) = calculate_composite_variable(
@@ -713,7 +713,7 @@ class Irmt:
         was_svi_computed = False
         if self.is_svi_computable(project_definition):
             svi_node = deepcopy(project_definition['children'][1])
-            msg = 'Calculating %s' % svi_node['field']
+            msg = 'Calculating %s' % svi_node['name']
             with WaitCursorManager(msg, self.iface):
                 (svi_added_attrs_ids, svi_discarded_feats,
                  svi_node, was_svi_computed) = calculate_composite_variable(
@@ -723,7 +723,7 @@ class Irmt:
         was_ri_computed = False
         if self.is_ri_computable(project_definition):
             ri_node = deepcopy(project_definition['children'][0])
-            msg = 'Calculating %s' % ri_node['field']
+            msg = 'Calculating %s' % ri_node['name']
             with WaitCursorManager(msg, self.iface):
                 (ri_added_attrs_ids, ri_discarded_feats,
                  ri_node, was_ri_computed) = calculate_composite_variable(

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -975,27 +975,30 @@ class Irmt:
                         tr("Error"),
                         tr(e.message),
                         level=QgsMessageBar.CRITICAL)
-                active_layer_id = self.iface.activeLayer().id()
-                read_layer_suppl_info_from_qgs(
-                    active_layer_id, self.supplemental_information)
-                if (dlg.ui.track_new_field_ckb.isChecked()
-                        and target_attr_name != input_attr_name
-                        and active_layer_id in self.supplemental_information):
-                    suppl_info = self.supplemental_information[active_layer_id]
-                    try:
-                        proj_defs = suppl_info['project_definitions']
-                    except KeyError:
-                        # do nothing if the project still has no project
-                        # definitions to update
-                        pass
-                    else:
-                        for proj_def in proj_defs:
-                            replace_fields(proj_def,
-                                           input_attr_name,
-                                           target_attr_name)
-                        suppl_info['project_definitions'] = proj_defs
-                        write_layer_suppl_info_to_qgs(active_layer_id,
-                                                      suppl_info)
+                else:  # only if the transformation was performed successfully
+                    active_layer_id = self.iface.activeLayer().id()
+                    read_layer_suppl_info_from_qgs(
+                        active_layer_id, self.supplemental_information)
+                    if (dlg.ui.track_new_field_ckb.isChecked()
+                            and target_attr_name != input_attr_name
+                            and (active_layer_id
+                                 in self.supplemental_information)):
+                        suppl_info = self.supplemental_information[
+                            active_layer_id]
+                        try:
+                            proj_defs = suppl_info['project_definitions']
+                        except KeyError:
+                            # do nothing if the project still has no project
+                            # definitions to update
+                            pass
+                        else:
+                            for proj_def in proj_defs:
+                                replace_fields(proj_def,
+                                               input_attr_name,
+                                               target_attr_name)
+                            suppl_info['project_definitions'] = proj_defs
+                            write_layer_suppl_info_to_qgs(active_layer_id,
+                                                          suppl_info)
         elif dlg.use_advanced:
             layer = self.iface.activeLayer()
             if layer.isModified():

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -940,7 +940,7 @@ class Irmt:
                 elif dlg.ui.fields_multiselect.selected_widget.count() == 1:
                     target_attr_name = dlg.ui.new_field_name_txt.text()
                 else:
-                    target_attr_name = ('T_' + input_attr_name)[:10]
+                    target_attr_name = ('_' + input_attr_name)[:10]
                 try:
                     with WaitCursorManager("Applying transformation",
                                            self.iface):

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -641,6 +641,16 @@ class Irmt:
                     dlg.project_definition)
                 dlg.added_attrs_ids.update(added_attrs_ids)
                 dlg.discarded_feats = discarded_feats
+            # But if changes were made to the tree while the on-the-fly
+            # calculation was disabled, then we need to recalculate indices
+            # using the modified project definition
+            elif dlg.modified_project_definition:
+                (added_attrs_ids,
+                 discarded_feats,
+                 edited_project_definition) = self.recalculate_indexes(
+                    dlg.modified_project_definition)
+                dlg.added_attrs_ids.update(added_attrs_ids)
+                dlg.discarded_feats = discarded_feats
             else:
                 edited_project_definition = deepcopy(dlg.project_definition)
             self.notify_added_attrs_and_discarded_feats(

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.4
 description=Tools for the development of composite indicators measuring societal characteristics and the integration of these with physical risk estimations
 about=Tools for creating and editing indicators and composite indices to measure social characteristics and for combining these with estimates of physical earthquake risk (i.e. estimates of human or infrastructure loss). The plugin enables users to directly interact with the OpenQuake Platform (https://platform.openquake.org), in order to browse and download socioeconomic data or existing projects, to edit projects locally in QGIS, then to upload and share them through the Platform. This plugin was designed as a collaborative effort between the GEM Foundation (http://www.globalquakemodel.org) and the Center for Disaster Management and Risk Reduction Technology (http://www.cedim.de/english/), and it has been developed by the GEM Foundation. It was formerly named GEM OpenQuake Social Vulnerability and Integrated Risk (SVIR).
-version=1.7.4
+version=1.7.5
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,9 +23,11 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    1.7.4
-    * Fix uploading issue on windows
-    * Don't attempt to update project definitions after a transformation if no project definitions are available
+    1.7.5
+    * Fix memory leak in weighting dialog
+    * Fix corner case in tracking transformed fields when transformation can not be completed
+    * Set transformed field names automatically to _ORIGNAME instead of T_ORIGNAME
+      (names up to 9 characters will not be truncated by the max 10 characters constraint of shapefiles)
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -28,6 +28,8 @@ changelog=
     * Fix corner case in tracking transformed fields when transformation can not be completed
     * Set transformed field names automatically to _ORIGNAME instead of T_ORIGNAME
       (names up to 9 characters will not be truncated by the max 10 characters constraint of shapefiles)
+    * Do not lose the modified project definition while on-the-fly index calculation is disabled and
+      Ok is pressed
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -30,6 +30,7 @@ changelog=
       (names up to 9 characters will not be truncated by the max 10 characters constraint of shapefiles)
     * Do not lose the modified project definition while on-the-fly index calculation is disabled and
       Ok is pressed
+    * Show informative messages in the messageBar during field transformations and index calculations
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -129,13 +129,13 @@ def get_field_names(sub_tree, field_names=None):
     # field_names is an accumulator that is extended browsing the tree
     # recursively
     if field_names is None:
-        field_names = []
+        field_names = set()
     if 'field' in sub_tree:
-        field_names.append(sub_tree['field'])
+        field_names.add(sub_tree['field'])
     if 'children' in sub_tree:
         for child in sub_tree['children']:
             child_field_names = get_field_names(child, field_names)
-            field_names.extend(child_field_names)
+            field_names.union(child_field_names)
     return field_names
 
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -135,7 +135,7 @@ def get_field_names(sub_tree, field_names=None):
     if 'children' in sub_tree:
         for child in sub_tree['children']:
             child_field_names = get_field_names(child, field_names)
-            field_names.union(child_field_names)
+            field_names = field_names.union(child_field_names)
     return field_names
 
 


### PR DESCRIPTION
3 bugs fixed:
* We had a HUGE memory issue in the recursive procedure used to collect the field names in a project definition. It made the application exponentially slower the more the project definition became complex. It was causing the application to go out of memory even with relatively simple projects. Now that it is solved, things should be much faster and the weighting dialog shouldn't freeze even for much bigger and complex projects.
* When making the project definition track transformed fields, we had a problem in case one of the fields could not be transformed correctly (e.g. a corner case in which min-max transformation couldn't be performed because all the input values are equal to each other). In such case, the project definition was set to point to the transformed attribute, but the latter couldn't be found, later causing indices calculations to fail. With the proposed change, only fields that are successfully transformed will be tracked by the project definition.
* Fix https://github.com/gem/oq-irmt-qgis/issues/110

2 other changes:
* Automatic names for transformed fields will be `_` + `NAME` instead of `T_` + `NAME`. This saves one character, which for shapefiles can be very useful. Our indicator codes have 9 characters each, so the additional underscore is still within the 10 characters limit for field names in shapefiles. Therefore, our indicator names will not be truncated, whereas adding 2 characters would result in the truncation of the last character of the indicator's name.
* Display messages into the messageBar during field transformations and index calculations.