### PR TITLE
Add toolbar button to show/hide the viewer dock

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -529,7 +529,6 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
                 and self.active_layer.type() == QgsMapLayer.VectorLayer
                 and self.active_layer.geometryType() == QGis.Point):
             self.active_layer.selectionChanged.connect(self.redraw)
-            self.setEnabled(True)
 
             if self.output_type == 'hcurves':
                 reload_attrib_cbx(self.imt_cbx,
@@ -543,8 +542,6 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
                                   TEXTUAL_FIELD_TYPES)
             if self.active_layer.selectedFeatureCount() > 0:
                 self.set_selection(self.active_layer.selectedFeaturesIds())
-        else:
-            self.setDisabled(True)
 
     def remove_connects(self):
         try:

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -1385,6 +1385,7 @@ class Irmt:
                                     u"Toggle viewer dock",
                                     self.toggle_dock_visibility,
                                     enable=True,
+                                    add_to_toolbar=True,
                                     set_checkable=True,
                                     set_checked=True)
 

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,7 @@ email=staff.it@globalquakemodel.org
 changelog=
     1.8.25
     * The list of OQ-Engine calculations is automatically scrolled to view the latest clicked row
+    * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar
     1.8.24
     * ProcessLayer.addAttributes launders proposed attribute names only if the processed layer is a shapefile
     * When fields with long names are added to shapefiles, the original long names are saved as aliases


### PR DESCRIPTION
It was a little counter-intuitive to have the viewer visible but disabled, being unable to click on the `x` to close it. With this change, the viewer remains always enabled, but you can hide it by pressing the `x` or the additional toolbar button, and you can re-open it by pressing the toolbar button.