### PR TITLE
Fix error on selecting feature for a layer with undefined output type

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -361,7 +361,7 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         self.plot_canvas.draw()
 
     def redraw(self, selected, deselected, _):
-        if self.output_type is None:
+        if not self.output_type:
             return
         for fid in deselected:
             try:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -28,6 +28,8 @@ changelog=
     * A clear error message is shown when attempting to modify a non-editable kind of layer
     * Many updates to the user manual
     * Color settings are saved as rgba instead of as QColor (fixing a storing issue in Mac OS)
+    * Fixed an error that was triggered by the Data Viewer when selecting features in a layer for which
+      the output type is undefined
     1.8.25
     * The list of OQ-Engine calculations is automatically scrolled to view the latest clicked row
     * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar


### PR DESCRIPTION
This PR fixes https://github.com/gem/oq-irmt-qgis/issues/259, that was observed while running a script by @mmpagani and that I was able to reproduce on my computer.

The problem was that the undefined output type can be an empty string, but the check was done only with respect to the case it was `None`.