### PR TITLE
Fix workflow using SAGA, in case of long field names

### DIFF
--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-#/***************************************************************************
+# /***************************************************************************
 # Irmt
 #                                 A QGIS plugin
 # OpenQuake Integrated Risk Modelling Toolkit
@@ -197,28 +197,45 @@ def calculate_zonal_stats(loss_layer,
                     if DEBUG:
                         QgsMapLayerRegistry.instance().addMapLayer(
                             loss_layer_plus_zones)
-                    # If the zone id attribute name was already taken in
-                    # the loss layer, when SAGA added the new attribute, it
-                    # was given a different name by default. We need to get
-                    # the new attribute name (as the difference between the
-                    # loss_layer and the loss_layer_plus_zones)
-                    new_fields = set(
-                        field.name() for field in
-                        loss_layer_plus_zones.dataProvider().fields())
-                    orig_fields = set(
-                        field.name() for field in
-                        loss_layer.dataProvider().fields())
-                    zone_field_name = (new_fields - orig_fields).pop()
-                    if zone_field_name:
+                    # NOTE: In previous versions, we were identifying the
+                    # zone_field_name as the difference between the sets of
+                    # field names before and after running the
+                    # clippointswithpolygons algorithm (supposing that the only
+                    # difference was an additional field with the zone ids). It
+                    # was good also for the corner case in which the field name
+                    # for zone ids was already taken in the loss layer, and it
+                    # was therefore modified by saga). BUT... it was not taking
+                    # into account the case of long field names in the loss
+                    # layer (for instance, using a csv-based layer instead of a
+                    # shapefile). In such case, saga produces a shapefile with
+                    # laundered names, and the "difference" approach does not
+                    # work anymore. THEREFORE... we are forced to make a little
+                    # hack, assuming that the field added by saga (the one
+                    # containing zone ids) will be the last one.
+                    if (len(loss_layer_plus_zones.fields())
+                            - len(loss_layer.fields()) == 1):
+                        # NOTE: we are assuming that the field containing zone
+                        # ids will be added by saga as the last field in the
+                        # layer
+                        zone_field_name = \
+                            loss_layer_plus_zones.fields()[-1].name()
+                    else:
+                        zone_field_name = None
+                    if zone_field_name is not None:
                         zone_id_in_losses_attr_name = zone_field_name
                     else:
                         zone_id_in_losses_attr_name = \
                             zone_id_in_zones_attr_name
+                    old_field_to_new_field = {}
+                    for idx, field in enumerate(loss_layer.fields()):
+                        old_field_to_new_field[field.name()] = \
+                            loss_layer_plus_zones.fields()[idx].name()
                     res = calculate_vector_stats_aggregating_by_zone_id(
                         loss_layer_plus_zones, zonal_layer,
                         zone_id_in_losses_attr_name,
                         zone_id_in_zones_attr_name,
-                        loss_attr_names, loss_attrs_dict, iface)
+                        loss_attr_names, loss_attrs_dict, iface,
+                        old_field_to_new_field)
                     (loss_layer, zonal_layer, loss_attrs_dict) = res
     else:
         (loss_layer, zonal_layer) = \
@@ -228,7 +245,8 @@ def calculate_zonal_stats(loss_layer,
 
 def calculate_vector_stats_aggregating_by_zone_id(
         loss_layer, zonal_layer, zone_id_in_losses_attr_name,
-        zone_id_in_zones_attr_name, loss_attr_names, loss_attrs_dict, iface):
+        zone_id_in_zones_attr_name, loss_attr_names, loss_attrs_dict,
+        iface, old_field_to_new_field=None):
     """
     Once we know the zone id of each point in the loss map, we
     can count how many points are in each zone, sum and average their values
@@ -255,7 +273,11 @@ def calculate_vector_stats_aggregating_by_zone_id(
                 if loss_attr_name not in zone_stats[zone_id]:
                     zone_stats[zone_id][loss_attr_name] = {
                         'count': 0, 'sum': 0.0}
-                loss_value = point_feat[loss_attr_name]
+                if old_field_to_new_field:
+                    loss_value = point_feat[
+                        old_field_to_new_field[loss_attr_name]]
+                else:
+                    loss_value = point_feat[loss_attr_name]
                 zone_stats[zone_id][loss_attr_name]['count'] += 1
                 zone_stats[zone_id][loss_attr_name]['sum'] += loss_value
     clear_progress_message_bar(iface.messageBar(), msg_bar_item)

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.4
 description=Tools for the development of composite indicators measuring societal characteristics and the integration of these with physical risk estimations
 about=Tools for creating and editing indicators and composite indices to measure social characteristics and for combining these with estimates of physical earthquake risk (i.e. estimates of human or infrastructure loss). The plugin enables users to directly interact with the OpenQuake Platform (https://platform.openquake.org), in order to browse and download socioeconomic data or existing projects, to edit projects locally in QGIS, then to upload and share them through the Platform. This plugin was designed as a collaborative effort between the GEM Foundation (http://www.globalquakemodel.org) and the Center for Disaster Management and Risk Reduction Technology (http://www.cedim.de/english/), and it has been developed by the GEM Foundation. It was formerly named GEM OpenQuake Social Vulnerability and Integrated Risk (SVIR).
-version=1.7.13
+version=1.7.15
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,9 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    1.7.13
-    * Ignore non vector layers when populating comboboxes with layer names
-    * Accept more types for numeric fields
+    1.7.15
+    * Fix workflow using SAGA in case of long field names
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk


### PR DESCRIPTION
SAGA's clippointswithpolygons produces a shapefile with laundered names (reduced to max 10 characters). Therefore, the original field names can't be found in the output layer, unless we keep a map of old fieldnames -> laundered fieldnames.

In addition to this, I had to change the approach that was used to identify the field name for zone ids. Previously, we were assuming the loss_layer_plus_zone_ids would differ with respect to the loss_layer only by one additional field containing zone ids. But, as mentioned above, other field names could be laundered. So, the only thing we can do is to assume that the new field containing zone ids will be added "after" the existing ones, and to get the name of the last field.

Tests are green.