### PR TITLE
Avoid removing border and fill from style

### DIFF
--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -915,8 +915,8 @@ class Irmt:
 
         not_null_rule = root_rule.children()[0].clone()
         not_null_rule.setSymbol(QgsFillSymbolV2.createSimple(
-            {'style': 'no',
-             'style_border': 'no'}))
+            {'color': '255,0,0,255',
+             'color_border': '0,0,0,255'}))
         not_null_rule.setFilterExpression('%s IS NOT NULL' % target_field)
         not_null_rule.setLabel('%s:' % target_field)
         root_rule.appendChild(not_null_rule)
@@ -974,17 +974,6 @@ class Irmt:
         self.iface.legendInterface().refreshLayerSymbology(
             self.iface.activeLayer())
         self.iface.mapCanvas().refresh()
-
-        # NOTE: The following commented lines do not work, because they apply
-        # to the active layer a solid fill and the null features are therefore
-        # colored in blue instead of being transparent
-        # The intent was to reset default symbol, otherwise if the user
-        # attempts to re-style the layer, they will need to explicitly
-        # set the border and fill). I am commenting this out for the moment.
-        # root_rule.setSymbol(QgsFillSymbolV2.createSimple(
-        #     {'style': 'solid',
-        #      'style_border': 'solid'}))
-        # self.iface.activeLayer().setRendererV2(rule_renderer)
 
     def show_settings(self):
         """

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Write log messages to the QGIS logging system
     * Limit weighting tree zooming scaleExtent to the interval [0.1, 5]
     * Before uploading a layer to the OQ-Platform, convert its projection to EPSG:4326
+    * Fix a counterintuitive behavior in the layer styling (issue #129)
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk


### PR DESCRIPTION
Fix #129 

When automatically restyling a layer after a calculation, we were setting no-pen and no-brush in a part of the legend. If users wanted to apply a different style, they needed to explicitly reset the brush and pen style. In order to avoid this, we are not hiding that part of the legend anymore, and we are showing it with with a color that makes sense.