### PR TITLE
Preselect output type in Data Viewer when hcurves or uhs are loaded

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -92,8 +92,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     it is possible to run calculations, delete them, list them, visualize
     their outputs and loading them as vector layers.
     """
-    def __init__(self, iface):
+    def __init__(self, iface, viewer_dock):
         self.iface = iface
+        self.viewer_dock = viewer_dock  # needed to change the output_type
         QDialog.__init__(self)
         # Set up the user interface from Designer.
         self.setupUi(self)
@@ -539,7 +540,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 if output_type not in output_type_loaders:
                     raise NotImplementedError(output_type)
                 dlg = output_type_loaders[output_type](
-                    self.iface, output_type, filepath)
+                    self.iface, self.viewer_dock, output_type, filepath)
                 dlg.exec_()
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -34,10 +34,11 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load dmg_by_asset from an oq-engine output, as layer
     """
 
-    def __init__(
-            self, iface, output_type='dmg_by_asset', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='dmg_by_asset',
+                 path=None, mode=None):
         assert output_type == 'dmg_by_asset'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.create_dmg_state_selector()
         self.create_loss_type_selector()
         self.create_save_as_shp_ckb()

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -38,9 +38,11 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load gmf_data from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, output_type='gmf_data', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='gmf_data',
+                 path=None, mode=None):
         assert output_type == 'gmf_data'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.setWindowTitle(
             'Load ground motion fields from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -39,9 +39,11 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load hazard curves from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, output_type='hcurves', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='hcurves',
+                 path=None, mode=None):
         assert output_type == 'hcurves'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.setWindowTitle(
             'Load hazard curves from NPZ, as layer')
         self.create_load_selected_only_ckb()
@@ -112,5 +114,6 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
                                    % rlz, self.iface):
                 self.build_layer(rlz)
                 self.style_curves()
