### PR TITLE
Improve the layout of the list of OQ Engine calculations

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -417,16 +417,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         selected_keys = [key for key in sorted(output_list[0].keys())
                          if key not in exclude]
         max_actions = 0
-        needs_additional_button = False
         for row in output_list:
+            num_actions = len(row['outtypes'])
             if (row['type'] in OQ_ALL_LOADABLE_TYPES
                     or row['type'] == 'fullreport'):
-                needs_additional_button = True
-            num_actions = len(row['outtypes'])
-            if num_actions > max_actions:
-                max_actions = num_actions
-        if needs_additional_button:
-            max_actions += 1
+                num_actions += 1  # needs additional column for loader button
+            max_actions = max(max_actions, num_actions)
 
         self.output_list_tbl.setRowCount(len(output_list))
         self.output_list_tbl.setColumnCount(

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -82,6 +82,8 @@ FORM_CLASS = get_ui_class('ui_drive_engine_server.ui')
 HANDLED_EXCEPTIONS = (SSLError, ConnectionError, InvalidSchema, MissingSchema,
                       ReadTimeout, SvNetworkError)
 
+BUTTON_WIDTH = 75
+
 
 class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     """
@@ -174,6 +176,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             calc_list = json.loads(resp.text)
         selected_keys = ['description', 'id', 'job_type', 'owner', 'status']
         col_names = ['Description', 'ID', 'Job Type', 'Owner', 'Status']
+        col_widths = [380, 50, 80, 80, 80]
         if not calc_list:
             if self.calc_list_tbl.rowCount() > 0:
                 self.calc_list_tbl.clearContents()
@@ -184,8 +187,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.calc_list_tbl.setHorizontalHeaderLabels(col_names)
                 self.calc_list_tbl.horizontalHeader().setStyleSheet(
                     "font-weight: bold;")
-                self.calc_list_tbl.resizeColumnsToContents()
-                self.calc_list_tbl.resizeRowsToContents()
+                self.set_calc_list_widths(col_widths)
             return
         actions = [
             {'label': 'Console', 'bg_color': '#3cb3c5', 'txt_color': 'white'},
@@ -227,14 +229,19 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     lambda calc_id=calc['id'], action=action['label']: (
                         self.on_calc_action_btn_clicked(calc_id, action)))
                 self.calc_list_tbl.setCellWidget(row, col, button)
+                self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
         empty_col_names = [''] * len(actions)
         headers = col_names + empty_col_names
         self.calc_list_tbl.setHorizontalHeaderLabels(headers)
         self.calc_list_tbl.horizontalHeader().setStyleSheet(
             "font-weight: bold;")
-        self.calc_list_tbl.resizeColumnsToContents()
-        self.calc_list_tbl.resizeRowsToContents()
+        self.set_calc_list_widths(col_widths)
         return True
+
+    def set_calc_list_widths(self, widths):
+        for i, width in enumerate(widths):
+            self.calc_list_tbl.setColumnWidth(i, width)
+        self.calc_list_tbl.resizeRowsToContents()
 
     def clear_output_list(self):
         self.output_list_tbl.clearContents()
@@ -436,6 +443,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 button = QPushButton()
                 self.connect_button_to_action(button, action, output, outtype)
                 self.output_list_tbl.setCellWidget(row, col, button)
+                self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
             if (output['type'] in OQ_ALL_LOADABLE_TYPES
                     or output['type'] == 'fullreport'):
                 if output['type'] == 'fullreport':
@@ -446,6 +454,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.connect_button_to_action(
                     button, action, output, outtype)
                 self.output_list_tbl.setCellWidget(row, col + 1, button)
+                self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
         col_names = [key.capitalize() for key in selected_keys]
         empty_col_names = ['' for outtype in range(max_actions)]
         headers = col_names + empty_col_names

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -36,6 +36,8 @@ changelog=
     * Improvements to the user manual
     * It is possible to continue risk calculations (e.g. postprocessing on top of a risk calculation)
     * Fixed an unreferenced variable in case of successful updating of a project on the OQ Platform
+    * Improved resizing of table items in the list of OQ Engine calculations, so the text of long
+      descriptions is wrapped instead of occupying too much horizontal space
     1.8.22
     * Added a sanity check on default colors stored in the settings, to make sure they are valid QColor objects
     1.8.21


### PR DESCRIPTION
Before this change, table cells were automatically resized, based on their contents, so a calculation with a very long description caused the table to become very wide and not so comfortable to browse.
I decided to set a reasonable size for all the columns (because in this case we know a priori how many columns we have and what kind of content they have). When a description is long, its text is wrapped and the size of the row is adapted accordingly.