### PR TITLE
Unify the management of exceptions while driving the oq-engine

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -150,7 +150,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             # handle case of redirection to the login page
             if resp.url != calc_list_url and 'login' in resp.url:
                 msg = ("Please check OpenQuake Engine connection settings and"
-                       " credentials")
+                       " credentials. The call to %s was redirected to %s."
+                       % (calc_list_url, resp.url))
                 log_msg(msg, level='C',
                         message_bar=self.iface.messageBar())
                 self.is_logged_in = False

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -89,6 +89,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         # NOTE: start_polling() is called from outside, in order to reset
         #       the timer whenever the button to open the dialog is pressed
         self.finished.connect(self.stop_polling)
+        self.attempt_login()
+
+    def attempt_login(self):
         try:
             self.login()
         except (ConnectionError, InvalidSchema, MissingSchema, ReadTimeout,

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -122,17 +122,17 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     def is_lockdown(self):
         # try retrieving the engine version and see if the server
         # redirects you to the login page
-        calc_list_url = "%s/engine_version" % self.hostname
+        engine_version_url = "%s/engine_version" % self.hostname
         with WaitCursorManager():
             # it can raise exceptions, catched by self.attempt_login
             # FIXME: enable the user to set verify=True
             resp = self.session.get(
-                calc_list_url, timeout=10, verify=False)
+                engine_version_url, timeout=10, verify=False)
             # handle case of redirection to the login page
             if not resp.ok:
                 raise ConnectionError(
                     "%s %s: %s" % (resp.status_code, resp.url, resp.reason))
-            if resp.url != calc_list_url and 'login' in resp.url:
+            if resp.url != engine_version_url and 'login' in resp.url:
                 return True
         return False
 

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -49,6 +49,7 @@ from svir.third_party.requests.exceptions import (ConnectionError,
                                                   InvalidSchema,
                                                   MissingSchema,
                                                   ReadTimeout,
+                                                  SSLError,
                                                   )
 from svir.utilities.settings import get_engine_credentials
 from svir.utilities.utils import (WaitCursorManager,
@@ -138,6 +139,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 # FIXME: enable the user to set verify=True
                 resp = self.session.get(
                     calc_list_url, timeout=10, verify=False)
+            except SSLError as exc:
+                err_msg = '; '.join(exc.message.message.strerror.message[0])
+                log_msg(err_msg, level='C',
+                        message_bar=self.iface.messageBar())
+                raise
             except (ConnectionError, InvalidSchema, MissingSchema,
                     ReadTimeout, SvNetworkError) as exc:
                 log_msg(str(exc), level='C',

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -107,14 +107,14 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.hostname, username, password = get_engine_credentials(self.iface)
         # try without authentication (if authentication is disabled server
         # side)
-        # NOTE: is_lockdown() can raise exceptions, to be catched from outside
+        # NOTE: is_lockdown() can raise exceptions, to be caught from outside
         is_lockdown = self.is_lockdown()
         if not is_lockdown:
             self.is_logged_in = True
             return
         if username and password:
             with WaitCursorManager('Logging in...', self.iface):
-                # it can raise exceptions, catched by self.attempt_login
+                # it can raise exceptions, caught by self.attempt_login
                 engine_login(self.hostname, username, password, self.session)
                 # if no exception occurred
                 self.is_logged_in = True
@@ -124,7 +124,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         # redirects you to the login page
         engine_version_url = "%s/engine_version" % self.hostname
         with WaitCursorManager():
-            # it can raise exceptions, catched by self.attempt_login
+            # it can raise exceptions, caught by self.attempt_login
             # FIXME: enable the user to set verify=True
             resp = self.session.get(
                 engine_version_url, timeout=10, verify=False)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -129,6 +129,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             resp = self.session.get(
                 calc_list_url, timeout=10, verify=False)
             # handle case of redirection to the login page
+            if not resp.ok:
+                raise ConnectionError(
+                    "%s %s: %s" % (resp.status_code, resp.url, resp.reason))
             if resp.url != calc_list_url and 'login' in resp.url:
                 return True
         return False

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -400,6 +400,8 @@ class Irmt:
         if self.drive_oq_engine_server_dlg is None:
             self.drive_oq_engine_server_dlg = DriveOqEngineServerDialog(
                 self.iface)
+        else:
+            self.drive_oq_engine_server_dlg.attempt_login()
         self.drive_oq_engine_server_dlg.show()
         self.drive_oq_engine_server_dlg.raise_()
         if self.drive_oq_engine_server_dlg.is_logged_in:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -26,6 +26,9 @@ changelog=
     1.8.21
     * Added tests for: importing hazard outputs from npz; selecting them with the Data Viewer; exporting selected data as csv.
     * Automatically add markers to uniform hazard spectra and hazard curves
+    * Fixed management of possible connection errors while driving the OQ-Engine
+    * Fixed layer selection issue in the recovery modeling dialog
+    * Fixed a layout issue in the plugin's settings dialog (checkboxes correctly inserted in corresponding group boxes)
     1.8.20
     * Custom QGIS widgets for color selection were substituted with standard Qt widgets,
       improving compatibility with Windows and Mac OS X


### PR DESCRIPTION
The unification removes some duplication and improves readability. I am also handling the SSLError exception, that was not managed before and that stores the error message in a peculiar way.
I am also fixing the check on the connection, that has to be done whenever the dialog that drives the engine is created or opened.
Furthermore, I'm now checking both in cases in which the engine server's LOCKDOWN parameter is set to True or to False.

Fixes https://github.com/gem/oq-irmt-qgis/issues/183