### PR TITLE
Change check on geometry type

### DIFF
--- a/svir/dialogs/select_input_layers_dialog.py
+++ b/svir/dialogs/select_input_layers_dialog.py
@@ -50,6 +50,16 @@ from svir.ui.ui_select_input_layers import Ui_SelectInputLayersDialog
 from svir.utilities.utils import tr, count_heading_commented_lines
 
 
+# NOTE: I would like to use the qgis.core.QGis.GeometryType enum, but for some
+#       reason I can't, so I am re-defining it
+class GeometryType(object):
+    Point = 0
+    Line = 1
+    Polygon = 2
+    UnknownGeometry = 3
+    NoGeometry = 4
+
+
 class SelectInputLayersDialog(QDialog):
     """
     Modal dialog allowing to select a raster or vector layer
@@ -197,7 +207,7 @@ class SelectInputLayersDialog(QDialog):
     @pyqtSlot()
     def on_loss_layer_tbn_clicked(self):
         layer = self.open_file_dialog('loss_layer')
-        if layer and ProcessLayer(layer).is_type_in(["point", "multipoint"]):
+        if layer and layer.geometryType() == GeometryType.Point:
             cbx = self.ui.loss_layer_cbx
             cbx.addItem(layer.name())
             last_index = cbx.count() - 1
@@ -208,8 +218,7 @@ class SelectInputLayersDialog(QDialog):
     @pyqtSlot()
     def on_zonal_layer_tbn_clicked(self):
         layer = self.open_file_dialog('zonal_layer')
-        if layer and ProcessLayer(layer).is_type_in(
-                ["polygon", "multipolygon"]):
+        if layer and layer.geometryType() == GeometryType.Polygon:
             cbx = self.ui.zonal_layer_cbx
             cbx.addItem(layer.name())
             last_index = cbx.count() - 1
@@ -221,11 +230,11 @@ class SelectInputLayersDialog(QDialog):
         for key, layer in \
                 QgsMapLayerRegistry.instance().mapLayers().iteritems():
             # populate loss cbx only with layers containing points
-            if ProcessLayer(layer).is_type_in(["point", "multipoint"]):
+            if layer.geometryType() == GeometryType.Point:
                 self.ui.loss_layer_cbx.addItem(layer.name())
                 self.ui.loss_layer_cbx.setItemData(
                     self.ui.loss_layer_cbx.count()-1, layer.id())
-            if ProcessLayer(layer).is_type_in(["polygon", "multipolygon"]):
+            if layer.geometryType() == GeometryType.Polygon:
                 self.ui.zonal_layer_cbx.addItem(layer.name())
                 self.ui.zonal_layer_cbx.setItemData(
                     self.ui.zonal_layer_cbx.count()-1, layer.id())

--- a/svir/dialogs/select_input_layers_dialog.py
+++ b/svir/dialogs/select_input_layers_dialog.py
@@ -50,16 +50,6 @@ from svir.ui.ui_select_input_layers import Ui_SelectInputLayersDialog
 from svir.utilities.utils import tr, count_heading_commented_lines
 
 
-# NOTE: I would like to use the qgis.core.QGis.GeometryType enum, but for some
-#       reason I can't, so I am re-defining it
-class GeometryType(object):
-    Point = 0
-    Line = 1
-    Polygon = 2
-    UnknownGeometry = 3
-    NoGeometry = 4
-
-
 class SelectInputLayersDialog(QDialog):
     """
     Modal dialog allowing to select a raster or vector layer
@@ -207,7 +197,7 @@ class SelectInputLayersDialog(QDialog):
     @pyqtSlot()
     def on_loss_layer_tbn_clicked(self):
         layer = self.open_file_dialog('loss_layer')
-        if layer and layer.geometryType() == GeometryType.Point:
+        if layer and layer.geometryType() == QGis.Point:
             cbx = self.ui.loss_layer_cbx
             cbx.addItem(layer.name())
             last_index = cbx.count() - 1
@@ -218,7 +208,7 @@ class SelectInputLayersDialog(QDialog):
     @pyqtSlot()
     def on_zonal_layer_tbn_clicked(self):
         layer = self.open_file_dialog('zonal_layer')
-        if layer and layer.geometryType() == GeometryType.Polygon:
+        if layer and layer.geometryType() == QGis.Polygon:
             cbx = self.ui.zonal_layer_cbx
             cbx.addItem(layer.name())
             last_index = cbx.count() - 1
@@ -230,11 +220,11 @@ class SelectInputLayersDialog(QDialog):
         for key, layer in \
                 QgsMapLayerRegistry.instance().mapLayers().iteritems():
             # populate loss cbx only with layers containing points
-            if layer.geometryType() == GeometryType.Point:
+            if layer.geometryType() == QGis.Point:
                 self.ui.loss_layer_cbx.addItem(layer.name())
                 self.ui.loss_layer_cbx.setItemData(
                     self.ui.loss_layer_cbx.count()-1, layer.id())
-            if layer.geometryType() == GeometryType.Polygon:
+            if layer.geometryType() == QGis.Polygon:
                 self.ui.zonal_layer_cbx.addItem(layer.name())
                 self.ui.zonal_layer_cbx.setItemData(
                     self.ui.zonal_layer_cbx.count()-1, layer.id())

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.4
 description=Tools for the development of composite indicators measuring societal characteristics and the integration of these with physical risk estimations
 about=Tools for creating and editing indicators and composite indices to measure social characteristics and for combining these with estimates of physical earthquake risk (i.e. estimates of human or infrastructure loss). The plugin enables users to directly interact with the OpenQuake Platform (https://platform.openquake.org), in order to browse and download socioeconomic data or existing projects, to edit projects locally in QGIS, then to upload and share them through the Platform. This plugin was designed as a collaborative effort between the GEM Foundation (http://www.globalquakemodel.org) and the Center for Disaster Management and Risk Reduction Technology (http://www.cedim.de/english/), and it has been developed by the GEM Foundation. It was formerly named GEM OpenQuake Social Vulnerability and Integrated Risk (SVIR).
-version=1.7.7
+version=1.7.8
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,11 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    1.7.7
-    * Write log messages to the QGIS logging system
-    * Limit weighting tree zooming scaleExtent to the interval [0.1, 5]
-    * Before uploading a layer to the OQ-Platform, convert its projection to EPSG:4326
-    * Fix a counterintuitive behavior in the layer styling (issue #129)
+    1.7.8
+    * Fix the "aggregate loss by zone" checks on layer types
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/135

`ProcessLayer.is_type_in` raises an exception if the layer's wkbType is unknown. This exception was not catched properly by the widget used to select layers for aggregating points in polygons. The undesired effect was that the presence of any "broken" layer in the list of available layers broke the tool, making it impossible to perform the aggregation even using "good" layers.
I fixed this wrong behavior by using the built-in `QgsVectorLayer.geometryType()` instead, which does not raise any exception in case the type is unknown.
NOTE: for some reason that is not so clear to me, QGIS has two different ways to classify the geometry type of a layer. One is by the enum QGis.GeometryType and one is by wkbType. In this case, the classification done through GeometryType (that is a bit more generic) looks sufficient.