### PR TITLE
Loaders of oq-engine outputs refactored using inheritance

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -62,6 +62,10 @@ from svir.utilities.utils import (WaitCursorManager,
                                   SvNetworkError,
                                   )
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.dialogs.load_ruptures_as_layer_dialog import (
+    LoadRupturesAsLayerDialog)
+from svir.dialogs.load_dmg_by_asset_as_layer_dialog import (
+    LoadDmgByAssetAsLayerDialog)
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 
 FORM_CLASS = get_ui_class('ui_drive_engine_server.ui')
@@ -481,8 +485,15 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             if outtype in ('npz', 'csv'):
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)
-                dlg = LoadOutputAsLayerDialog(
-                    self.iface, output_type, filepath)
+                if output_type == 'ruptures':
+                    dlg = LoadRupturesAsLayerDialog(
+                        self.iface, output_type, filepath)
+                elif output_type == 'dmg_by_asset':
+                    dlg = LoadDmgByAssetAsLayerDialog(
+                        self.iface, output_type, filepath)
+                else:
+                    dlg = LoadOutputAsLayerDialog(
+                        self.iface, output_type, filepath)
                 dlg.exec_()
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -66,6 +66,14 @@ from svir.dialogs.load_ruptures_as_layer_dialog import (
     LoadRupturesAsLayerDialog)
 from svir.dialogs.load_dmg_by_asset_as_layer_dialog import (
     LoadDmgByAssetAsLayerDialog)
+from svir.dialogs.load_gmf_data_as_layer_dialog import (
+    LoadGmfDataAsLayerDialog)
+from svir.dialogs.load_hmaps_as_layer_dialog import (
+    LoadHazardMapsAsLayerDialog)
+from svir.dialogs.load_hcurves_as_layer_dialog import (
+    LoadHazardCurvesAsLayerDialog)
+from svir.dialogs.load_uhs_as_layer_dialog import (
+    LoadUhsAsLayerDialog)
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 
 FORM_CLASS = get_ui_class('ui_drive_engine_server.ui')
