### PR TITLE
Synchronize correctly the d3 tree with changes made by on-the-fly recalculations...

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.4
 description=Tools for the development of composite indicators measuring societal characteristics and the integration of these with physical risk estimations
 about=Tools for creating and editing indicators and composite indices to measure social characteristics and for combining these with estimates of physical earthquake risk (i.e. estimates of human or infrastructure loss). The plugin enables users to directly interact with the OpenQuake Platform (https://platform.openquake.org), in order to browse and download socioeconomic data or existing projects, to edit projects locally in QGIS, then to upload and share them through the Platform. This plugin was designed as a collaborative effort between the GEM Foundation (http://www.globalquakemodel.org) and the Center for Disaster Management and Risk Reduction Technology (http://www.cedim.de/english/), and it has been developed by the GEM Foundation. It was formerly named GEM OpenQuake Social Vulnerability and Integrated Risk (SVIR).
-version=1.7.5
+version=1.7.6
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -24,6 +24,8 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     1.7.6
+    * Fix corner case occurring when two nodes in a project definition had the same name and were incorrectly pointing to the same field
+    * Fix refactoring-related issue that was breaking the plugin in case on-the-fly calculations were disabled
     * Fix "What's This?" functionality on Windows
     * Fix searching functionality in the documentation
     * Minor improvements to the user manual


### PR DESCRIPTION
…avoiding to make 2 nodes pointing to a same field, which happened in some corner cases (fix #117)