### PR TITLE
Use a customProperty to store the output_type of a layer

### DIFF
--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -114,6 +114,5 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
                                    % rlz, self.iface):
                 self.build_layer(rlz)
                 self.style_curves()
-        self.viewer_dock.change_output_type('Hazard Curves')
         if self.npz_file is not None:
             self.npz_file.close()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -484,6 +484,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.read_npz_into_layer(
             field_names, rlz=rlz, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type)
+        self.layer.setCustomProperty('output_type', self.output_type)
         # add self.layer to the legend
         # False is to avoid adding the layer to the tree root, but only to the
         # group

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -117,4 +117,3 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
                         ' and poe "%s"...' % (rlz, poe), self.iface):
                     self.build_layer(rlz, poe=poe)
                     self.style_curves()
-        self.viewer_dock.change_output_type('Uniform Hazard Spectra')

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -24,6 +24,7 @@
 
 import json
 import os
+from collections import OrderedDict
 
 from PyQt4 import QtGui
 
@@ -121,8 +122,12 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         self.iface.mapCanvas().setSelectionColor(QColor('magenta'))
 
         # TODO: re-add 'Loss Curves' when the corresponding npz is available
-        self.output_type_cbx.addItems(
-            ['', 'Hazard Curves', 'Uniform Hazard Spectra', 'Recovery Curves'])
+        self.output_types_names = OrderedDict([
+            ('', ''),
+            ('hcurves', 'Hazard Curves'),
+            ('uhs', 'Uniform Hazard Spectra'),
+            ('recovery_curves', 'Recovery Curves')])
+        self.output_type_cbx.addItems(self.output_types_names.values())
 
         self.plot_figure = Figure()
         self.plot_canvas = FigureCanvas(self.plot_figure)
@@ -682,17 +687,13 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
 
     @pyqtSlot(int)
     def on_output_type_cbx_currentIndexChanged(self):
-        otype = self.output_type_cbx.currentText()
-        if otype == 'Hazard Curves':
-            output_type = 'hcurves'
-        elif otype == 'Loss Curves':
-            output_type = 'loss_curves'
-        elif otype == 'Uniform Hazard Spectra':
-            output_type = 'uhs'
-        elif otype == 'Recovery Curves':
-            output_type = 'recovery_curves'
-        else:
-            output_type = None
+        otname = self.output_type_cbx.currentText()
+        for output_type, output_type_name in self.output_types_names.items():
+            if output_type_name == otname:
+                self.set_output_type_and_its_gui(output_type)
+                self.layer_changed()
+                return
+        output_type = None
         self.set_output_type_and_its_gui(output_type)
         self.layer_changed()
 
@@ -701,8 +702,11 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         event.accept()
 
     def change_output_type(self, output_type):
+        if output_type not in self.output_types_names:
+            output_type = ''
         # get the index of the item that has the given string
         # and set the combobox to that item
-        index = self.output_type_cbx.findText(output_type)
+        index = self.output_type_cbx.findText(
+            self.output_types_names[output_type])
         if index != -1:
             self.output_type_cbx.setCurrentIndex(index)

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -448,15 +448,10 @@ class Irmt:
 
     def current_layer_changed(self, layer=None):
         self.update_actions_status()
-        output_type = None
+        output_type = ''
         if layer:
-            output_type = layer.customProperty('output_type')
-        if output_type == 'hcurves':
-            self.viewer_dock.change_output_type('Hazard Curves')
-        elif output_type == 'uhs':
-            self.viewer_dock.change_output_type('Uniform Hazard Spectra')
-        else:
-            self.viewer_dock.change_output_type('')
+            output_type = layer.customProperty('output_type') or ''
+        self.viewer_dock.change_output_type(output_type)
         self.viewer_dock.layer_changed()
 
     def add_menu_item(self,

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -448,7 +448,15 @@ class Irmt:
 
     def current_layer_changed(self, layer=None):
         self.update_actions_status()
-        self.viewer_dock.change_output_type('')
+        output_type = None
+        if layer:
+            output_type = layer.customProperty('output_type')
+        if output_type == 'hcurves':
+            self.viewer_dock.change_output_type('Hazard Curves')
+        elif output_type == 'uhs':
+            self.viewer_dock.change_output_type('Uniform Hazard Spectra')
+        else:
+            self.viewer_dock.change_output_type('')
         self.viewer_dock.layer_changed()
 
     def add_menu_item(self,


### PR DESCRIPTION
and pre-select the Data Viewer's output type accordingly.

The solution implemented in https://github.com/gem/oq-irmt-qgis/pull/245 was sub-optimal. Now I've found out how to save a custom property for a layer, so I can associate each layer with its type. Therefore, when the user selects a different layer, the plugin automatically selects the corresponding output type in the Data Viewer.

