### PR TITLE
Fix adding features when importing data from oq-engine

### DIFF
--- a/svir/dialogs/load_npz_as_layer_dialog.py
+++ b/svir/dialogs/load_npz_as_layer_dialog.py
@@ -55,6 +55,7 @@ from svir.utilities.shared import DEBUG
 from svir.utilities.utils import (LayerEditingManager,
                                   WaitCursorManager,
                                   get_ui_class,
+                                  log_msg,
                                   get_style)
 from svir.calculations.calculate_utils import (add_numeric_attribute,
                                                add_textual_attribute,
@@ -568,7 +569,10 @@ class LoadNpzAsLayerDialog(QDialog, FORM_CLASS):
                     feat.setGeometry(QgsGeometry.fromPoint(
                         QgsPoint(row['lon'], row['lat'])))
                     feats.append(feat)
-            (res, outFeats) = self.layer.addFeatures(feats)
+            added_ok = self.layer.addFeatures(feats, makeSelected=False)
+            if not added_ok:
+                msg = 'There was a problem adding features to the layer.'
+                log_msg(msg, level='C', message_bar=self.iface.messageBar())
         # add self.layer to the legend
         QgsMapLayerRegistry.instance().addMapLayer(self.layer, False)
         rlz_group.addLayer(self.layer)

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=1.8.18
+version=1.8.19
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    1.8.19
+    * Fix adding features to layers when importing data from oq-engine outputs
     1.8.18
     * Redundancy reduced in the visualization of recovery curves
     * Fixed a numeric issue in saving shapefiles while having a locale that uses comma as decimal separator


### PR DESCRIPTION
Fix a bug that was introduced in https://github.com/gem/oq-irmt-qgis/pull/162
It was due to the fact that the methods named `addFeatures` in the QgsVectorLayer class and in the layer's dataProvider are slightly different (the former returns a boolean, and the latter returns a tuple; the former pre-selects features, the latter does not). I disabled the automatic selection, setting the makeSelected argument to False.