@@ -490,6 +498,18 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                         self.iface, output_type, filepath)
                 elif output_type == 'dmg_by_asset':
                     dlg = LoadDmgByAssetAsLayerDialog(
+                        self.iface, output_type, filepath)
+                elif output_type == 'gmf_data':
+                    dlg = LoadGmfDataAsLayerDialog(
+                        self.iface, output_type, filepath)
+                elif output_type == 'hmaps':
+                    dlg = LoadHazardMapsAsLayerDialog(
+                        self.iface, output_type, filepath)
+                elif output_type == 'hcurves':
+                    dlg = LoadHazardCurvesAsLayerDialog(
+                        self.iface, output_type, filepath)
+                elif output_type == 'uhs':
+                    dlg = LoadUhsAsLayerDialog(
                         self.iface, output_type, filepath)
                 else:
                     dlg = LoadOutputAsLayerDialog(

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -61,7 +61,6 @@ from svir.utilities.utils import (WaitCursorManager,
                                   get_ui_class,
                                   SvNetworkError,
                                   )
-from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.dialogs.load_ruptures_as_layer_dialog import (
     LoadRupturesAsLayerDialog)
 from svir.dialogs.load_dmg_by_asset_as_layer_dialog import (
@@ -493,27 +492,17 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             if outtype in ('npz', 'csv'):
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)
-                if output_type == 'ruptures':
-                    dlg = LoadRupturesAsLayerDialog(
-                        self.iface, output_type, filepath)
-                elif output_type == 'dmg_by_asset':
-                    dlg = LoadDmgByAssetAsLayerDialog(
-                        self.iface, output_type, filepath)
-                elif output_type == 'gmf_data':
-                    dlg = LoadGmfDataAsLayerDialog(
-                        self.iface, output_type, filepath)
-                elif output_type == 'hmaps':
-                    dlg = LoadHazardMapsAsLayerDialog(
-                        self.iface, output_type, filepath)
-                elif output_type == 'hcurves':
-                    dlg = LoadHazardCurvesAsLayerDialog(
-                        self.iface, output_type, filepath)
-                elif output_type == 'uhs':
-                    dlg = LoadUhsAsLayerDialog(
-                        self.iface, output_type, filepath)
-                else:
-                    dlg = LoadOutputAsLayerDialog(
-                        self.iface, output_type, filepath)
+                output_type_loaders = {
+                    'ruptures': LoadRupturesAsLayerDialog,
+                    'dmg_by_asset': LoadDmgByAssetAsLayerDialog,
+                    'gmf_data': LoadGmfDataAsLayerDialog,
+                    'hmaps': LoadHazardMapsAsLayerDialog,
+                    'hcurves': LoadHazardCurvesAsLayerDialog,
+                    'uhs': LoadUhsAsLayerDialog}
+                if output_type not in output_type_loaders:
+                    raise NotImplementedError(output_type)
+                dlg = output_type_loaders[output_type](
+                    self.iface, output_type, filepath)
                 dlg.exec_()
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2013-10-24
+#        copyright            : (C) 2014 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import csv
+import tempfile
+from PyQt4.QtCore import pyqtSlot
+from svir.utilities.utils import import_layer_from_csv
+from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+
+
+class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
+    """
+    Modal dialog to load ruptures from an oq-engine output, as layer
+    """
+
+    def __init__(self, iface, output_type='ruptures', path=None, mode=None):
+        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        self.ok_button.setDisabled(True)
+        self.file_browser_tbn.setEnabled(False)
+        self.create_dmg_state_selector()
+        self.create_loss_type_selector()
+        self.create_save_as_shp_ckb()
+        self.setWindowTitle('Load scenario damage by asset from CSV, as layer')
+        self.adjustSize()
+        self.set_ok_button()
+        if self.path:
+            self.read_loss_types_and_dmg_states_from_csv_header()
+
+    @pyqtSlot()
+    def on_file_browser_tbn_clicked(self):
+        if self.open_file_dialog():
+            # read the header of the csv, so we can select from its fields
+            self.read_loss_types_and_dmg_states_from_csv_header()
+
+    def set_ok_button(self):
+        self.ok_button.setEnabled(
+            bool(self.path)
+            and self.dmg_state_cbx.currentIndex() != -1
+            and self.loss_type_cbx.currentIndex() != -1)
+        self.ok_button.setEnabled(bool(self.path))
+
+    def load_from_csv(self):
+        if self.mode == 'testing':
+            dest_shp = tempfile.mkstemp(suffix='.shp')[1]
+        else:
+            dest_shp = None  # the destination file will be selected via GUI
+        self.layer = import_layer_from_csv(
+            self, self.path_le.text(), self.output_type,
+            self.iface.messageBar(),
+            save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp)
+        dmg_state = self.dmg_state_cbx.currentText()
+        loss_type = self.loss_type_cbx.currentText()
+        field_idx = -1  # default
+        for idx, name in enumerate(self.csv_header):
+            if dmg_state in name and loss_type in name and 'mean' in name:
+                field_idx = idx
+        self.default_field_name = self.layer.fields()[field_idx].name()
+        self.style_maps()
+
+    def read_loss_types_and_dmg_states_from_csv_header(self):
+        with open(self.path, "rb") as source:
+            reader = csv.reader(source)
+            self.csv_header = reader.next()
+            # ignore asset_ref, taxonomy, lon, lat
+            names = self.csv_header[4:]
+            # extract from column names such as: structural~no_damage_mean
+            loss_types = set([name.split('~')[0] for name in names])
+            dmg_states = set(['_'.join(name.split('~')[1].split('_')[:-1])
+                              for name in names])
+            self.populate_loss_type_cbx(list(loss_types))
+            self.populate_dmg_state_cbx(list(dmg_states))
+
+    # def populate_taxonomies(self):
+    #     # FIXME: change as soon as npz risk outputs are available
+    #     if self.output_type == 'dmg_by_asset':
+    #         self.taxonomies.insert(0, 'Sum')
+    #         self.taxonomy_cbx.clear()
+    #         self.taxonomy_cbx.addItems(self.taxonomies)
+    #         self.taxonomy_cbx.setEnabled(True)
+
+    # def populate_dmg_states(self):
+    #     # FIXME: change as soon as npz risk outputs are available
+    #     if self.output_type == 'dmg_by_asset':
+    #         self.dmg_states = ['no damage']
+    #         self.dmg_states.extend(self.npz_file['oqparam'].limit_states)
+    #         self.dmg_state_cbx.clear()
+    #         self.dmg_state_cbx.setEnabled(True)
+    #         self.dmg_state_cbx.addItems(self.dmg_states)
+
+    def accept(self):
+        self.load_from_csv()
+        super(LoadDmgByAssetAsLayerDialog, self).accept()

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -31,12 +31,13 @@ from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 
 class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     """
-    Modal dialog to load ruptures from an oq-engine output, as layer
+    Modal dialog to load dmg_by_asset from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, output_type='ruptures', path=None, mode=None):
+    def __init__(
+            self, iface, output_type='dmg_by_asset', path=None, mode=None):
+        assert(output_type == 'dmg_by_asset')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.ok_button.setDisabled(True)
         self.file_browser_tbn.setEnabled(False)
         self.create_dmg_state_selector()
         self.create_loss_type_selector()
@@ -58,7 +59,6 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             bool(self.path)
             and self.dmg_state_cbx.currentIndex() != -1
             and self.loss_type_cbx.currentIndex() != -1)
-        self.ok_button.setEnabled(bool(self.path))
 
     def load_from_csv(self):
         if self.mode == 'testing':

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -64,10 +64,12 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             dest_shp = tempfile.mkstemp(suffix='.shp')[1]
         else:
             dest_shp = None  # the destination file will be selected via GUI
+        zoom_to_layer = False if self.mode == 'testing' else True
         self.layer = import_layer_from_csv(
             self, self.path_le.text(), self.output_type,
             self.iface.messageBar(),
-            save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp)
+            save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp,
+            zoom_to_layer=zoom_to_layer)
         dmg_state = self.dmg_state_cbx.currentText()
         loss_type = self.loss_type_cbx.currentText()
         field_idx = -1  # default

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -38,7 +38,6 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, output_type='dmg_by_asset', path=None, mode=None):
         assert(output_type == 'dmg_by_asset')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.file_browser_tbn.setEnabled(False)
         self.create_dmg_state_selector()
         self.create_loss_type_selector()
         self.create_save_as_shp_ckb()
@@ -107,7 +106,3 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     #         self.dmg_state_cbx.clear()
     #         self.dmg_state_cbx.setEnabled(True)
     #         self.dmg_state_cbx.addItems(self.dmg_states)
-
-    def accept(self):
-        self.load_from_csv()
-        super(LoadDmgByAssetAsLayerDialog, self).accept()

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -91,7 +91,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             self.populate_dmg_state_cbx(list(dmg_states))
 
     # def populate_taxonomies(self):
-    #     # FIXME: change as soon as npz risk outputs are available
+    #     # TODO: change as soon as npz risk outputs are available
     #     if self.output_type == 'dmg_by_asset':
     #         self.taxonomies.insert(0, 'Sum')
     #         self.taxonomy_cbx.clear()
@@ -99,7 +99,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     #         self.taxonomy_cbx.setEnabled(True)
 
     # def populate_dmg_states(self):
-    #     # FIXME: change as soon as npz risk outputs are available
+    #     # TODO: change as soon as npz risk outputs are available
     #     if self.output_type == 'dmg_by_asset':
     #         self.dmg_states = ['no damage']
     #         self.dmg_states.extend(self.npz_file['oqparam'].limit_states)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2013-10-24
+#        copyright            : (C) 2014 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.calculations.calculate_utils import add_numeric_attribute
+from svir.utilities.utils import (WaitCursorManager,
+                                  LayerEditingManager,
+                                  log_msg,
+                                  )
+from svir.utilities.shared import DEBUG
+
+
+class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
+    """
+    Modal dialog to load gmf_data from an oq-engine output, as layer
+    """
+
+    def __init__(self, iface, output_type='gmf_data', path=None, mode=None):
+        assert(output_type == 'gmf_data')
+        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        self.file_browser_tbn.setEnabled(False)
+        self.setWindowTitle(
+            'Load ground motion fields from NPZ, as layer')
+        self.create_load_selected_only_ckb()
+        self.create_rlz_selector()
+        self.create_imt_selector()
+        self.create_eid_selector()
+        if self.path:
+            self.npz_file = numpy.load(self.path, 'r')
+            self.populate_out_dep_widgets()
+        self.adjustSize()
+        self.set_ok_button()
+
+    def set_ok_button(self):
+        self.ok_button.setEnabled(
+            bool(self.path)
+            and self.imt_cbx.currentIndex() != -1)
+
+    def on_rlz_changed(self):
+        self.dataset = self.npz_file[self.rlz_cbx.currentText()]
+        imts = self.dataset.dtype.names[2:]
+        self.imt_cbx.clear()
+        self.imt_cbx.setEnabled(True)
+        self.imt_cbx.addItems(imts)
+        self.set_ok_button()
+
+    def on_imt_changed(self):
+        imt = self.imt_cbx.currentText()
+        min_eid = 0
+        max_eid = (self.dataset[imt].shape[1] - 1)
+        self.eid_sbx.cleanText()
+        self.eid_sbx.setEnabled(True)
+        self.eid_lbl.setText(
+            'Event ID (used for default styling) (range %d-%d)' % (
+                min_eid, max_eid))
+        self.eid_sbx.setRange(min_eid, max_eid)
+        self.set_ok_button()
+
+    def populate_rlz_cbx(self):
+        self.rlzs = [item[0] for item in self.npz_file.items()]
+        self.rlz_cbx.clear()
+        self.rlz_cbx.setEnabled(True)
+        # self.rlz_cbx.addItem('All')
+        self.rlz_cbx.addItems(self.rlzs)
+
+    def load_from_npz(self):
+        for rlz in self.rlzs:
+            if (self.load_selected_only_ckb.isChecked()
+                    and rlz != self.rlz_cbx.currentText()):
+                continue
+            with WaitCursorManager('Creating layer for realization "%s"...'
+                                   % rlz, self.iface):
+                self.build_layer(rlz)
+                self.style_maps()
+        if self.npz_file is not None:
+            self.npz_file.close()
+
+    def build_layer_name(self):
+        rlz = self.rlz_cbx.currentText()
+        # build layer name
+        self.imt = self.imt_cbx.currentText()
+        self.eid = self.eid_sbx.value()
+        self.default_field_name = '%s-%s' % (self.imt, self.eid)
+        # layer_name = "gmf_data_%s_eid-%s" % (rlz, self.eid)
+        layer_name = "scenario_damage_gmfs_%s_eid-%s" % (rlz, self.eid)
+        return layer_name
+
+    def get_field_names(self):
+        field_names = list(self.dataset.dtype.names)
+        return field_names
+
+    def add_field_to_layer(self, field_name):
+        field_name = "%s-%s" % (field_name, self.eid)
+        added_field_name = add_numeric_attribute(field_name, self.layer)
+        return added_field_name
+
+    def read_npz_into_layer(self, field_names):
+        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+            feats = []
+            fields = self.layer.pendingFields()
+            layer_field_names = [field.name() for field in fields]
+            dataset_field_names = self.get_field_names()
+            d2l_field_names = dict(
+                zip(dataset_field_names[2:], layer_field_names))
+            for row in self.dataset:
+                # add a feature
+                feat = QgsFeature(fields)
+                for field_name in dataset_field_names:
+                    if field_name in ['lon', 'lat']:
+                        continue
+                    layer_field_name = d2l_field_names[field_name]
+                    value = float(row[field_name][self.eid])
+                    feat.setAttribute(layer_field_name, value)
+                feat.setGeometry(QgsGeometry.fromPoint(
+                    QgsPoint(row[0], row[1])))
+                feats.append(feat)
+            added_ok = self.layer.addFeatures(feats, makeSelected=False)
+            if not added_ok:
+                msg = 'There was a problem adding features to the layer.'
+                log_msg(msg, level='C', message_bar=self.iface.messageBar())

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -97,9 +97,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         if self.npz_file is not None:
             self.npz_file.close()
 
-    def build_layer_name(self):
-        rlz = self.rlz_cbx.currentText()
-        # build layer name
+    def build_layer_name(self, rlz, **kwargs):
         self.imt = self.imt_cbx.currentText()
         self.eid = self.eid_sbx.value()
         self.default_field_name = '%s-%s' % (self.imt, self.eid)
@@ -107,7 +105,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         layer_name = "scenario_damage_gmfs_%s_eid-%s" % (rlz, self.eid)
         return layer_name
 
-    def get_field_names(self):
+    def get_field_names(self, **kwargs):
         field_names = list(self.dataset.dtype.names)
         return field_names
 

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -41,7 +41,6 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
     def __init__(self, iface, output_type='gmf_data', path=None, mode=None):
         assert(output_type == 'gmf_data')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.file_browser_tbn.setEnabled(False)
         self.setWindowTitle(
             'Load ground motion fields from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -114,7 +114,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         added_field_name = add_numeric_attribute(field_name, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names):
+    def read_npz_into_layer(self, field_names, **kwargs):
         with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
             feats = []
             fields = self.layer.pendingFields()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2013-10-24
+#        copyright            : (C) 2014 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy
+import json
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.calculations.calculate_utils import add_textual_attribute
+from svir.utilities.utils import (LayerEditingManager,
+                                  log_msg,
+                                  WaitCursorManager,
+                                  )
+from svir.utilities.shared import DEBUG
+
+
+class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
+    """
+    Modal dialog to load hazard curves from an oq-engine output, as layer
+    """
+
+    def __init__(self, iface, output_type='hcurves', path=None, mode=None):
+        assert(output_type == 'hcurves')
+        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        self.file_browser_tbn.setEnabled(False)
+        self.setWindowTitle(
+            'Load hazard curves from NPZ, as layer')
+        self.create_load_selected_only_ckb()
+        self.create_rlz_selector()
+        if self.path:
+            self.npz_file = numpy.load(self.path, 'r')
+            self.populate_out_dep_widgets()
+        self.adjustSize()
+        self.set_ok_button()
+
+    def set_ok_button(self):
+        self.ok_button.setEnabled(
+            bool(self.path) and self.rlz_cbx.currentIndex() != -1)
+
+    def on_rlz_changed(self):
+        self.dataset = self.npz_file[self.rlz_cbx.currentText()]
+        self.imts = {}
+        for name in self.dataset.dtype.names[2:]:
+            imt = name
+            self.imts[imt] = []
+        self.set_ok_button()
+
+    def populate_rlz_cbx(self):
+        self.rlzs = [key for key in self.npz_file.keys()
+                     if key.startswith('rlz')]
+        self.rlz_cbx.clear()
+        self.rlz_cbx.setEnabled(True)
+        # self.rlz_cbx.addItem('All')
+        self.rlz_cbx.addItems(self.rlzs)
+
+    def build_layer_name(self):
+        rlz = self.rlz_cbx.currentText()
+        # build layer name
+        self.imt = self.imts.keys()[0]
+        self.default_field_name = self.imt
+        layer_name = "hazard_curves_%s" % rlz
+        return layer_name
+
+    def get_field_names(self):
+        field_names = list(self.dataset.dtype.names)
+        return field_names
+
+    def add_field_to_layer(self, field_name):
+        # FIXME: probably we need a different type with more capacity
+        added_field_name = add_textual_attribute(field_name, self.layer)
+        return added_field_name
+
+    def read_npz_into_layer(self, field_names):
+        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+            feats = []
+            imtls = self.npz_file['imtls']
+            for row in self.dataset:
+                # add a feature
+                feat = QgsFeature(self.layer.pendingFields())
+                for field_name_idx, field_name in enumerate(field_names):
+                    if field_name in ['lon', 'lat']:
+                        continue
+                    poes = row[field_name_idx].tolist()
+                    imls = imtls[field_name].tolist()
+                    dic = dict(poes=poes, imls=imls)
+                    value = json.dumps(dic)
+                    feat.setAttribute(field_name, value)
+                feat.setGeometry(QgsGeometry.fromPoint(
+                    QgsPoint(row[0], row[1])))
+                feats.append(feat)
+            added_ok = self.layer.addFeatures(feats, makeSelected=False)
+            if not added_ok:
+                msg = 'There was a problem adding features to the layer.'
+                log_msg(msg, level='C', message_bar=self.iface.messageBar())
+
+    def load_from_npz(self):
+        for rlz in self.rlzs:
+            if (self.load_selected_only_ckb.isChecked()
+                    and rlz != self.rlz_cbx.currentText()):
+                continue
+            with WaitCursorManager('Creating layer for realization "%s"...'
+                                   % rlz, self.iface):
+                self.build_layer(rlz)
+                self.style_curves()
+        if self.npz_file is not None:
+            self.npz_file.close()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -42,7 +42,6 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
     def __init__(self, iface, output_type='hcurves', path=None, mode=None):
         assert(output_type == 'hcurves')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.file_browser_tbn.setEnabled(False)
         self.setWindowTitle(
             'Load hazard curves from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -72,7 +72,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         # self.rlz_cbx.addItem('All')
         self.rlz_cbx.addItems(self.rlzs)
 
-    def build_layer_name(self):
+    def build_layer_name(self, rlz, **kwargs):
         rlz = self.rlz_cbx.currentText()
         # build layer name
         self.imt = self.imts.keys()[0]
@@ -80,7 +80,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         layer_name = "hazard_curves_%s" % rlz
         return layer_name
 
-    def get_field_names(self):
+    def get_field_names(self, **kwargs):
         field_names = list(self.dataset.dtype.names)
         return field_names
 

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -89,7 +89,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         added_field_name = add_textual_attribute(field_name, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names):
+    def read_npz_into_layer(self, field_names, **kwargs):
         with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
             feats = []
             imtls = self.npz_file['imtls']

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -102,7 +102,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             field_name, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names):
+    def read_npz_into_layer(self, field_names, **kwargs):
         with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
             feats = []
             for row in self.dataset:

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -72,10 +72,10 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         self.set_ok_button()
 
     def on_imt_changed(self):
-        imt = self.imt_cbx.currentText()
+        self.imt = self.imt_cbx.currentText()
         self.poe_cbx.clear()
         self.poe_cbx.setEnabled(True)
-        self.poe_cbx.addItems(self.imts[imt])
+        self.poe_cbx.addItems(self.imts[self.imt])
         self.set_ok_button()
 
     def populate_rlz_cbx(self):
@@ -85,17 +85,14 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         self.rlz_cbx.setEnabled(True)
         self.rlz_cbx.addItems(self.rlzs)
 
-    def build_layer_name(self):
-        rlz = self.rlz_cbx.currentText()
-        # build layer name
-        self.imt = self.imt_cbx.currentText()
-        self.poe = self.poe_cbx.currentText()
-        self.default_field_name = '%s-%s' % (self.imt, self.poe)
+    def build_layer_name(self, rlz, **kwargs):
+        imt = self.imt_cbx.currentText()
+        poe = self.poe_cbx.currentText()
+        self.default_field_name = '%s-%s' % (imt, poe)
         layer_name = "hazard_map_%s" % rlz
         return layer_name
 
-    def get_field_names(self):
-        # get field names
+    def get_field_names(self, **kwargs):
         field_names = list(self.dataset.dtype.names)
         return field_names
 

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -41,7 +41,6 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
     def __init__(self, iface, output_type='hmaps', path=None, mode=None):
         assert(output_type == 'hmaps')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.file_browser_tbn.setEnabled(False)
         self.setWindowTitle(
             'Load hazard maps from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2013-10-24
+#        copyright            : (C) 2014 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.calculations.calculate_utils import add_numeric_attribute
+from svir.utilities.utils import (WaitCursorManager,
+                                  LayerEditingManager,
+                                  log_msg,
+                                  )
+from svir.utilities.shared import DEBUG
+
+
+class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
+    """
+    Modal dialog to load hazard maps from an oq-engine output, as layer
+    """
+
+    def __init__(self, iface, output_type='hmaps', path=None, mode=None):
+        assert(output_type == 'hmaps')
+        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        self.file_browser_tbn.setEnabled(False)
+        self.setWindowTitle(
+            'Load hazard maps from NPZ, as layer')
+        self.create_load_selected_only_ckb()
+        self.create_rlz_selector()
+        self.create_imt_selector()
+        self.create_poe_selector()
+        if self.path:
+            self.npz_file = numpy.load(self.path, 'r')
+            self.populate_out_dep_widgets()
+        self.adjustSize()
+        self.set_ok_button()
+
+    def set_ok_button(self):
+        self.ok_button.setEnabled(
+            bool(self.path) and self.poe_cbx.currentIndex() != -1)
+
+    def on_rlz_changed(self):
+        self.dataset = self.npz_file[self.rlz_cbx.currentText()]
+        self.imts = {}
+        for name in self.dataset.dtype.names[2:]:
+            imt, poe = name.split('-')
+            if imt not in self.imts:
+                self.imts[imt] = [poe]
+            else:
+                self.imts[imt].append(poe)
+        self.imt_cbx.clear()
+        self.imt_cbx.setEnabled(True)
+        self.imt_cbx.addItems(self.imts.keys())
+        self.set_ok_button()
+
+    def on_imt_changed(self):
+        imt = self.imt_cbx.currentText()
+        self.poe_cbx.clear()
+        self.poe_cbx.setEnabled(True)
+        self.poe_cbx.addItems(self.imts[imt])
+        self.set_ok_button()
+
+    def populate_rlz_cbx(self):
+        self.rlzs = [key for key in self.npz_file.keys()
+                     if key.startswith('rlz')]
+        self.rlz_cbx.clear()
+        self.rlz_cbx.setEnabled(True)
+        self.rlz_cbx.addItems(self.rlzs)
+
+    def build_layer_name(self):
+        rlz = self.rlz_cbx.currentText()
+        # build layer name
+        self.imt = self.imt_cbx.currentText()
+        self.poe = self.poe_cbx.currentText()
+        self.default_field_name = '%s-%s' % (self.imt, self.poe)
+        layer_name = "hazard_map_%s" % rlz
+        return layer_name
+
+    def get_field_names(self):
+        # get field names
+        field_names = list(self.dataset.dtype.names)
+        return field_names
+
+    def add_field_to_layer(self, field_name):
+        # NOTE: add_numeric_attribute uses LayerEditingManager
+        added_field_name = add_numeric_attribute(
+            field_name, self.layer)
+        return added_field_name
+
+    def read_npz_into_layer(self, field_names):
+        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+            feats = []
+            for row in self.dataset:
+                # add a feature
+                feat = QgsFeature(self.layer.pendingFields())
+                for field_name_idx, field_name in enumerate(field_names):
+                    if field_name in ['lon', 'lat']:
+                        continue
+                    # NOTE: without casting to float, it produces a
+                    #       null because it does not recognize the
+                    #       numpy type
+                    value = float(row[field_name_idx])
+                    feat.setAttribute(field_name, value)
+                feat.setGeometry(QgsGeometry.fromPoint(
+                    QgsPoint(row[0], row[1])))
+                feats.append(feat)
+            added_ok = self.layer.addFeatures(feats, makeSelected=False)
+            if not added_ok:
+                msg = 'There was a problem adding features to the layer.'
+                log_msg(msg, level='C', message_bar=self.iface.messageBar())
+
+    def load_from_npz(self):
+        for rlz in self.rlzs:
+            if (self.load_selected_only_ckb.isChecked()
+                    and rlz != self.rlz_cbx.currentText()):
+                continue
+            with WaitCursorManager('Creating layer for '
+                                   ' realization "%s"...' % rlz,
+                                   self.iface):
+                self.build_layer(rlz)
+                self.style_maps()
+        if self.npz_file is not None:
+            self.npz_file.close()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -91,19 +91,6 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.file_browser_tbn.setEnabled(True)
         if self.path:
             self.path_le.setText(self.path)
-        # self.default_field_name = None  # field used for styling by default
-        # if output_type is not None:
-        #     index = self.output_type_cbx.findText(output_type)
-        #     if index != -1:
-        #         self.output_type_cbx.setCurrentIndex(index)
-        #         self.on_output_type_changed()
-        #         if self.path:
-        #             if self.output_type in OQ_NPZ_LOADABLE_TYPES:
-        #                 self.npz_file = numpy.load(self.path, 'r')
-        #                 self.populate_out_dep_widgets()
-        #     self.file_browser_tbn.setEnabled(True)
-        # else:
-        #     self.file_browser_tbn.setEnabled(False)
         clear_widgets_from_layout(self.output_dep_vlayout)
 
     def create_rlz_selector(self):
@@ -172,7 +159,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.taxonomy_lbl = QLabel('Taxonomy')
         self.taxonomy_cbx = QComboBox()
         self.taxonomy_cbx.setEnabled(False)
-        # FIXME: it might be needed when npz risk outputs are available
+        # TODO: it might be needed when npz risk outputs are available
         # self.taxonomy_cbx.currentIndexChanged['QString'].connect(
         #     self.on_taxonomy_changed)
         self.output_dep_vlayout.addWidget(self.taxonomy_lbl)
@@ -209,31 +196,34 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def on_file_browser_tbn_clicked(self):
         path = self.open_file_dialog()
         if path:
-            if self.ouput_type in OQ_NPZ_LOADABLE_TYPES:
+            if self.output_type in OQ_NPZ_LOADABLE_TYPES:
                 self.npz_file = numpy.load(self.path, 'r')
             self.populate_out_dep_widgets()
+        self.set_ok_button()
 
     def on_rlz_changed(self):
         self.dataset = self.npz_file[self.rlz_cbx.currentText()]
-        if self.output_type in ('loss_maps'):
-            # FIXME: likely, self.npz_file.keys()
-            self.loss_types = self.npz_file.dtype.fields
-            self.loss_type_cbx.clear()
-            self.loss_type_cbx.setEnabled(True)
-            self.loss_type_cbx.addItems(self.loss_types.keys())
-        elif self.output_type == 'loss_curves':
-            # FIXME: likely, self.npz_file.keys()
-            self.loss_types = self.npz_file.dtype.names
+        # TODO: change as soon as npz files for these become available
+        # if self.output_type in ('loss_maps'):
+        #     # FIXME: likely, self.npz_file.keys()
+        #     self.loss_types = self.npz_file.dtype.fields
+        #     self.loss_type_cbx.clear()
+        #     self.loss_type_cbx.setEnabled(True)
+        #     self.loss_type_cbx.addItems(self.loss_types.keys())
+        # elif self.output_type == 'loss_curves':
+        #     # FIXME: likely, self.npz_file.keys()
+        #     self.loss_types = self.npz_file.dtype.names
         self.set_ok_button()
 
     def on_loss_type_changed(self):
-        self.loss_type = self.loss_type_cbx.currentText()
-        if self.output_type == 'loss_maps':
-            poe_names = self.loss_types[self.loss_type][0].names
-            poe_thresholds = [name.split('poe-')[1] for name in poe_names]
-            self.poe_cbx.clear()
-            self.poe_cbx.setEnabled(True)
-            self.poe_cbx.addItems(poe_thresholds)
+        # TODO: change as soon as npz becomes available
+        # self.loss_type = self.loss_type_cbx.currentText()
+        # if self.output_type == 'loss_maps':
+        #     poe_names = self.loss_types[self.loss_type][0].names
+        #     poe_thresholds = [name.split('poe-')[1] for name in poe_names]
+        #     self.poe_cbx.clear()
+        #     self.poe_cbx.setEnabled(True)
+        #     self.poe_cbx.addItems(poe_thresholds)
         self.set_ok_button()
 
     def on_imt_changed(self):
@@ -242,8 +232,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def on_poe_changed(self):
         self.set_ok_button()
 
-    # def on_eid_changed(self):
-    #     self.set_ok_button()
+    def on_eid_changed(self):
+        self.set_ok_button()
 
     def on_dmg_state_changed(self):
         self.set_ok_button()
@@ -270,13 +260,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.path = path
         self.path_le.setText(self.path)
         return path
-        # # FIXME
-        # if self.output_type in OQ_NPZ_LOADABLE_TYPES:
-        #     self.npz_file = numpy.load(self.path, 'r')
-        #     self.populate_out_dep_widgets()
 
     def populate_out_dep_widgets(self):
-        # FIXME: change as soon as npz risk outputs are available
+        # TODO: change as soon as npz risk outputs are available
         # self.get_taxonomies()
         # self.populate_taxonomies()
         self.populate_rlz_cbx()
@@ -284,19 +270,22 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # self.populate_dmg_states()
 
     def get_taxonomies(self):
-        # FIXME: change as soon as npz risk outputs are available
-        if self.output_type in (
-                'loss_curves', 'loss_maps'):
-            self.taxonomies = self.npz_file['assetcol/taxonomies'][:].tolist()
+        raise NotImplementedError()
+        # TODO: change as soon as npz risk outputs are available
+        # if self.output_type in (
+        #         'loss_curves', 'loss_maps'):
+        #     self.taxonomies = self.npz_file[
+        #         'assetcol/taxonomies'][:].tolist()
 
     def populate_rlz_cbx(self):
-        if self.output_type in ('loss_curves', 'loss_maps'):
-            if self.output_type == 'loss_curves':
-                self.hdata = self.npz_file['loss_curves-rlzs']
-            elif self.output_type == 'loss_maps':
-                self.hdata = self.npz_file['loss_maps-rlzs']
-            _, n_rlzs = self.hdata.shape
-            self.rlzs = [str(i+1) for i in range(n_rlzs)]
+        # TODO: change as soon as npz files for these become available
+        # if self.output_type in ('loss_curves', 'loss_maps'):
+        #     if self.output_type == 'loss_curves':
+        #         self.hdata = self.npz_file['loss_curves-rlzs']
+        #     elif self.output_type == 'loss_maps':
+        #         self.hdata = self.npz_file['loss_maps-rlzs']
+        #     _, n_rlzs = self.hdata.shape
+        #     self.rlzs = [str(i+1) for i in range(n_rlzs)]
         self.rlz_cbx.clear()
         self.rlz_cbx.setEnabled(True)
         # self.rlz_cbx.addItem('All')
@@ -321,10 +310,12 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.rlz_num_sites_lbl.setText(self.num_sites_msg % rlz_data.shape)
 
     def set_ok_button(self):
-        if self.output_type == 'loss_maps':
-            self.ok_button.setEnabled(self.poe_cbx.currentIndex() != -1)
-        elif self.output_type == 'loss_curves':
-            self.ok_button.setEnabled(self.rlz_cbx.currentIndex() != -1)
+        raise NotImplementedError()
+        # TODO: change as soon as npz files for these become available
+        # if self.output_type == 'loss_maps':
+        #     self.ok_button.setEnabled(self.poe_cbx.currentIndex() != -1)
+        # elif self.output_type == 'loss_curves':
+        #     self.ok_button.setEnabled(self.rlz_cbx.currentIndex() != -1)
 
     def get_layer_group(self, rlz):
         # get the root of layerTree, in order to add groups of layers
@@ -337,7 +328,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         return rlz_group
 
     def build_layer_name(self):
-        raise NotImplementedError
+        raise NotImplementedError()
+        # TODO: change as soon as npz files for these become available
         # rlz = self.rlz_cbx.currentText()
         # build layer name
         # elif self.output_type == 'loss_curves':
@@ -345,7 +337,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # elif self.output_type == 'loss_maps':
         #     layer_name = "loss_maps_%s_%s" % (rlz, taxonomy)
         # elif self.output_type == 'dmg_by_asset':
-        #     # FIXME: probably to be removed
+        #     # TODO: probably to be removed
         #     layer_name = "dmg_by_asset_%s_%s" % (rlz, taxonomy)
         # return layer_name
 
@@ -365,7 +357,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             added_field_name = add_numeric_attribute(
                 field_name, self.layer)
         elif self.output_type == 'loss_curves':
-            # FIXME: probably we need a different type with more capacity
+            # NOTE: probably we need a different type with more capacity
             added_field_name = add_textual_attribute(
                 field_name, self.layer)
         else:
@@ -375,6 +367,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def read_npz_into_layer(self, field_names):
         with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
             feats = []
+            # TODO: change as soon as npz files for these become available
             # elif self.output_type == 'loss_curves':
             #     # We need to select rows from loss_curves-rlzs where the
             #     # row index (the asset idx) has the given taxonomy. The
@@ -410,7 +403,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             #     # taxonomy is found in the assetcol/array, together with
             #     # the coordinates lon and lat of the asset.
             #     # From the selected rows, we extract loss_type -> poes
-            #     # FIXME: with npz, the following needs to be changed
+            #     # TODO: with npz, the following needs to be changed
             #     asset_array = self.npz_file['assetcol/array']
             #     loss_maps = self.npz_file['loss_maps-rlzs'][:, rlz_idx]
             #     for asset_idx, row in enumerate(loss_maps):
@@ -438,6 +431,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def build_layer(self, rlz, taxonomy=None, poe=None):
         rlz_group = self.get_layer_group(rlz)
         layer_name = self.build_layer_name()
+        # TODO: change as soon as npz files for these become available
         # if self.output_type in ('loss_maps',
         #                         'loss_curves'):
         #                         # 'dmg_by_asset'):
@@ -559,9 +553,12 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def accept(self):
         if self.output_type in OQ_NPZ_LOADABLE_TYPES:
             self.load_from_npz()
+        elif self.output_type in OQ_CSV_LOADABLE_TYPES:
+            self.load_from_csv()
         super(LoadOutputAsLayerDialog, self).accept()
 
     def reject(self):
-        if self.npz_file is not None:
+        if (self.output_type in OQ_NPZ_LOADABLE_TYPES
+                and self.npz_file is not None):
             self.npz_file.close()
         super(LoadOutputAsLayerDialog, self).reject()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -362,7 +362,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             raise NotImplementedError(self.output_type)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names):
+    def read_npz_into_layer(self, field_names, **kwargs):
         with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
             feats = []
             # TODO: change as soon as npz files for these become available
@@ -457,7 +457,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 field_names.remove(field_name)
                 field_names.insert(field_name_idx, added_field_name)
 
-        self.read_npz_into_layer(field_names)
+        self.read_npz_into_layer(field_names, taxonomy=taxonomy, poe=poe)
         # add self.layer to the legend
         QgsMapLayerRegistry.instance().addMapLayer(self.layer, False)
         rlz_group.addLayer(self.layer)

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -327,11 +327,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             rlz_group = root.addGroup('Realization %s' % rlz)
         return rlz_group
 
-    def build_layer_name(self):
+    def build_layer_name(self, rlz, **kwargs):
         raise NotImplementedError()
         # TODO: change as soon as npz files for these become available
-        # rlz = self.rlz_cbx.currentText()
-        # build layer name
         # elif self.output_type == 'loss_curves':
         #     layer_name = "loss_curves_%s_%s" % (rlz, taxonomy)
         # elif self.output_type == 'loss_maps':
@@ -341,15 +339,15 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         #     layer_name = "dmg_by_asset_%s_%s" % (rlz, taxonomy)
         # return layer_name
 
-    def get_field_names(self):
-        # get field names
-        if self.output_type == 'loss_maps':
-            field_names = self.loss_types.keys()
-        elif self.output_type == 'loss_curves':
-            field_names = list(self.loss_types)
-        if self.output_type in ('loss_curves', 'loss_maps'):
-            self.taxonomy_idx = self.taxonomies.index(self.taxonomy)
-        return field_names
+    def get_field_names(self, **kwargs):
+        raise NotImplementedError
+        # if self.output_type == 'loss_maps':
+        #     field_names = self.loss_types.keys()
+        # elif self.output_type == 'loss_curves':
+        #     field_names = list(self.loss_types)
+        # if self.output_type in ('loss_curves', 'loss_maps'):
+        #     self.taxonomy_idx = self.taxonomies.index(self.taxonomy)
+        # return field_names
 
     def add_field_to_layer(self, field_name):
         if self.output_type == 'loss_maps':
@@ -430,7 +428,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
 
     def build_layer(self, rlz, taxonomy=None, poe=None):
         rlz_group = self.get_layer_group(rlz)
-        layer_name = self.build_layer_name()
+        layer_name = self.build_layer_name(rlz, taxonomy=taxonomy, poe=poe)
         # TODO: change as soon as npz files for these become available
         # if self.output_type in ('loss_maps',
         #                         'loss_curves'):
@@ -442,7 +440,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         #     loss_type = self.loss_type_cbx.currentText()
         #     poe = "poe-%s" % self.poe_cbx.currentText()
         #     self.default_field_name = loss_type
-        field_names = self.get_field_names()
+        field_names = self.get_field_names(rlz=rlz, taxonomy=taxonomy, poe=poe)
 
         # create layer
         self.layer = QgsVectorLayer(
@@ -528,6 +526,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             if (self.load_selected_only_ckb.isChecked()
                     and rlz != self.rlz_cbx.currentText()):
                 continue
+            # TODO: change as soon as the npz outputs are available
             if self.output_type in ('loss_curves', 'loss_maps'):
                 for taxonomy in self.taxonomies:
                     if (self.load_selected_only_ckb.isChecked()

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -48,10 +48,12 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
             dest_shp = tempfile.mkstemp(suffix='.shp')[1]
         else:
             dest_shp = None  # the destination file will be selected via GUI
+        zoom_to_layer = False if self.mode == 'testing' else True
         self.layer = import_layer_from_csv(
             self, self.path_le.text(), 'ruptures', self.iface.messageBar(),
             wkt_field='boundary', delimiter='\t',
-            save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp)
+            save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp,
+            zoom_to_layer=zoom_to_layer)
 
     def populate_out_dep_widgets(self):
         # no widgets to populate

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2013-10-24
+#        copyright            : (C) 2014 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import tempfile
+from svir.utilities.utils import import_layer_from_csv
+from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+
+
+class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
+    """
+    Modal dialog to load ruptures from an oq-engine output, as layer
+    """
+
+    def __init__(self, iface, output_type='ruptures', path=None, mode=None):
+        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        self.ok_button.setDisabled(True)
+        self.file_browser_tbn.setEnabled(False)
+        self.create_save_as_shp_ckb()
+        self.setWindowTitle('Load ruptures from CSV, as layer')
+        self.adjustSize()
+        self.set_ok_button()
+
+    def set_ok_button(self):
+        self.ok_button.setEnabled(bool(self.path))
+
+    def load_from_csv(self):
+        if self.mode == 'testing':
+            dest_shp = tempfile.mkstemp(suffix='.shp')[1]
+        else:
+            dest_shp = None  # the destination file will be selected via GUI
+        self.layer = import_layer_from_csv(
+            self, self.path_le.text(), 'ruptures', self.iface.messageBar(),
+            wkt_field='boundary', delimiter='\t',
+            save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp)
+
+    def accept(self):
+        self.load_from_csv()
+        super(LoadRupturesAsLayerDialog, self).accept()

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -35,7 +35,6 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
     def __init__(self, iface, output_type='ruptures', path=None, mode=None):
         assert(output_type == 'ruptures')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.file_browser_tbn.setEnabled(False)
         self.create_save_as_shp_ckb()
         self.setWindowTitle('Load ruptures from CSV, as layer')
         self.adjustSize()
@@ -54,6 +53,6 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
             wkt_field='boundary', delimiter='\t',
             save_as_shp=self.save_as_shp_ckb.isChecked(), dest_shp=dest_shp)
 
-    def accept(self):
-        self.load_from_csv()
-        super(LoadRupturesAsLayerDialog, self).accept()
+    def populate_out_dep_widgets(self):
+        # no widgets to populate
+        pass

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -33,8 +33,8 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
     """
 
     def __init__(self, iface, output_type='ruptures', path=None, mode=None):
+        assert(output_type == 'ruptures')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.ok_button.setDisabled(True)
         self.file_browser_tbn.setEnabled(False)
         self.create_save_as_shp_ckb()
         self.setWindowTitle('Load ruptures from CSV, as layer')

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -42,7 +42,6 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
     def __init__(self, iface, output_type='uhs', path=None, mode=None):
         assert(output_type == 'uhs')
         LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
-        self.file_browser_tbn.setEnabled(False)
         self.setWindowTitle(
             'Load uniform hazard spectra from NPZ, as layer')
         self.create_load_selected_only_ckb()
@@ -73,20 +72,6 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         self.rlz_cbx.setEnabled(True)
         # self.rlz_cbx.addItem('All')
         self.rlz_cbx.addItems(self.rlzs)
-
-    def populate_out_dep_widgets(self):
-        # FIXME: change as soon as npz risk outputs are available
-        # self.get_taxonomies()
-        # self.populate_taxonomies()
-        self.populate_rlz_cbx()
-        self.show_num_sites()
-        # self.populate_dmg_states()
-
-    def get_taxonomies(self):
-        # FIXME: change as soon as npz risk outputs are available
-        if self.output_type in (
-                'loss_curves', 'loss_maps'):
-            self.taxonomies = self.npz_file['assetcol/taxonomies'][:].tolist()
 
     def build_layer_name(self):
         rlz = self.rlz_cbx.currentText()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2013-10-24
+#        copyright            : (C) 2014 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.calculations.calculate_utils import add_numeric_attribute
+from svir.utilities.utils import (LayerEditingManager,
+                                  log_msg,
+                                  WaitCursorManager,
+                                  )
+from svir.utilities.shared import DEBUG
+
+
+class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
+    """
+    Modal dialog to load uniform hazard spectra from an oq-engine output,
+    as layer
+    """
+
+    def __init__(self, iface, output_type='uhs', path=None, mode=None):
+        assert(output_type == 'uhs')
+        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        self.file_browser_tbn.setEnabled(False)
+        self.setWindowTitle(
+            'Load uniform hazard spectra from NPZ, as layer')
+        self.create_load_selected_only_ckb()
+        self.create_rlz_selector()
+        self.create_poe_selector()
+        if self.path:
+            self.npz_file = numpy.load(self.path, 'r')
+            self.populate_out_dep_widgets()
+        self.adjustSize()
+        self.set_ok_button()
+
+    def set_ok_button(self):
+        self.ok_button.setEnabled(
+            bool(self.path) and self.poe_cbx.currentIndex() != -1)
+
+    def on_rlz_changed(self):
+        self.dataset = self.npz_file[self.rlz_cbx.currentText()]
+        self.poes = self.dataset.dtype.names[2:]
+        self.poe_cbx.clear()
+        self.poe_cbx.setEnabled(True)
+        self.poe_cbx.addItems(self.poes)
+        self.set_ok_button()
+
+    def populate_rlz_cbx(self):
+        self.rlzs = [key for key in self.npz_file.keys()
+                     if key.startswith('rlz')]
+        self.rlz_cbx.clear()
+        self.rlz_cbx.setEnabled(True)
+        # self.rlz_cbx.addItem('All')
+        self.rlz_cbx.addItems(self.rlzs)
+
+    def populate_out_dep_widgets(self):
+        # FIXME: change as soon as npz risk outputs are available
+        # self.get_taxonomies()
+        # self.populate_taxonomies()
+        self.populate_rlz_cbx()
+        self.show_num_sites()
+        # self.populate_dmg_states()
+
+    def get_taxonomies(self):
+        # FIXME: change as soon as npz risk outputs are available
+        if self.output_type in (
+                'loss_curves', 'loss_maps'):
+            self.taxonomies = self.npz_file['assetcol/taxonomies'][:].tolist()
+
+    def build_layer_name(self):
+        rlz = self.rlz_cbx.currentText()
+        poe = self.poe_cbx.currentText()
+        layer_name = "uhs_%s_poe-%s" % (rlz, poe)
+        return layer_name
+
+    def get_field_names(self):
+        poe = self.poe_cbx.currentText()
+        field_names = self.dataset[poe].dtype.names
+        return field_names
+
+    def add_field_to_layer(self, field_name):
+        # NOTE: add_numeric_attribute uses LayerEditingManager
+        added_field_name = add_numeric_attribute(
+            field_name, self.layer)
+        return added_field_name
+
+    def read_npz_into_layer(self, field_names):
+        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+            feats = []
+            for row in self.dataset:
+                # add a feature
+                feat = QgsFeature(self.layer.pendingFields())
+                for field_name_idx, field_name in enumerate(field_names):
+                    if field_name in ['lon', 'lat']:
+                        continue
+                    poe = self.poe_cbx.currentText()
+                    value = float(row[poe][field_name_idx])
+                    feat.setAttribute(field_name, value)
+                feat.setGeometry(QgsGeometry.fromPoint(
+                    QgsPoint(row['lon'], row['lat'])))
+                feats.append(feat)
+            added_ok = self.layer.addFeatures(feats, makeSelected=False)
+            if not added_ok:
+                msg = 'There was a problem adding features to the layer.'
+                log_msg(msg, level='C', message_bar=self.iface.messageBar())
+
+    def load_from_npz(self):
+        for rlz in self.rlzs:
+            if (self.load_selected_only_ckb.isChecked()
+                    and rlz != self.rlz_cbx.currentText()):
+                continue
+            for poe in self.poes:
+                if (self.load_selected_only_ckb.isChecked()
+                        and poe != self.poe_cbx.currentText()):
+                    continue
+                with WaitCursorManager(
+                        'Creating layer for realization "%s" '
+                        ' and poe "%s"...' % (rlz, poe),
+                        self.iface):
+                    self.build_layer(rlz, poe=poe)
+                    self.style_curves()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -73,14 +73,13 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         # self.rlz_cbx.addItem('All')
         self.rlz_cbx.addItems(self.rlzs)
 
-    def build_layer_name(self):
-        rlz = self.rlz_cbx.currentText()
-        poe = self.poe_cbx.currentText()
+    def build_layer_name(self, rlz, **kwargs):
+        poe = kwargs['poe']
         layer_name = "uhs_%s_poe-%s" % (rlz, poe)
         return layer_name
 
-    def get_field_names(self):
-        poe = self.poe_cbx.currentText()
+    def get_field_names(self, **kwargs):
+        poe = kwargs['poe']
         field_names = self.dataset[poe].dtype.names
         return field_names
 

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -89,7 +89,8 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
             field_name, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names):
