### PR TITLE
Plot markers in hazard curves and uniform hazard spectra

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,7 @@ email=staff.it@globalquakemodel.org
 changelog=
     1.8.21
     * Added tests for: importing hazard outputs from npz; selecting them with the Data Viewer; exporting selected data as csv.
+    * Automatically add markers to uniform hazard spectra and hazard curves
     1.8.20
     * Custom QGIS widgets for color selection were substituted with standard Qt widgets,
       improving compatibility with Windows and Mac OS X


### PR DESCRIPTION
When the plot is crowded, differentiating markers makes it easier to identify the correspondence between curves and legend items.