### PR TITLE
Explain how to add openstreetmap without using external plugins

### DIFF
--- a/svir/help/source/15_viewer_dock.rst
+++ b/svir/help/source/15_viewer_dock.rst
@@ -54,6 +54,23 @@ and latitude of the points corresponding to each of the curves in the plot. By
 hovering on the legend items or on the curves, the corresponding points in the
 map are highlighted.
 
+
+.. warning:: The highlighting effect produced by hovering with the mouse on
+   legend items or curves, stops working correctly when a layer is loaded using
+   the OpenLayers Plugin. Please note that, starting from QGIS 2.18, base maps
+   can be added as layers without installing any external plugin (such as
+   OpenLayers), but using the new core functionality *XYZ driver* instead. In
+   order to do so, you have to open the :guilabel:`Browser Panel`, right-click
+   on the :guilabel:`Tile Server (XYZ)` and select :guilabel:`New
+   connection...`.  Then, for instance, to add a connection to OpenStreetMap,
+   you can insert into the text box the following string:
+   `http://tile.openstreetmap.org/{z}/{x}/{y}.png`. Then press :guilabel:`Ok`
+   and insert a name for the tile layer (e.g., *OpenStreetMap*). Afterwards, it
+   is sufficient to double-click on the new item you have just created, to add
+   OpenStreetMap to the :guilabel:`Layers Panel` and to visualize it in the map
+   canvas.
+
+
 .. _fig-dataViewerHazardCurves:
 
 .. figure:: images/dataViewerHazardCurves.png


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/204
(it describes something that is available from QGIS 2.18+, but I would not invest time fixing the interaction with OpenLayers Plugin) 

I'm adding to the manual a warning about the fact that the OpenLayers Plugin breaks the behavior of the data viewer, that should highlight the corresponding point in the map when the mouse is moved on a hazard curve. Where the highlighting effect is described, I am adding a warning, explaining how to use tile servers through a built-in QGIS functionality (as suggested by @mbernasocchi), without using any external plugin.
Please note that OpenStreetMap is loaded faster and more efficiently this way, and we can avoid depending on a third-party plugin.
