### PR TITLE
A second click on the currently selected OQ-Engine calculation, unselects it

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -428,7 +428,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         calc_id_col_idx = 1
         item_calc_id = self.calc_list_tbl.item(row, calc_id_col_idx)
         calc_id = int(item_calc_id.text())
-        self.current_pointed_calc_id = calc_id
+        if self.current_pointed_calc_id == calc_id:
+            self.current_pointed_calc_id = None
+            self.calc_list_tbl.clearSelection()
+        else:
+            self.current_pointed_calc_id = calc_id
         self.update_output_list(calc_id)
 
     @pyqtSlot()

--- a/svir/help/source/14_driving_the_oqengine.rst
+++ b/svir/help/source/14_driving_the_oqengine.rst
@@ -25,13 +25,34 @@ cluster, to perform jobs that are highly demanding in terms of computational res
 
 
 Run a calculation
-===================
+=================
 
 When the :guilabel:`Run Calculation` button is pressed, a file explorer is opened,
 enabling to select the input files needed to run the job (or a zip archive
 containing them), including the `job.ini` file. By pressing :guilabel:`Open` to confirm,
 the job is submitted. The interface keeps querying the server asynchronously, and
 displaying the status of the calculation.
+
+
+The list of calculations
+========================
+
+For each calculation available on the connected OQ-Engine server (only those that
+the current user is authorized to visualize), the :guilabel:`List of calculations`
+(see :ref:`fig-dialogDriveOqEngine`)
+shows its :guilabel:`Description`, its unique :guilabel:`Job ID`, its :guilabel:`Job Type`
+(specifying if it is a hazard or risk calculation), its :guilabel:`Owner` and
+its :guilabel:`Status` (indicating if the calculation is still running, if it
+failed or if it was successfully completed). The list is refreshed at regular
+intervals of few seconds and it displays the most recent 100 calculations.
+
+It is possible to scroll the list up and down and to resize it with respect to the
+:guilabel:`List of outputs`. When any row of the list of calculations is selected,
+the row is highlighted and the list of outputs for the corresponding calculation
+is populated (it will be an empty list if the calculation has not been successfully
+completed). While a row is selected, it is automatically centered in the visible
+area of the list, at each refresh. By clicking again on the currently selected row,
+it will be unhighlighted, resetting the default scrolling behavior of the table.
 
 
 Watch the console log

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,8 @@ changelog=
     * Improved README with instructions on installation and troubleshooting
     * A clear error message is shown when attempting to modify a non-editable kind of layer
     * Many updates to the user manual
+    * Re-clicking the row of the currently selected calculation, the row is unselected and
+      the table ceases to scroll automatically to keep that row visible
     1.8.25
     * The list of OQ-Engine calculations is automatically scrolled to view the latest clicked row
     * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/256
Re-clicking the row of the currently selected calculation, the row is unselected and the table ceases to scroll automatically to keep that row visible.