### PR TITLE
Let Travis check fail when a test fails

### DIFF
--- a/svir/Makefile
+++ b/svir/Makefile
@@ -63,12 +63,11 @@ test: compile transcompile
 	@echo "Regression Test Suite"
 	@echo "----------------------"
 
-	@# Preceding dash means that make will continue in case of errors
-	@-export PYTHONPATH=`pwd`:$(PYTHONPATH); \
+	@export PYTHONPATH=`pwd`:$(PYTHONPATH); \
 		export QGIS_DEBUG=0; \
 		export QGIS_LOG_FILE=/dev/null; \
 		nosetests -s -v --with-xunit --with-id test\
-		3>&1 1>&2 2>&3 3>&- || true
+		3>&1 1>&2 2>&3 3>&-
 	@echo "----------------------"
 	@echo "If you get 'no module...' errors, try sourcing"
 	@echo "the helper script we have provided first then run make test."

--- a/svir/test/test_recovery_modeling.py
+++ b/svir/test/test_recovery_modeling.py
@@ -152,6 +152,8 @@ class StochasticTestCase(unittest.TestCase):
             self.regenerate_expected_values, n_simulations=200)
 
     def test_community_disaggregate(self):
+        # FIXME this should break the test on purpose
+        self.assertTrue(False)
         approach = 'Disaggregate'
         # using only 1 asset
         dmg_by_asset_features = list(self.dmg_by_asset_layer.getFeatures())

--- a/svir/test/test_recovery_modeling.py
+++ b/svir/test/test_recovery_modeling.py
@@ -152,8 +152,6 @@ class StochasticTestCase(unittest.TestCase):
             self.regenerate_expected_values, n_simulations=200)
 
     def test_community_disaggregate(self):
-        # FIXME this should break the test on purpose
-        self.assertTrue(False)
         approach = 'Disaggregate'
         # using only 1 asset
         dmg_by_asset_features = list(self.dmg_by_asset_layer.getFeatures())


### PR DESCRIPTION
For some strange reason, the Makefile was intentionally returning an exit code 0 even in case of failing tests. This caused Travis to pass even in case of failing tests.