### PR TITLE
Use standard widgets to select colors for classification

### DIFF
--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -24,7 +24,7 @@
 
 
 from PyQt4.QtCore import pyqtSlot, QSettings, Qt
-from PyQt4.QtGui import QDialog, QPalette, QColor, QColorDialog
+from PyQt4.QtGui import QDialog, QPalette, QColorDialog
 
 from qgis.core import QgsGraduatedSymbolRendererV2, QgsProject
 
@@ -121,11 +121,7 @@ class SettingsDialog(QDialog, FORM_CLASS):
                 mySettings.value('irmt/developer_mode', False, type=bool))
 
     def set_button_color(self, button, color):
-        palette = button.palette()
-        palette.setColor(QPalette.Button, QColor(color))
-        button.setAutoFillBackground(True)
-        button.setPalette(palette)
-        button.update()
+        button.setStyleSheet("background-color: %s" % color.name())
 
     def saveState(self):
         """

--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -184,7 +184,8 @@ class SettingsDialog(QDialog, FORM_CLASS):
     def select_color(self, button):
         initial = button.palette().color(QPalette.Button)
         color = QColorDialog.getColor(initial)
-        self.set_button_color(button, color)
+        if color.isValid():
+            self.set_button_color(button, color)
 
     def accept(self):
         """

--- a/svir/ui/ui_settings.ui
+++ b/svir/ui/ui_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>501</width>
-    <height>621</height>
+    <height>628</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -138,43 +138,72 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QgsColorButtonV2" name="style_color_from"/>
-      </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
          <string>Color to</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <widget class="QgsColorButtonV2" name="style_color_to"/>
-      </item>
-      <item row="5" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_4">
         <property name="text">
          <string>Mode</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="7" column="1">
        <widget class="QComboBox" name="style_mode"/>
       </item>
-      <item row="6" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
          <string>Classes</string>
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="8" column="1">
        <widget class="QSpinBox" name="style_classes">
         <property name="minimum">
          <number>1</number>
         </property>
         <property name="value">
          <number>10</number>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="style_color_from">
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QPushButton" name="style_color_to">
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="autoFillBackground">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="default">
+         <bool>false</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -227,13 +256,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QgsColorButtonV2</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbuttonv2.h</header>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>buttonBox</tabstop>
  </tabstops>

--- a/svir/ui/ui_settings.ui
+++ b/svir/ui/ui_settings.ui
@@ -180,6 +180,9 @@
           <height>16777215</height>
          </size>
         </property>
+        <property name="autoFillBackground">
+         <bool>false</bool>
+        </property>
         <property name="text">
          <string/>
         </property>
@@ -194,7 +197,7 @@
          </size>
         </property>
         <property name="autoFillBackground">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
         <property name="text">
          <string/>


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/171 (an issue that was found on Mac and Windows)

Instead of using the more convenient (but less compatible) QgsColorButtonV2, I replaced it with a QPushButton opening a QColorDialog.

I first attempted to set the background color of buttons using their palettes, but it modified only the border of the button, so I had to set the stylesheet instead.

This implementation should run on Ubuntu, Mac OS X and Windows, but I still have to test it on Mac and Windows, to make sure it actually solves the issue.
