### PR TITLE
Save color settings as rgba instead of QColor

### DIFF
--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -145,12 +145,14 @@ class SettingsDialog(QDialog, FORM_CLASS):
         mySettings.setValue('irmt/engine_password',
                             self.enginePasswordEdit.text())
 
+        color_from = self.style_color_from.palette().color(QPalette.Button)
         mySettings.setValue(
             'irmt/style_color_from',
-            self.style_color_from.palette().color(QPalette.Button))
+            color_from.rgba())
+        color_to = self.style_color_to.palette().color(QPalette.Button)
         mySettings.setValue(
             'irmt/style_color_to',
-            self.style_color_to.palette().color(QPalette.Button))
+            color_to.rgba())
 
         mySettings.setValue('irmt/style_mode', self.style_mode.itemData(
             self.style_mode.currentIndex()))

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Improved README with instructions on installation and troubleshooting
     * A clear error message is shown when attempting to modify a non-editable kind of layer
     * Many updates to the user manual
+    * Color settings are saved as rgba instead of as QColor (fixing a storing issue in Mac OS)
     1.8.25
     * The list of OQ-Engine calculations is automatically scrolled to view the latest clicked row
     * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -823,15 +823,23 @@ def get_style(layer, message_bar):
     force_restyling_default = True
 
     settings = QSettings()
-    color_from_rgba = settings.value(
-        'irmt/style_color_from', color_from_rgba_default, type=int)
-    color_from_rgba = _check_type(color_from_rgba, 'Color from', int,
-                                  color_from_rgba_default, message_bar)
+    try:
+        color_from_rgba = settings.value(
+            'irmt/style_color_from', color_from_rgba_default, type=int)
+    except TypeError:
+        msg = ('The type of the stored setting "style_color_from" was not'
+               ' valid, so the default has been restored.')
+        log_msg(msg, level='C', message_bar=message_bar)
+        color_from_rgba = color_from_rgba_default
     color_from = QColor().fromRgba(color_from_rgba)
-    color_to_rgba = settings.value(
-        'irmt/style_color_to', color_to_rgba_default, type=int)
-    color_to_rgba = _check_type(
-        color_to_rgba, 'Color to', int, color_to_rgba_default, message_bar)
+    try:
+        color_to_rgba = settings.value(
+            'irmt/style_color_to', color_to_rgba_default, type=int)
+    except TypeError:
+        msg = ('The type of the stored setting "style_color_to" was not'
+               ' valid, so the default has been restored.')
+        log_msg(msg, level='C', message_bar=message_bar)
+        color_to_rgba = color_to_rgba_default
     color_to = QColor().fromRgba(color_to_rgba)
     mode = settings.value(
         'irmt/style_mode', style_mode_default, type=int)

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -816,21 +816,23 @@ def _check_type(
 
 
 def get_style(layer, message_bar):
-    color_from_default = QColor('#FFEBEB')
-    color_to_default = QColor('red')
+    color_from_rgba_default = QColor('#FFEBEB').rgba()
+    color_to_rgba_default = QColor('red').rgba()
     style_mode_default = QgsGraduatedSymbolRendererV2.Quantile
     style_classes_default = 10
     force_restyling_default = True
 
     settings = QSettings()
-    color_from = settings.value(
-        'irmt/style_color_from', color_from_default)
-    color_from = _check_type(
-        color_from, 'Color from', QColor, color_from_default, message_bar)
-    color_to = settings.value(
-        'irmt/style_color_to', color_to_default)
-    color_to = _check_type(
-        color_to, 'Color to', QColor, color_to_default, message_bar)
+    color_from_rgba = settings.value(
+        'irmt/style_color_from', color_from_rgba_default, type=int)
+    color_from_rgba = _check_type(color_from_rgba, 'Color from', int,
+                                  color_from_rgba_default, message_bar)
+    color_from = QColor().fromRgba(color_from_rgba)
+    color_to_rgba = settings.value(
+        'irmt/style_color_to', color_to_rgba_default, type=int)
+    color_to_rgba = _check_type(
+        color_to_rgba, 'Color to', int, color_to_rgba_default, message_bar)
+    color_to = QColor().fromRgba(color_to_rgba)
     mode = settings.value(
         'irmt/style_mode', style_mode_default, type=int)
     classes = settings.value(


### PR DESCRIPTION
Fixes #251 
This is a workaround to a storing issue in Mac OS