### PR TITLE
Load stats as layers

### DIFF
--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -64,16 +64,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
             self.imts[imt] = []
         self.set_ok_button()
 
-    def populate_rlz_cbx(self):
-        self.rlzs = [key for key in self.npz_file.keys()
-                     if key.startswith('rlz')]
-        self.rlz_cbx.clear()
-        self.rlz_cbx.setEnabled(True)
-        # self.rlz_cbx.addItem('All')
-        self.rlz_cbx.addItems(self.rlzs)
-
     def build_layer_name(self, rlz, **kwargs):
-        rlz = self.rlz_cbx.currentText()
         # build layer name
         self.imt = self.imts.keys()[0]
         self.default_field_name = self.imt

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -75,15 +75,9 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         self.imt = self.imt_cbx.currentText()
         self.poe_cbx.clear()
         self.poe_cbx.setEnabled(True)
-        self.poe_cbx.addItems(self.imts[self.imt])
+        if self.imt:
+            self.poe_cbx.addItems(self.imts[self.imt])
         self.set_ok_button()
-
-    def populate_rlz_cbx(self):
-        self.rlzs = [key for key in self.npz_file.keys()
-                     if key.startswith('rlz')]
-        self.rlz_cbx.clear()
-        self.rlz_cbx.setEnabled(True)
-        self.rlz_cbx.addItems(self.rlzs)
 
     def build_layer_name(self, rlz, **kwargs):
         imt = self.imt_cbx.currentText()

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -67,13 +67,6 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         self.populate_loss_type_cbx(self.loss_types)
         self.set_ok_button()
 
-    def populate_rlz_cbx(self):
-        self.rlzs = [key for key in self.npz_file.keys()
-                     if key.startswith('rlz')]
-        self.rlz_cbx.clear()
-        self.rlz_cbx.setEnabled(True)
-        self.rlz_cbx.addItems(self.rlzs)
-
     def populate_taxonomy_cbx(self, taxonomies):
         taxonomies.insert(0, 'All')
         self.taxonomy_cbx.clear()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -86,7 +86,6 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         clear_widgets_from_layout(self.output_dep_vlayout)
 
     def create_rlz_selector(self):
-        self.rlz_lbl = QLabel('Realization')
         self.rlz_cbx = QComboBox()
         self.rlz_cbx.setEnabled(False)
         self.rlz_cbx.currentIndexChanged['QString'].connect(
@@ -272,9 +271,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         #         self.hdata = self.npz_file['loss_maps-rlzs']
         #     _, n_rlzs = self.hdata.shape
         #     self.rlzs = [str(i+1) for i in range(n_rlzs)]
+        self.rlzs = [key for key in self.npz_file.keys() if key != 'imtls']
         self.rlz_cbx.clear()
         self.rlz_cbx.setEnabled(True)
-        # self.rlz_cbx.addItem('All')
         self.rlz_cbx.addItems(self.rlzs)
 
     def populate_dmg_state_cbx(self, dmg_states):
@@ -307,10 +306,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # get the root of layerTree, in order to add groups of layers
         # (one group for each realization)
         root = QgsProject.instance().layerTreeRoot()
-        group_name = 'Realization %s' % rlz
-        rlz_group = root.findGroup(group_name)
+        rlz_group = root.findGroup(rlz)
         if not rlz_group:
-            rlz_group = root.addGroup('Realization %s' % rlz)
+            rlz_group = root.addGroup(rlz)
         return rlz_group
 
     def build_layer_name(self, rlz, **kwargs):

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -271,7 +271,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         #         self.hdata = self.npz_file['loss_maps-rlzs']
         #     _, n_rlzs = self.hdata.shape
         #     self.rlzs = [str(i+1) for i in range(n_rlzs)]
-        self.rlzs = [key for key in self.npz_file.keys() if key != 'imtls']
+        self.rlzs = [key for key in sorted(self.npz_file) if key != 'imtls']
         self.rlz_cbx.clear()
         self.rlz_cbx.setEnabled(True)
         self.rlz_cbx.addItems(self.rlzs)
@@ -302,14 +302,14 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # elif self.output_type == 'loss_curves':
         #     self.ok_button.setEnabled(self.rlz_cbx.currentIndex() != -1)
 
-    def get_layer_group(self, rlz):
+    def get_layer_group(self, npz_key):
         # get the root of layerTree, in order to add groups of layers
-        # (one group for each realization)
+        # (one group for each realization or statistic)
         root = QgsProject.instance().layerTreeRoot()
-        rlz_group = root.findGroup(rlz)
-        if not rlz_group:
-            rlz_group = root.addGroup(rlz)
-        return rlz_group
+        npz_key_group = root.findGroup(npz_key)
+        if not npz_key_group:
+            npz_key_group = root.addGroup(npz_key)
+        return npz_key_group
 
     def build_layer_name(self, rlz, **kwargs):
         raise NotImplementedError()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -65,14 +65,6 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         self.poe_cbx.addItems(self.poes)
         self.set_ok_button()
 
-    def populate_rlz_cbx(self):
-        self.rlzs = [key for key in self.npz_file.keys()
-                     if key.startswith('rlz')]
-        self.rlz_cbx.clear()
-        self.rlz_cbx.setEnabled(True)
-        # self.rlz_cbx.addItem('All')
-        self.rlz_cbx.addItems(self.rlzs)
-
     def build_layer_name(self, rlz, **kwargs):
         poe = kwargs['poe']
         layer_name = "uhs_%s_poe-%s" % (rlz, poe)

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -36,6 +36,7 @@ changelog=
     * Improvements to the user manual
     * It is possible to continue risk calculations (e.g. postprocessing on top of a risk calculation)
     * Fixed an unreferenced variable in case of successful updating of a project on the OQ Platform
+    * Stats of OQ Engine calculations with multiple realizations can be loaded as layers
     1.8.22
     * Added a sanity check on default colors stored in the settings, to make sure they are valid QColor objects
     1.8.21


### PR DESCRIPTION
When a OQ Engine calculation has more than one realization, the corresponding output does not contain results for any of the realizations, but it contains statistical outputs (e.g. mean, quantiles). With the same widget that was used to select one of the available realizations, now it is possible to select the single existing realization or one of the statistical outputs.
Since the method `populate_rlz_cbx` does the same for many loaders, I don't need to override that method in the subclasses anymore.

I've also fixed a little bug in the creation of the layer name for hazard curves.

Fixes https://github.com/gem/oq-irmt-qgis/issues/219