### PR TITLE
Keep the calculation list scrolled to visualize the latest clicked row

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -39,6 +39,7 @@ from PyQt4.QtCore import (QDir,
 
 from PyQt4.QtGui import (QDialog,
                          QTableWidgetItem,
+                         QAbstractItemView,
                          QPushButton,
                          QFileDialog,
                          QColor,
@@ -101,6 +102,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.session = None
         self.hostname = None
         self.current_output_calc_id = None
+        self.current_pointed_calc_id = None  # we will scroll to it
         self.is_logged_in = False
         self.timer = None
         # Keep retrieving the list of calculations (especially important to
@@ -236,6 +238,14 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.calc_list_tbl.horizontalHeader().setStyleSheet(
             "font-weight: bold;")
         self.set_calc_list_widths(col_widths)
+        if self.current_pointed_calc_id:
+            # find QTableItem corresponding to that calc_id
+            calc_id_col_idx = 1
+            for row in xrange(self.calc_list_tbl.rowCount()):
+                item_calc_id = self.calc_list_tbl.item(row, calc_id_col_idx)
+                if int(item_calc_id.text()) == self.current_pointed_calc_id:
+                    self.calc_list_tbl.scrollToItem(
+                        item_calc_id, QAbstractItemView.PositionAtCenter)
         return True
 
     def set_calc_list_widths(self, widths):
@@ -249,6 +259,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.output_list_tbl.setColumnCount(0)
 
     def on_calc_action_btn_clicked(self, calc_id, action):
+        # NOTE: while scrolling through the list of calculations, the tool
+        # keeps polling and refreshing the list, without losing the current
+        # scrolling.  But if you click on any button, at the next refresh, the
+        # view is scrolled to the top. Therefore we need to keep track of which
+        # line was selected, in order to scroll to that line.
+        self.current_pointed_calc_id = calc_id
         if action == 'Console':
             dlg = ShowConsoleDialog(self, calc_id)
             dlg.setWindowTitle(

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=1.8.24
+version=1.8.25
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    1.8.25
+    * The list of OQ-Engine calculations is automatically scrolled to view the latest clicked row
     1.8.24
     * ProcessLayer.addAttributes launders proposed attribute names only if the processed layer is a shapefile
     * When fields with long names are added to shapefiles, the original long names are saved as aliases


### PR DESCRIPTION
While scrolling through the list of calculations, the tool keeps polling and refreshing the list, without losing the current scrolling.  But if you click on any button, at the next refresh, the view is scrolled to the top. Therefore we need to keep track of which line was clicked, in order to scroll to that line after refreshing the list.