+    def read_npz_into_layer(self, field_names, **kwargs):
+        poe = kwargs['poe']
         with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
             feats = []
             for row in self.dataset:
@@ -98,7 +99,6 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
                 for field_name_idx, field_name in enumerate(field_names):
                     if field_name in ['lon', 'lat']:
                         continue
-                    poe = self.poe_cbx.currentText()
                     value = float(row[poe][field_name_idx])
                     feat.setAttribute(field_name, value)
                 feat.setGeometry(QgsGeometry.fromPoint(
@@ -120,7 +120,6 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
                     continue
                 with WaitCursorManager(
                         'Creating layer for realization "%s" '
-                        ' and poe "%s"...' % (rlz, poe),
-                        self.iface):
+                        ' and poe "%s"...' % (rlz, poe), self.iface):
                     self.build_layer(rlz, poe=poe)
                     self.style_curves()

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -70,7 +70,18 @@ from svir.dialogs.recovery_modeling_dialog import RecoveryModelingDialog
 from svir.dialogs.recovery_settings_dialog import RecoverySettingsDialog
 from svir.dialogs.drive_oq_engine_server_dialog import (
     DriveOqEngineServerDialog)
-from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.dialogs.load_ruptures_as_layer_dialog import (
+    LoadRupturesAsLayerDialog)
+from svir.dialogs.load_dmg_by_asset_as_layer_dialog import (
+    LoadDmgByAssetAsLayerDialog)
+from svir.dialogs.load_hmaps_as_layer_dialog import (
+    LoadHazardMapsAsLayerDialog)
+from svir.dialogs.load_hcurves_as_layer_dialog import (
+    LoadHazardCurvesAsLayerDialog)
+from svir.dialogs.load_gmf_data_as_layer_dialog import (
+    LoadGmfDataAsLayerDialog)
+from svir.dialogs.load_uhs_as_layer_dialog import (
+    LoadUhsAsLayerDialog)
 
 from svir.thread_worker.abstract_worker import start_worker
 from svir.thread_worker.download_platform_data_worker import (
@@ -229,11 +240,45 @@ class Irmt:
                            add_to_layer_actions=False,
                            submenu='Utilities')
 
-        # Action to load an oq-engine output as layer
-        self.add_menu_item("load_oqengine_output_as_layer",
+        self.add_menu_item("load_ruptures_as_layer",
                            ":/plugins/irmt/calculate.svg",  # FIXME
-                           u"Load an OpenQuake Engine output file as layer",
-                           self.load_oqengine_output_as_layer,
+                           u"Load ruptures as layer",
+                           self.load_ruptures_as_layer,
+                           enable=True,
+                           submenu='OQ Engine')
+
+        self.add_menu_item("load_dmg_by_asset_as_layer",
+                           ":/plugins/irmt/calculate.svg",  # FIXME
+                           u"Load damage by asset as layer",
+                           self.load_dmg_by_asset_as_layer,
+                           enable=True,
+                           submenu='OQ Engine')
+
+        self.add_menu_item("load_hmaps_as_layer",
+                           ":/plugins/irmt/calculate.svg",  # FIXME
+                           u"Load hazard maps as layer",
+                           self.load_hmaps_as_layer,
+                           enable=True,
+                           submenu='OQ Engine')
+
+        self.add_menu_item("load_hcurves_as_layer",
+                           ":/plugins/irmt/calculate.svg",  # FIXME
+                           u"Load hazard curves as layer",
+                           self.load_hcurves_as_layer,
+                           enable=True,
+                           submenu='OQ Engine')
+
+        self.add_menu_item("load_gmf_data_as_layer",
+                           ":/plugins/irmt/calculate.svg",  # FIXME
+                           u"Load ground motion fields as layer",
+                           self.load_gmf_data_as_layer,
+                           enable=True,
+                           submenu='OQ Engine')
+
+        self.add_menu_item("load_uhs_as_layer",
+                           ":/plugins/irmt/calculate.svg",  # FIXME
+                           u"Load uniform hazard spectra as layer",
+                           self.load_uhs_as_layer,
                            enable=True,
                            submenu='OQ Engine')
 
@@ -285,8 +330,33 @@ class Irmt:
         dlg = RecoverySettingsDialog(self.iface)
         dlg.exec_()
 
-    def load_oqengine_output_as_layer(self):
-        dlg = LoadOutputAsLayerDialog(self.iface)
+    def load_ruptures_as_layer(self):
+        dlg = LoadRupturesAsLayerDialog(self.iface, 'ruptures')
+        dlg.exec_()
+        self.viewer_dock.change_output_type(dlg.output_type)
+
+    def load_dmg_by_asset_as_layer(self):
+        dlg = LoadDmgByAssetAsLayerDialog(self.iface, 'dmg_by_asset')
+        dlg.exec_()
+        self.viewer_dock.change_output_type(dlg.output_type)
+
+    def load_hmaps_as_layer(self):
+        dlg = LoadHazardMapsAsLayerDialog(self.iface, 'hmaps')
+        dlg.exec_()
+        self.viewer_dock.change_output_type(dlg.output_type)
+
+    def load_hcurves_as_layer(self):
+        dlg = LoadHazardCurvesAsLayerDialog(self.iface, 'hcurves')
+        dlg.exec_()
+        self.viewer_dock.change_output_type(dlg.output_type)
+
+    def load_gmf_data_as_layer(self):
+        dlg = LoadGmfDataAsLayerDialog(self.iface, 'gmf_data')
+        dlg.exec_()
+        self.viewer_dock.change_output_type(dlg.output_type)
+
+    def load_uhs_as_layer(self):
+        dlg = LoadUhsAsLayerDialog(self.iface, 'uhs')
         dlg.exec_()
         self.viewer_dock.change_output_type(dlg.output_type)
 

--- a/svir/test/test_load_oq_engine_output_as_layer.py
+++ b/svir/test/test_load_oq_engine_output_as_layer.py
@@ -30,7 +30,18 @@ import filecmp
 
 from PyQt4.QtGui import QAction
 from qgis.core import QgsMapLayerRegistry, QgsVectorLayer
-from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
+from svir.dialogs.load_dmg_by_asset_as_layer_dialog import (
+    LoadDmgByAssetAsLayerDialog)
+from svir.dialogs.load_ruptures_as_layer_dialog import (
+    LoadRupturesAsLayerDialog)
+from svir.dialogs.load_hmaps_as_layer_dialog import (
+    LoadHazardMapsAsLayerDialog)
+from svir.dialogs.load_hcurves_as_layer_dialog import (
+    LoadHazardCurvesAsLayerDialog)
+from svir.dialogs.load_gmf_data_as_layer_dialog import (
+    LoadGmfDataAsLayerDialog)
+from svir.dialogs.load_uhs_as_layer_dialog import (
+    LoadUhsAsLayerDialog)
 from svir.dialogs.viewer_dock import ViewerDock
 from svir.calculations.process_layer import ProcessLayer
 from utilities import get_qgis_app
@@ -54,21 +65,21 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_hazard_map(self):
         filepath = os.path.join(
             self.data_dir_name, 'hazard', 'output-182-hmaps_67.npz')
-        dlg = LoadOutputAsLayerDialog(IFACE, 'hmaps', filepath)
+        dlg = LoadHazardMapsAsLayerDialog(IFACE, 'hmaps', filepath)
         dlg.accept()
         # hazard maps have nothing to do with the Data Viewer
 
     def test_load_gmf(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-195-gmf_data_70.npz')
-        dlg = LoadOutputAsLayerDialog(IFACE, 'gmf_data', filepath)
+        dlg = LoadGmfDataAsLayerDialog(IFACE, 'gmf_data', filepath)
         dlg.accept()
         # ground motion fields have nothing to do with the Data Viewer
 
     def test_load_hazard_curves(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-181-hcurves_67.npz')
-        dlg = LoadOutputAsLayerDialog(IFACE, 'hcurves', filepath)
+        dlg = LoadHazardCurvesAsLayerDialog(IFACE, 'hcurves', filepath)
         dlg.accept()
         self._set_output_type('Hazard Curves')
         self._change_selection()
@@ -89,7 +100,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_uhs_only_selected_poe(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-184-uhs_67.npz')
-        dlg = LoadOutputAsLayerDialog(IFACE, 'uhs', filepath)
+        dlg = LoadUhsAsLayerDialog(IFACE, 'uhs', filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         idx = dlg.poe_cbx.findText('0.02')
         self.assertEqual(idx, 1, 'POE 0.02 was not found')
@@ -103,7 +114,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_uhs_all(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-184-uhs_67.npz')
-        dlg = LoadOutputAsLayerDialog(IFACE, 'uhs', filepath)
+        dlg = LoadUhsAsLayerDialog(IFACE, 'uhs', filepath)
         dlg.load_selected_only_ckb.setChecked(False)
         dlg.accept()
         # FIXME: setActiveLayer is not working. As a workaround, I am deleting
@@ -121,7 +132,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(
             self.data_dir_name, 'risk',
             'output-308-dmg_by_asset-ChiouYoungs2008()_103.csv')
-        dlg = LoadOutputAsLayerDialog(
+        dlg = LoadDmgByAssetAsLayerDialog(
             IFACE, 'dmg_by_asset', filepath, mode='testing')
         dlg.save_as_shp_ckb.setChecked(True)
         idx = dlg.dmg_state_cbx.findText('complete')
@@ -141,7 +152,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_ruptures(self):
         filepath = os.path.join(
             self.data_dir_name, 'hazard', 'output-316-ruptures_104.csv')
-        dlg = LoadOutputAsLayerDialog(
+        dlg = LoadRupturesAsLayerDialog(
             IFACE, 'ruptures', filepath, mode='testing')
         dlg.save_as_shp_ckb.setChecked(True)
         dlg.accept()

--- a/svir/ui/ui_load_output_as_layer.ui
+++ b/svir/ui/ui_load_output_as_layer.ui
@@ -17,23 +17,6 @@
    <item>
     <layout class="QVBoxLayout" name="vlayout">
      <item>
-      <layout class="QFormLayout" name="output_type_flayout">
-       <property name="fieldGrowthPolicy">
-        <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-       </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="output_type_lbl">
-         <property name="text">
-          <string>Output type</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="output_type_cbx"/>
-       </item>
-      </layout>
-     </item>
-     <item>
       <layout class="QHBoxLayout" name="file_hlayout">
        <item>
         <widget class="QLabel" name="file_lbl">

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -892,7 +892,8 @@ def import_layer_from_csv(parent,
                           lines_to_skip_count=0,
                           wkt_field=None,
                           save_as_shp=False,
-                          dest_shp=None):
+                          dest_shp=None,
+                          zoom_to_layer=True):
     url = QUrl.fromLocalFile(csv_path)
     url.addQueryItem('type', 'csv')
     if wkt_field is not None:
@@ -927,8 +928,10 @@ def import_layer_from_csv(parent,
         layer = QgsVectorLayer(dest_filename, layer_name, 'ogr')
     if layer.isValid():
         QgsMapLayerRegistry.instance().addMapLayer(layer)
-        qgis.utils.iface.setActiveLayer(layer)
-        qgis.utils.iface.zoomToActiveLayer()
+        if zoom_to_layer:
+            qgis.utils.iface.setActiveLayer(layer)
+            qgis.utils.iface.zoomToActiveLayer()
+
     else:
         msg = 'Unable to load layer'
         log_msg(msg, level='C', message_bar=message_bar)

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -927,8 +927,8 @@ def import_layer_from_csv(parent,
         layer = QgsVectorLayer(dest_filename, layer_name, 'ogr')
     if layer.isValid():
         QgsMapLayerRegistry.instance().addMapLayer(layer)
-        canvas = qgis.utils.iface.mapCanvas()
-        canvas.setExtent(layer.extent())
+        qgis.utils.iface.setActiveLayer(layer)
+        qgis.utils.iface.zoomToActiveLayer()
     else:
         msg = 'Unable to load layer'
         log_msg(msg, level='C', message_bar=message_bar)

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -26,19 +26,21 @@ import collections
 import json
 import os
 import locale
+import qgis
 from copy import deepcopy
 from time import time
 from pprint import pformat
 from qgis.core import (QgsMapLayerRegistry,
                        QgsProject,
                        QgsMessageLog,
+                       QgsVectorLayer,
                        QgsVectorFileWriter,
                        QgsGraduatedSymbolRendererV2
                        )
 from qgis.gui import QgsMessageBar
 
 from PyQt4 import uic
-from PyQt4.QtCore import Qt, QSettings
+from PyQt4.QtCore import Qt, QSettings, QUrl
 from PyQt4.QtGui import (QApplication,
                          QProgressBar,
                          QToolButton,
@@ -877,3 +879,58 @@ def clear_widgets_from_layout(layout):
         if widget is not None:
             # a widget is deleted when it does not have a parent
             widget.setParent(None)
+
+
+def import_layer_from_csv(parent,
+                          csv_path,
+                          layer_name,
+                          message_bar,
+                          longitude_field='lon',
+                          latitude_field='lat',
+                          delimiter=',',
+                          quote='"',
+                          lines_to_skip_count=0,
+                          wkt_field=None,
+                          save_as_shp=False,
+                          dest_shp=None):
+    url = QUrl.fromLocalFile(csv_path)
+    url.addQueryItem('type', 'csv')
+    if wkt_field is not None:
+        url.addQueryItem('wktField', wkt_field)
+    else:
+        url.addQueryItem('xField', longitude_field)
+        url.addQueryItem('yField', latitude_field)
+    url.addQueryItem('spatialIndex', 'no')
+    url.addQueryItem('subsetIndex', 'no')
+    url.addQueryItem('watchFile', 'no')
+    url.addQueryItem('delimiter', delimiter)
+    url.addQueryItem('quote', quote)
+    url.addQueryItem('crs', 'epsg:4326')
+    url.addQueryItem('skipLines', str(lines_to_skip_count))
+    url.addQueryItem('trimFields', 'yes')
+    layer_uri = str(url.toEncoded())
+    layer = QgsVectorLayer(layer_uri, layer_name, "delimitedtext")
+    if save_as_shp:
+        dest_filename = dest_shp or QFileDialog.getSaveFileName(
+            parent,
+            'Save loss shapefile as...',
+            os.path.expanduser("~"),
+            'Shapefiles (*.shp)')
+        if dest_filename:
+            if dest_filename[-4:] != ".shp":
+                dest_filename += ".shp"
+        else:
+            return
+        result = save_layer_as_shapefile(layer, dest_filename)
+        if result != QgsVectorFileWriter.NoError:
+            raise RuntimeError('Could not save shapefile')
+        layer = QgsVectorLayer(dest_filename, layer_name, 'ogr')
+    if layer.isValid():
+        QgsMapLayerRegistry.instance().addMapLayer(layer)
+        canvas = qgis.utils.iface.mapCanvas()
+        canvas.setExtent(layer.extent())
+    else:
+        msg = 'Unable to load layer'
+        log_msg(msg, level='C', message_bar=message_bar)
+        return None
+    return layer


### PR DESCRIPTION
Before this big refactoring, a single class was used to load every possible kinds of oq-engine outputs for which we have already implemented such functionality. Keeping everything in one single place is ok for a small number of output types, but it is not easily scalable. The aim of this refactoring was to identify the portions of code that all loaders have in common and those that need to be implemented differently for each output type. A main class takes care of the common parts and it defines some methods that are performed in the same by most loaders. For each output type I have defined a subclass that inherits the common behaviors and that overrides the methods that needed to be re-implemented specifically.

Although the total number of lines of code has increased, many lines are just comments (e.g. copyright strings), imports, additional menu items, etc. Furthermore, the file that was becoming problematically big (svir/dialogs/load_output_as_layer_dialog.py) has been shortened a lot, and it will be reduced much more as soon as drafts for other loaders (risk stuff that was implemented for hdf5 and that need to be rebuilt) will be moved from there into their own classes. Thanks to the current structure, the addition of new loaders will be much simpler.