+        self.viewer_dock.change_output_type('Hazard Curves')
         if self.npz_file is not None:
             self.npz_file.close()

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -38,9 +38,11 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load hazard maps from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, output_type='hmaps', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='hmaps',
+                 path=None, mode=None):
         assert output_type == 'hmaps'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.setWindowTitle(
             'Load hazard maps from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -39,10 +39,11 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load losses by asset from an oq-engine output, as layer
     """
 
-    def __init__(
-            self, iface, output_type='losses_by_asset', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='losses_by_asset',
+                 path=None, mode=None):
         assert output_type == 'losses_by_asset'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.setWindowTitle(
             'Load losses by asset from NPZ, aggregated by location, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -67,12 +67,14 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     Modal dialog to load an oq-engine output as layer
     """
 
-    def __init__(self, iface, output_type=None, path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type=None,
+                 path=None, mode=None):
 
         # sanity check
         if output_type not in OQ_ALL_LOADABLE_TYPES:
             raise NotImplementedError(output_type)
         self.iface = iface
+        self.viewer_dock = viewer_dock
         self.path = path
         self.output_type = output_type
         self.mode = mode  # if 'testing' it will avoid some user interaction

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -33,9 +33,11 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load ruptures from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, output_type='ruptures', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='ruptures',
+                 path=None, mode=None):
         assert output_type == 'ruptures'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.create_save_as_shp_ckb()
         self.setWindowTitle('Load ruptures from CSV, as layer')
         self.adjustSize()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -39,9 +39,11 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
     as layer
     """
 
-    def __init__(self, iface, output_type='uhs', path=None, mode=None):
+    def __init__(self, iface, viewer_dock, output_type='uhs',
+                 path=None, mode=None):
         assert output_type == 'uhs'
-        LoadOutputAsLayerDialog.__init__(self, iface, output_type, path, mode)
+        LoadOutputAsLayerDialog.__init__(
+            self, iface, viewer_dock, output_type, path, mode)
         self.setWindowTitle(
             'Load uniform hazard spectra from NPZ, as layer')
         self.create_load_selected_only_ckb()
@@ -115,3 +117,4 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
                         ' and poe "%s"...' % (rlz, poe), self.iface):
                     self.build_layer(rlz, poe=poe)
                     self.style_curves()
+        self.viewer_dock.change_output_type('Uniform Hazard Spectra')

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -410,7 +410,7 @@ class Irmt:
     def drive_oq_engine_server(self):
         if self.drive_oq_engine_server_dlg is None:
             self.drive_oq_engine_server_dlg = DriveOqEngineServerDialog(
-                self.iface)
+                self.iface, self.viewer_dock)
         else:
             self.drive_oq_engine_server_dlg.attempt_login()
         self.drive_oq_engine_server_dlg.show()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -28,6 +28,8 @@ changelog=
     * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar
     * A splitter has been added between the list of calculations and the list of outputs for a calculation, allowing to
       mutually resize the two lists
+    * When hazard curves or uniform hazard spectra are loaded from an OQ-Engine output, the corresponding output type
+      is pre-selected in the Data Viewer
     1.8.24
     * ProcessLayer.addAttributes launders proposed attribute names only if the processed layer is a shapefile
     * When fields with long names are added to shapefiles, the original long names are saved as aliases

--- a/svir/test/test_load_oq_engine_output_as_layer.py
+++ b/svir/test/test_load_oq_engine_output_as_layer.py
@@ -63,21 +63,24 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_hazard_map(self):
         filepath = os.path.join(
             self.data_dir_name, 'hazard', 'output-182-hmaps_67.npz')
-        dlg = LoadHazardMapsAsLayerDialog(IFACE, 'hmaps', filepath)
+        dlg = LoadHazardMapsAsLayerDialog(
+            IFACE, self.viewer_dock, 'hmaps', filepath)
         dlg.accept()
         # hazard maps have nothing to do with the Data Viewer
 
     def test_load_gmf(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-195-gmf_data_70.npz')
-        dlg = LoadGmfDataAsLayerDialog(IFACE, 'gmf_data', filepath)
+        dlg = LoadGmfDataAsLayerDialog(
+            IFACE, self.viewer_dock, 'gmf_data', filepath)
         dlg.accept()
         # ground motion fields have nothing to do with the Data Viewer
 
     def test_load_hazard_curves(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-181-hcurves_67.npz')
-        dlg = LoadHazardCurvesAsLayerDialog(IFACE, 'hcurves', filepath)
+        dlg = LoadHazardCurvesAsLayerDialog(
+            IFACE, self.viewer_dock, 'hcurves', filepath)
         dlg.accept()
         self._set_output_type('Hazard Curves')
         self._change_selection()
@@ -97,7 +100,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_uhs_only_selected_poe(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-184-uhs_67.npz')
-        dlg = LoadUhsAsLayerDialog(IFACE, 'uhs', filepath)
+        dlg = LoadUhsAsLayerDialog(
+            IFACE, self.viewer_dock, 'uhs', filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         idx = dlg.poe_cbx.findText('0.02')
         self.assertEqual(idx, 1, 'POE 0.02 was not found')
@@ -112,7 +116,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_uhs_all(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-184-uhs_67.npz')
-        dlg = LoadUhsAsLayerDialog(IFACE, 'uhs', filepath)
+        dlg = LoadUhsAsLayerDialog(
+            IFACE, self.viewer_dock, 'uhs', filepath)
         dlg.load_selected_only_ckb.setChecked(False)
         dlg.accept()
         self._set_output_type('Uniform Hazard Spectra')
@@ -125,7 +130,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
             self.data_dir_name, 'risk',
             'output-308-dmg_by_asset-ChiouYoungs2008()_103.csv')
         dlg = LoadDmgByAssetAsLayerDialog(
-            IFACE, 'dmg_by_asset', filepath, mode='testing')
+            IFACE, self.viewer_dock, 'dmg_by_asset', filepath, mode='testing')
         dlg.save_as_shp_ckb.setChecked(True)
         idx = dlg.dmg_state_cbx.findText('complete')
         self.assertEqual(idx, 4, '"complete" damage state was not found')
@@ -145,7 +150,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(
             self.data_dir_name, 'hazard', 'output-607-ruptures_162.csv')
         dlg = LoadRupturesAsLayerDialog(
-            IFACE, 'ruptures', filepath, mode='testing')
+            IFACE, self.viewer_dock, 'ruptures', filepath, mode='testing')
         dlg.save_as_shp_ckb.setChecked(True)
         dlg.accept()
         current_layer = IFACE.activeLayer()
@@ -159,7 +164,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-399-losses_by_asset_123.npz')
         dlg = LoadLossesByAssetAsLayerDialog(
-            IFACE, 'losses_by_asset', filepath)
+            IFACE, self.viewer_dock, 'losses_by_asset', filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('"Concrete"')
         self.assertNotEqual(taxonomy_idx, -1,
@@ -175,7 +180,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-399-losses_by_asset_123.npz')
         dlg = LoadLossesByAssetAsLayerDialog(
-            IFACE, 'losses_by_asset', filepath)
+            IFACE, self.viewer_dock, 'losses_by_asset', filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('All')
         self.assertNotEqual(taxonomy_idx, -1, 'Taxonomy All was not found')


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/241

Even with this change, the output type will be automatically selected only right after loading a layer. When another layer is manually selected, the output type in the Viewer Dock will be reset to None. We might change this behavior, for instance reading the output type from the name of the selected layer. It sounds potentially risky though, so I am not doing that for now.

For simplicity, I am passing a reference to the Viewer Dock also to loaders for outputs that are not currently visualized in the Viewer Dock. Although at the moment it is suboptimal, it can become useful in the future, if we want to use the Viewer Dock also to interactively change some parameters in other kinds of outputs. For instance, we might want to style a map with respect to a different column, that might be chosen through a combo box added to the Viewer Dock.