### PR TITLE
Focus on the currently pointed calculation

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -178,8 +178,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 return
             calc_list = json.loads(resp.text)
         selected_keys = ['description', 'id', 'job_type', 'owner', 'status']
-        col_names = ['Description', 'ID', 'Job Type', 'Owner', 'Status']
-        col_widths = [380, 50, 80, 80, 80]
+        col_names = ['Description', 'Job ID', 'Job Type', 'Owner', 'Status']
+        col_widths = [370, 60, 80, 80, 80]
         if not calc_list:
             if self.calc_list_tbl.rowCount() > 0:
                 self.calc_list_tbl.clearContents()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -34,6 +34,8 @@ changelog=
     * The size policy of the Viewer Dock has been improved, to fit better in smaller screens
     * When any cell of the table containing the list of oq-engine calculation is clicked, the list of outputs
       corresponding to the same calculation is displayed, and the row is selected and kept on focus
+    * The row numbers, in both the list of calculations and the list of outputs for a calculation,
+      have been made  invisible
     1.8.24
     * ProcessLayer.addAttributes launders proposed attribute names only if the processed layer is a shapefile
     * When fields with long names are added to shapefiles, the original long names are saved as aliases
@@ -159,7 +161,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=True
+experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -32,6 +32,8 @@ changelog=
       is pre-selected in the Data Viewer
     * Removed annoying messages while retrieveing the console log of a OQ-Engine calculation
     * The size policy of the Viewer Dock has been improved, to fit better in smaller screens
+    * When any cell of the table containing the list of oq-engine calculation is clicked, the list of outputs
+      corresponding to the same calculation is displayed, and the row is selected and kept on focus
     1.8.24
     * ProcessLayer.addAttributes launders proposed attribute names only if the processed layer is a shapefile
     * When fields with long names are added to shapefiles, the original long names are saved as aliases

--- a/svir/ui/ui_drive_engine_server.ui
+++ b/svir/ui/ui_drive_engine_server.ui
@@ -43,7 +43,7 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
         <widget class="QLabel" name="list_of_calcs_lbl">
@@ -70,11 +70,14 @@
          <property name="columnCount">
           <number>0</number>
          </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
         </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="layoutWidget">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QLabel" name="list_of_outputs_lbl">
@@ -100,6 +103,9 @@
          <property name="columnCount">
           <number>0</number>
          </property>
+         <attribute name="verticalHeaderVisible">
+          <bool>false</bool>
+         </attribute>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/242

When any cell of the table containing the list of oq-engine calculations is clicked, the list of outputs
corresponding to the same calculation is displayed, and the clicked row is selected and kept on focus after following refreshes of the list.

I'm also making the row numbers invisible, in both the list of calculations and the list of outputs for a calculation, in order to avoid confusion between those numbers and the job id and output id