### PR TITLE
Do not show info messages while polling to get console log of calc

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -302,8 +302,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         stop = ''  # get until the end
         calc_log_url = "%s/v1/calc/%s/log/%s:%s" % (
             self.hostname, calc_id, start, stop)
-        with WaitCursorManager(
-                'Getting log for output %s...' % calc_id, self.iface):
+        with WaitCursorManager():
             try:
                 # FIXME: enable the user to set verify=True
                 resp = self.session.get(calc_log_url, timeout=10, verify=False)
@@ -316,8 +315,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
 
     def get_calc_status(self, calc_id):
         calc_status_url = "%s/v1/calc/%s/status" % (self.hostname, calc_id)
-        with WaitCursorManager(
-                'Getting status for output %s...' % calc_id, self.iface):
+        with WaitCursorManager():
             try:
                 # FIXME: enable the user to set verify=True
                 resp = self.session.get(

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -28,6 +28,7 @@ changelog=
     * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar
     * A splitter has been added between the list of calculations and the list of outputs for a calculation, allowing to
       mutually resize the two lists
+    * Removed annoying messages while retrieveing the console log of a OQ-Engine calculation
     1.8.24
     * ProcessLayer.addAttributes launders proposed attribute names only if the processed layer is a shapefile
     * When fields with long names are added to shapefiles, the original long names are saved as aliases


### PR DESCRIPTION
The `WaitCursorManager` changes the mouse pointer, to indicate the plugin is busy doing something. If also a message is specified, it is shown into the QGIS message bar. While retrieving the log of a OQ-Engine calculation, we keep getting the calculation's status and the calculation's log, spamming the QGIS message bar with annoying messages. I prefer to keep it more silent, as it already happens while polling the engine server to update the list of calculations.