### PR TITLE
Map selected fieldnames to laundered names

### DIFF
--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -142,7 +142,7 @@ def calculate_zonal_stats(loss_layer,
                         zonal_layer.changeAttributeValue(
                                 feat.id(), unique_id_idx, feat.id())
 
-            (_, loss_layer_plus_zones, zonal_layer,
+            (_, loss_layer_plus_zones,
              zone_id_in_losses_attr_name) = add_zone_id_to_points(
                     iface, loss_layer, zonal_layer,
                     zone_id_in_zones_attr_name)
@@ -181,7 +181,6 @@ def add_zone_id_to_points(iface, point_layer, zonal_layer,
                                ones,
              point_layer_plus_zones: the points layer with the additional field
                                      containing the zone id
-             zonal_layer: the zonal layer
              points_zone_id_attr_name: the id of the new field added to the
                                        points layer, containing the zone id
     """
@@ -191,7 +190,7 @@ def add_zone_id_to_points(iface, point_layer, zonal_layer,
     use_fallback_calculation = False
     if saga_install_err is None:
         try:
-            (point_layer, res, zonal_layer,
+            (point_layer, res,
              points_zone_id_attr_name, point_layer_plus_zones) = \
                 _add_zone_id_to_points_saga(point_layer,
                                             zonal_layer,
@@ -222,7 +221,7 @@ def add_zone_id_to_points(iface, point_layer, zonal_layer,
     #       can't use zip on lists of different length
     point_attrs_dict = {orig_fieldnames[i]: final_fieldnames[i]
                         for i in range(len(orig_fieldnames))}
-    return (point_attrs_dict, point_layer_plus_zones, zonal_layer,
+    return (point_attrs_dict, point_layer_plus_zones,
             points_zone_id_attr_name)
 
 
@@ -383,7 +382,7 @@ def _add_zone_id_to_points_saga(loss_layer, zonal_layer,
     else:
         zone_id_in_losses_attr_name = \
             zone_id_in_zones_attr_name
-    return (loss_layer, res, zonal_layer,
+    return (loss_layer, res,
             zone_id_in_losses_attr_name, loss_layer_plus_zones)
 
 

--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -145,7 +145,7 @@ def calculate_zonal_stats(loss_layer,
             (_, loss_layer_plus_zones, zonal_layer,
              zone_id_in_losses_attr_name) = add_zone_id_to_points(
                     iface, loss_layer, zonal_layer,
-                    zone_id_in_losses_attr_name, zone_id_in_zones_attr_name)
+                    zone_id_in_zones_attr_name)
 
             old_field_to_new_field = {}
             for idx, field in enumerate(loss_layer.fields()):
@@ -167,16 +167,23 @@ def calculate_zonal_stats(loss_layer,
 
 
 def add_zone_id_to_points(iface, point_layer, zonal_layer,
-                          points_zone_id_attr_name, zones_id_attr_name):
+                          zones_id_attr_name):
     """
-    this is the metod to use for getting points with an id of the containing
-    zone
+    Given a layer with points and a layer with zones, add to the points layer a
+    new field containing the id of the zone inside which it is located.
     :param iface:
-    :param point_layer:
-    :param zonal_layer:
-    :param points_zone_id_attr_name:
-    :param zones_id_attr_name:
-    :return:
+    :param point_layer: a QgsVectorLayer containing points
+    :param zonal_layer: a QgsVectorLayer containing polygons
+    :param zones_id_attr_name: name of the field of the zonal_layer that
+                               contains the zone id
+    :return: point_attrs_dict: a dictionary mapping the original field names
+                               of the point_layer with the possibly laundered
+                               ones,
+             point_layer_plus_zones: the points layer with the additional field
+                                     containing the zone id
+             zonal_layer: the zonal layer
+             points_zone_id_attr_name: the id of the new field added to the
+                                       points layer, containing the zone id
     """
 
     orig_fieldnames = [field.name() for field in point_layer.fields()]

--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -211,6 +211,8 @@ def add_zone_id_to_points(iface, point_layer, zonal_layer,
     # fieldnames might have been laundered to max 10 characters
     final_fieldnames = [
         field.name() for field in point_layer_plus_zones.fields()]
+    # NOTE: final_fieldnames contains an additional field with the id, so I
+    #       can't use zip on lists of different length
     point_attrs_dict = {orig_fieldnames[i]: final_fieldnames[i]
                         for i in range(len(orig_fieldnames))}
     return (point_attrs_dict, point_layer_plus_zones, zonal_layer,

--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -142,9 +142,9 @@ def calculate_zonal_stats(loss_layer,
                         zonal_layer.changeAttributeValue(
                                 feat.id(), unique_id_idx, feat.id())
 
-            (loss_attrs_dict, loss_layer_plus_zones, zonal_layer,
+            (_, loss_layer_plus_zones, zonal_layer,
              zone_id_in_losses_attr_name) = add_zone_id_to_points(
-                    iface, loss_attrs_dict, loss_layer, zonal_layer,
+                    iface, loss_layer, zonal_layer,
                     zone_id_in_losses_attr_name, zone_id_in_zones_attr_name)
 
             old_field_to_new_field = {}
@@ -166,13 +166,12 @@ def calculate_zonal_stats(loss_layer,
     return loss_layer, zonal_layer, loss_attrs_dict
 
 
-def add_zone_id_to_points(iface, point_attrs_dict, point_layer, zonal_layer,
+def add_zone_id_to_points(iface, point_layer, zonal_layer,
                           points_zone_id_attr_name, zones_id_attr_name):
     """
     this is the metod to use for getting points with an id of the containing
     zone
     :param iface:
-    :param point_attrs_dict:
     :param point_layer:
     :param zonal_layer:
     :param points_zone_id_attr_name:
@@ -212,8 +211,8 @@ def add_zone_id_to_points(iface, point_attrs_dict, point_layer, zonal_layer,
     # fieldnames might have been laundered to max 10 characters
     final_fieldnames = [
         field.name() for field in point_layer_plus_zones.fields()]
-    for i, fieldname in enumerate(orig_fieldnames):
-        point_attrs_dict[orig_fieldnames[i]] = final_fieldnames[i]
+    point_attrs_dict = {orig_fieldnames[i]: final_fieldnames[i]
+                        for i in range(len(orig_fieldnames))}
     return (point_attrs_dict, point_layer_plus_zones, zonal_layer,
             points_zone_id_attr_name)
 

--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -166,13 +166,13 @@ def calculate_zonal_stats(loss_layer,
     return loss_layer, zonal_layer, loss_attrs_dict
 
 
-def add_zone_id_to_points(iface, loss_attrs_dict, point_layer, zonal_layer,
+def add_zone_id_to_points(iface, point_attrs_dict, point_layer, zonal_layer,
                           points_zone_id_attr_name, zones_id_attr_name):
     """
     this is the metod to use for getting points with an id of the containing
     zone
     :param iface:
-    :param loss_attrs_dict:
+    :param point_attrs_dict:
     :param point_layer:
     :param zonal_layer:
     :param points_zone_id_attr_name:
@@ -180,12 +180,13 @@ def add_zone_id_to_points(iface, loss_attrs_dict, point_layer, zonal_layer,
     :return:
     """
 
+    orig_fieldnames = [field.name() for field in point_layer.fields()]
     saga_install_err = get_saga_install_error()
     use_fallback_calculation = False
     if saga_install_err is None:
         try:
             (point_layer, res, zonal_layer,
-             points_zone_id_attr_name, loss_layer_plus_zones) = \
+             points_zone_id_attr_name, point_layer_plus_zones) = \
                 _add_zone_id_to_points_saga(point_layer,
                                             zonal_layer,
                                             zones_id_attr_name)
@@ -204,11 +205,16 @@ def add_zone_id_to_points(iface, loss_attrs_dict, point_layer, zonal_layer,
         log_msg(saga_install_err, level='W', message_bar=iface.messageBar())
         use_fallback_calculation = True
     if use_fallback_calculation:
-        loss_layer_plus_zones, points_zone_id_attr_name = \
+        point_layer_plus_zones, points_zone_id_attr_name = \
             _add_zone_id_to_points_internal(
                     iface, point_layer, zonal_layer,
                     zones_id_attr_name)
-    return (loss_attrs_dict, loss_layer_plus_zones, zonal_layer,
+    # fieldnames might have been laundered to max 10 characters
+    final_fieldnames = [
+        field.name() for field in point_layer_plus_zones.fields()]
+    for i, fieldname in enumerate(orig_fieldnames):
+        point_attrs_dict[orig_fieldnames[i]] = final_fieldnames[i]
+    return (point_attrs_dict, point_layer_plus_zones, zonal_layer,
             points_zone_id_attr_name)
 
 

--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -157,7 +157,8 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
             QSettings().setValue('irmt/output_data_dir', path)
             self.output_data_dir_le.setText(path)
 
-    def calculate_community_level_recovery_curve(self, integrate_svi=True):
+    def calculate_community_level_recovery_curve(
+            self, point_attrs_dict, integrate_svi=True):
         # Developed By: Henry Burton
         # Edited by: Hua Kang
         # Reimplemented for this plugin by: Paolo Tormene and Marco Bernasocchi
@@ -179,6 +180,8 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
             self.output_data_dir, self.save_bldg_curves_check.isChecked())
 
         probs_field_names = list(self.fields_multiselect.get_selected_items())
+        for i, fieldname in enumerate(probs_field_names):
+            probs_field_names[i] = point_attrs_dict[fieldname]
         zonal_dmg_by_asset_probs, zonal_asset_refs = \
             recovery.collect_zonal_data(
                 probs_field_names, integrate_svi, zone_field_name)
@@ -209,12 +212,13 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
     def accept(self):
         if self.integrate_svi_check.isChecked():
             self.zone_field_name = self.zone_field_name_cbx.currentText()
-            (_, self.dmg_by_asset_layer, self.svi_layer,
+            (point_attrs_dict, self.dmg_by_asset_layer, self.svi_layer,
              self.zone_field_name) = add_zone_id_to_points(
-                self.iface, None, self.dmg_by_asset_layer,
+                self.iface, {}, self.dmg_by_asset_layer,
                 self.svi_layer, None, self.zone_field_name)
         with WaitCursorManager('Generating recovery curves...', self.iface):
             self.calculate_community_level_recovery_curve(
+                point_attrs_dict,
                 self.integrate_svi_check.isChecked())
         msg = 'Recovery curves have been saved to [%s]' % self.output_data_dir
         log_msg(msg, level='I', message_bar=self.iface.messageBar())

--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -214,7 +214,7 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
             self.zone_field_name = self.zone_field_name_cbx.currentText()
             (point_attrs_dict, self.dmg_by_asset_layer, self.svi_layer,
              self.zone_field_name) = add_zone_id_to_points(
-                self.iface, {}, self.dmg_by_asset_layer,
+                self.iface, self.dmg_by_asset_layer,
                 self.svi_layer, None, self.zone_field_name)
         with WaitCursorManager('Generating recovery curves...', self.iface):
             self.calculate_community_level_recovery_curve(

--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -215,7 +215,7 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
             (point_attrs_dict, self.dmg_by_asset_layer, self.svi_layer,
              self.zone_field_name) = add_zone_id_to_points(
                 self.iface, self.dmg_by_asset_layer,
-                self.svi_layer, None, self.zone_field_name)
+                self.svi_layer, self.zone_field_name)
         with WaitCursorManager('Generating recovery curves...', self.iface):
             self.calculate_community_level_recovery_curve(
                 point_attrs_dict,

--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -212,7 +212,7 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
     def accept(self):
         if self.integrate_svi_check.isChecked():
             self.zone_field_name = self.zone_field_name_cbx.currentText()
-            (point_attrs_dict, self.dmg_by_asset_layer, self.svi_layer,
+            (point_attrs_dict, self.dmg_by_asset_layer,
              self.zone_field_name) = add_zone_id_to_points(
                 self.iface, self.dmg_by_asset_layer,
                 self.svi_layer, self.zone_field_name)


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/190

While aggregating points by zone, if the original layer contains long names, those names might be laundered to contain max 10 characters. When it happens, the selected original fields that contain damage state probabilities might not be found (not found returns -1), and the recovery modeling workflow would assume probabilities are contained in the field of index -1 (the last one) which instead contains the zone id. This was causing linux to produce bad results and windows to crash.
Here I am fixing it by mapping the original field names and the laundered ones, so the selected fields can actually be found and the calculation produces meaningful results.

While working on this I found out that a previous refactoring of some functions included in some functions' signatures and return values some unused objects, that now are removed.