### PR TITLE
Some integration tests

### DIFF
--- a/svir/Makefile
+++ b/svir/Makefile
@@ -74,6 +74,23 @@ test: compile transcompile
 	@echo "e.g. source ../scripts/run-env-linux.sh <path to qgis install>; make test"
 	@echo "----------------------"
 
+integrationtest: compile transcompile
+	@echo
+	@echo "----------------------"
+	@echo "Integration Test Suite"
+	@echo "----------------------"
+
+	@export PYTHONPATH=`pwd`:$(PYTHONPATH); \
+		export QGIS_DEBUG=0; \
+		export QGIS_LOG_FILE=/dev/null; \
+		nosetests -s -v --with-xunit --with-id test/integration\
+		3>&1 1>&2 2>&3 3>&-
+	@echo "----------------------"
+	@echo "If you get 'no module...' errors, try sourcing"
+	@echo "the helper script we have provided first then run make integrationtest."
+	@echo "e.g. source ../scripts/run-env-linux.sh <path to qgis install>; make integrationtest"
+	@echo "----------------------"
+
 deploy: compile doc transcompile
 	@echo
 	@echo "------------------------------------------"

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -371,7 +371,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             log_msg(msg, level='C', message_bar=self.iface.messageBar())
         return
 
-    def run_calc(self, calc_id=None):
+    def run_calc(self, calc_id=None, file_names=None):
         """
         Run a calculation. If `calc_id` is given, it means we want to run
         a calculation re-using the output of the given calculation
@@ -380,7 +380,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                        ' or the zip archive containing those files.')
         default_dir = QSettings().value('irmt/run_oqengine_calc_dir',
                                         QDir.homePath())
-        file_names = QFileDialog.getOpenFileNames(self, text, default_dir)
+        if not file_names:
+            file_names = QFileDialog.getOpenFileNames(self, text, default_dir)
         if not file_names:
             return
         selected_dir = QFileInfo(file_names[0]).dir().path()

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -23,7 +23,6 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import json
 import tempfile
 import zipfile
@@ -627,11 +626,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     raise NotImplementedError(output_type)
                 dlg = output_type_loaders[output_type](
                     self.iface, self.viewer_dock, output_type, filepath)
-                # if we are running nosetests, accept defaults in combos
-                if 'nose' in sys.modules.keys():
-                    dlg.accept()
-                else:
-                    dlg.exec_()
+                dlg.exec_()
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))
         elif action == 'Download':

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -23,6 +23,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import sys
 import json
 import tempfile
 import zipfile
@@ -585,7 +586,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     raise NotImplementedError(output_type)
                 dlg = output_type_loaders[output_type](
                     self.iface, self.viewer_dock, output_type, filepath)
-                dlg.exec_()
+                # if we are running nosetests, accept defaults in combos
+                if 'nose' in sys.modules.keys():
+                    dlg.accept()
+                else:
+                    dlg.exec_()
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))
         elif action == 'Download':

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -422,6 +422,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 return
         if resp.ok:
             self.refresh_calc_list()
+            return resp.json()
         else:
             log_msg(resp.text, level='C', message_bar=self.iface.messageBar())
 

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -40,10 +40,12 @@ class DriveOqEngineTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.session = Session()
-        # FIXME: it might be passed as argument when running integration tests
+        # TODO: it might be passed as argument when running integration tests
         cls.demos_dir = os.path.join(
-            os.path.expanduser('~'), 'projects', 'oq-engine', 'demos')
-        cls.hostname = 'http://0.0.0.0:8800'
+            os.path.dirname(__file__),
+            os.pardir, os.pardir, os.pardir, os.pardir,
+            'oq-engine', 'demos')
+        cls.hostname = 'http://localhost:8800'
         # TODO: we should run all the demos that cover the output types for
         # which we have already implemented a corresponding loader. For now,
         # we are just running the hazard AreaSource demo

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -24,15 +24,16 @@
 
 # import qgis libs so that we set the correct sip api version
 import os
-import sys
+# import sys
 import unittest
-import time
+# import time
+import tempfile
 
-from PyQt4.QtCore import (
-                          QObject,
-                          SIGNAL,
-                          QThread,
-                          )
+# from PyQt4.QtCore import (
+#                           QObject,
+#                           SIGNAL,
+#                           QThread,
+#                           )
 from PyQt4.QtGui import QAction
 from svir.dialogs.drive_oq_engine_server_dialog import (
     DriveOqEngineServerDialog)
@@ -56,17 +57,24 @@ class DriveOqEngineTestCase(unittest.TestCase):
         mock_action = QAction(IFACE.mainWindow())
         self.viewer_dock = ViewerDock(IFACE, mock_action)
         self.dlg = DriveOqEngineServerDialog(IFACE, self.viewer_dock)
-        self.dlg.show()
-        self.dlg.raise_()
-        self.dlg.start_polling()
+        self.calc_id = 219
+        self.output_id = 935
+        # self.dlg.show()
+        # self.dlg.raise_()
+        # self.dlg.start_polling()
         # self.irmt = Irmt(IFACE)
         # self.irmt.drive_oq_engine_server()
         # self.driver_dlg = self.irmt.drive_oq_engine_server_dlg
+
+    def tearDown(self):
+        # self.dlg.remove_calc(self.calc_id)
+        pass
 
     def test_run_calculation_separate_input_files(self):
         area_source_dir = os.path.join(
             self.demos_dir, 'hazard', 'AreaSourceClassicalPSHA')
         file_names = listdir_fullpath(area_source_dir)
+        # FIXME uncomment
         # self.dlg.run_calc(file_names=file_names)
 
         # import pdb
@@ -107,11 +115,20 @@ class DriveOqEngineTestCase(unittest.TestCase):
     #     sys.stderr.write('\n')
 
     def test_get_calc_log(self):
-        print(self.dlg.get_calc_log(219))
+        print(self.dlg.get_calc_log(self.calc_id))
 
     def test_get_calc_status(self):
-        print(self.dlg.get_calc_status(219))
+        print(self.dlg.get_calc_status(self.calc_id))
 
     def test_remove_calculation(self):
-        # self.dlg.remove_calc(219)
+        # self.dlg.remove_calc(self.calc_id)
         pass
+
+    def test_get_output_list(self):
+        output_list = self.dlg.get_output_list(self.calc_id)
+        print output_list
+
+    def test_load_output(self):
+        filepath = self.dlg.download_output(
+            self.output_id, 'npz', tempfile.gettempdir())
+        print filepath

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -109,7 +109,7 @@ class DriveOqEngineTestCase(unittest.TestCase):
         resp = cls.session.post(
             run_calc_url, files=files, data=data, timeout=20)
         if not resp.ok:
-            raise
+            raise Exception(resp.text)
         return resp.json()
 
     @classmethod
@@ -117,7 +117,7 @@ class DriveOqEngineTestCase(unittest.TestCase):
         calc_remove_url = "%s/v1/calc/%s/remove" % (cls.hostname, calc_id)
         resp = cls.session.post(calc_remove_url, timeout=10)
         if not resp.ok:
-            raise
+            raise Exception(resp.text)
 
     @classmethod
     def get_calc_status(cls, calc_id):
@@ -133,7 +133,7 @@ class DriveOqEngineTestCase(unittest.TestCase):
         # FIXME: enable the user to set verify=True
         resp = cls.session.get(output_list_url, timeout=10, verify=False)
         if not resp.ok:
-            raise
+            raise Exception(resp.text)
         output_list = json.loads(resp.text)
         return output_list
 
@@ -147,7 +147,7 @@ class DriveOqEngineTestCase(unittest.TestCase):
         # FIXME: enable the user to set verify=True
         resp = self.session.get(output_download_url, verify=False)
         if not resp.ok:
-            raise
+            raise Exception(resp.text)
         filename = resp.headers['content-disposition'].split(
             'filename=')[1]
         filepath = os.path.join(dest_folder, filename)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+# /***************************************************************************
+# Irmt
+#                                 A QGIS plugin
+# OpenQuake Integrated Risk Modelling Toolkit
+#                              -------------------
+#        begin                : 2014-10-24
+#        copyright            : (C) 2014-2017 by GEM Foundation
+#        email                : devops@openquake.org
+# ***************************************************************************/
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+# import qgis libs so that we set the correct sip api version
+import os
+import sys
+import unittest
+import time
+
+from PyQt4.QtCore import (
+                          QObject,
+                          SIGNAL,
+                          QThread,
+                          )
+from PyQt4.QtGui import QAction
+from svir.dialogs.drive_oq_engine_server_dialog import (
+    DriveOqEngineServerDialog)
+# from svir.irmt import Irmt
+from svir.dialogs.viewer_dock import ViewerDock
+from svir.utilities.utils import listdir_fullpath
+from svir.test.utilities import get_qgis_app
+
+QGIS_APP, CANVAS, IFACE, PARENT = get_qgis_app()
+
+
+class DriveOqEngineTestCase(unittest.TestCase):
+    def setUp(self):
+        IFACE.newProject()
+        curr_dir_name = os.path.dirname(__file__)
+        self.data_dir_name = os.path.join(
+            curr_dir_name, os.pardir, 'data')
+        # FIXME: it might be passed as argument when running integration tests
+        self.demos_dir = os.path.join(
+            os.path.expanduser('~'), 'projects', 'oq-engine', 'demos')
+        mock_action = QAction(IFACE.mainWindow())
+        self.viewer_dock = ViewerDock(IFACE, mock_action)
+        self.dlg = DriveOqEngineServerDialog(IFACE, self.viewer_dock)
+        self.dlg.show()
+        self.dlg.raise_()
+        self.dlg.start_polling()
+        # self.irmt = Irmt(IFACE)
+        # self.irmt.drive_oq_engine_server()
+        # self.driver_dlg = self.irmt.drive_oq_engine_server_dlg
+
+    def test_run_calculation_separate_input_files(self):
+        area_source_dir = os.path.join(
+            self.demos_dir, 'hazard', 'AreaSourceClassicalPSHA')
+        file_names = listdir_fullpath(area_source_dir)
+        # self.dlg.run_calc(file_names=file_names)
+
+        # import pdb
+        # pdb.set_trace()
+        # print 'ciao'
+        # self.calc_status = None
+        # QObject.connect(
+        #     self.dlg.timer, SIGNAL('timeout()'), self._get_calc_status)
+        # self._get_calc_status()
+        # while self.calc_status != 'complete':
+        #     time.sleep(1)
+        #     sys.stderr.write(self.status)
+        #     sys.stderr.write('\n')
+
+        # thread = QThread()
+        # while True:
+        #     thread.sleep(2000)
+        #     self._get_calc_status()
+        # while True:
+        #     time.sleep(2)
+        #     try:
+        #         status = self.dlg.calc_list_tbl.item(0, 4).text()
+        #         sys.stderr.write(status)
+        #         sys.stderr.write('\n')
+        #     except:
+        #         pass
+        #     if status == 'complete':
+        #         break
+        # import pdb
+        # pdb.set_trace()
+        # remove_btn = self.dlg.calc_list_tbl.item(0, 6)
+        # remove_btn.click()
+        # print 'ciao'
+
+    # def _get_calc_status(self):
+    #     self.calc_status = self.dlg.calc_list_tbl.item(0, 4).text()
+    #     sys.stderr.write(self.calc_status)
+    #     sys.stderr.write('\n')
+
+    def test_get_calc_log(self):
+        print(self.dlg.get_calc_log(219))
+
+    def test_get_calc_status(self):
+        print(self.dlg.get_calc_status(219))
+
+    def test_remove_calculation(self):
+        # self.dlg.remove_calc(219)
+        pass

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -156,30 +156,79 @@ class DriveOqEngineTestCase(unittest.TestCase):
 
     def test_load_hmaps(self):
         npz = numpy.load(self.hmaps_filepath, 'r')
-        rlz_dtype_names = npz['rlz-000'].dtype.names
-        expected_rlz_dtype_names = (
-            'lon', 'lat', 'PGA-0.1', 'PGA-0.02', 'PGV-0.1', 'PGV-0.02',
-            'SA(0.025)-0.1', 'SA(0.025)-0.02', 'SA(0.05)-0.1', 'SA(0.05)-0.02',
-            'SA(0.1)-0.1', 'SA(0.1)-0.02', 'SA(0.2)-0.1', 'SA(0.2)-0.02',
-            'SA(0.5)-0.1', 'SA(0.5)-0.02', 'SA(1.0)-0.1', 'SA(1.0)-0.02',
-            'SA(2.0)-0.1', 'SA(2.0)-0.02')
-        self.assertEqual(rlz_dtype_names, expected_rlz_dtype_names)
+        rlz_dtype = npz['rlz-000'].dtype
+        expected_rlz_dtype = numpy.dtype([
+            ('lon', '<f8'),
+            ('lat', '<f8'),
+            ('PGA-0.1', '<f8'),
+            ('PGA-0.02', '<f8'),
+            ('PGV-0.1', '<f8'),
+            ('PGV-0.02', '<f8'),
+            ('SA(0.025)-0.1', '<f8'),
+            ('SA(0.025)-0.02', '<f8'),
+            ('SA(0.05)-0.1', '<f8'),
+            ('SA(0.05)-0.02', '<f8'),
+            ('SA(0.1)-0.1', '<f8'),
+            ('SA(0.1)-0.02', '<f8'),
+            ('SA(0.2)-0.1', '<f8'),
+            ('SA(0.2)-0.02', '<f8'),
+            ('SA(0.5)-0.1', '<f8'),
+            ('SA(0.5)-0.02', '<f8'),
+            ('SA(1.0)-0.1', '<f8'),
+            ('SA(1.0)-0.02', '<f8'),
+            ('SA(2.0)-0.1', '<f8'),
+            ('SA(2.0)-0.02', '<f8')])
+        self.assertEqual(rlz_dtype, expected_rlz_dtype)
 
     def test_load_hcurves(self):
         npz = numpy.load(self.hcurves_filepath, 'r')
-        imtls_dtype_names = npz['imtls'].dtype.names
-        expected_imtls_dtype_names = (
-            'PGA', 'PGV', 'SA(0.025)', 'SA(0.05)', 'SA(0.1)', 'SA(0.2)',
-            'SA(0.5)', 'SA(1.0)', 'SA(2.0)')
-        self.assertEqual(imtls_dtype_names, expected_imtls_dtype_names)
-        rlz_dtype_names = npz['rlz-000'].dtype.names
-        expected_rlz_dtype_names = (
-            'lon', 'lat', 'PGA', 'PGV', 'SA(0.025)', 'SA(0.05)', 'SA(0.1)',
-            'SA(0.2)', 'SA(0.5)', 'SA(1.0)', 'SA(2.0)')
-        self.assertEqual(rlz_dtype_names, expected_rlz_dtype_names)
+        imtls_dtype = npz['imtls'].dtype
+        expected_imtls_dtype = numpy.dtype([
+            ('PGA', '<f8', (19,)),
+            ('PGV', '<f8', (45,)),
+            ('SA(0.025)', '<f8', (19,)),
+            ('SA(0.05)', '<f8', (19,)),
+            ('SA(0.1)', '<f8', (19,)),
+            ('SA(0.2)', '<f8', (19,)),
+            ('SA(0.5)', '<f8', (19,)),
+            ('SA(1.0)', '<f8', (20,)),
+            ('SA(2.0)', '<f8', (20,))])
+        self.assertEqual(imtls_dtype, expected_imtls_dtype)
+        rlz_dtype = npz['rlz-000'].dtype
+        expected_rlz_dtype = numpy.dtype([
+            ('lon', '<f8'),
+            ('lat', '<f8'),
+            ('PGA', '<f8', (19,)),
+            ('PGV', '<f8', (45,)),
+            ('SA(0.025)', '<f8', (19,)),
+            ('SA(0.05)', '<f8', (19,)),
+            ('SA(0.1)', '<f8', (19,)),
+            ('SA(0.2)', '<f8', (19,)),
+            ('SA(0.5)', '<f8', (19,)),
+            ('SA(1.0)', '<f8', (20,)),
+            ('SA(2.0)', '<f8', (20,))])
+        self.assertEqual(rlz_dtype, expected_rlz_dtype)
 
     def test_load_uhs(self):
         npz = numpy.load(self.uhs_filepath, 'r')
-        rlz_dtype_names = npz['rlz-000'].dtype.names
-        expected_rlz_dtype_names = ('lon', 'lat', '0.1', '0.02')
-        self.assertEqual(rlz_dtype_names, expected_rlz_dtype_names)
+        rlz_dtype = npz['rlz-000'].dtype
+        expected_rlz_dtype = numpy.dtype([
+            ('lon', '<f8'),
+            ('lat', '<f8'),
+            ('0.1', [('PGA', '<f8'),
+                     ('SA(0.025)', '<f8'),
+                     ('SA(0.05)', '<f8'),
+                     ('SA(0.1)', '<f8'),
+                     ('SA(0.2)', '<f8'),
+                     ('SA(0.5)', '<f8'),
+                     ('SA(1.0)', '<f8'),
+                     ('SA(2.0)', '<f8')]),
+            ('0.02', [('PGA', '<f8'),
+                      ('SA(0.025)', '<f8'),
+                      ('SA(0.05)', '<f8'),
+                      ('SA(0.1)', '<f8'),
+                      ('SA(0.2)', '<f8'),
+                      ('SA(0.5)', '<f8'),
+                      ('SA(1.0)', '<f8'),
+                      ('SA(2.0)', '<f8')])])
+        self.assertEqual(rlz_dtype, expected_rlz_dtype)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -24,20 +24,13 @@
 
 # import qgis libs so that we set the correct sip api version
 import os
-# import sys
 import unittest
 import time
 import tempfile
 
-# from PyQt4.QtCore import (
-#                           QObject,
-#                           SIGNAL,
-#                           QThread,
-#                           )
 from PyQt4.QtGui import QAction
 from svir.dialogs.drive_oq_engine_server_dialog import (
     DriveOqEngineServerDialog)
-# from svir.irmt import Irmt
 from svir.dialogs.viewer_dock import ViewerDock
 from svir.utilities.utils import listdir_fullpath
 from svir.test.utilities import get_qgis_app
@@ -49,8 +42,6 @@ class DriveOqEngineTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        # super(DriveOqEngineTestCase, cls).setUpClass()
-        # IFACE.newProject()
         curr_dir_name = os.path.dirname(__file__)
         cls.data_dir_name = os.path.join(
             curr_dir_name, os.pardir, 'data')
@@ -68,15 +59,13 @@ class DriveOqEngineTestCase(unittest.TestCase):
             cls.demos_dir, 'hazard', 'AreaSourceClassicalPSHA')
         file_names = listdir_fullpath(area_source_dir)
         resp = cls.dlg.run_calc(file_names=file_names)
-        # FIXME
-        # cls.assertEqual(resp['status'], 'created')
+        assert resp['status'] == 'created', resp['status']
         cls.calc_id = resp['job_id']
 
         while True:
             time.sleep(4)
             status = cls.dlg.get_calc_status(cls.calc_id)
-            # FIXME
-            # cls.assertNotEqual(status['status'], 'failed')
+            assert status['status'] != 'failed', status['status']
             if status['status'] == 'complete':
                 break
 
@@ -91,7 +80,6 @@ class DriveOqEngineTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        # super(DriveOqEngineTestCase, cls).tearDownClass()
         # TODO: we should remove all the calculations that were created in the
         # setUp
         cls.dlg.remove_calc(cls.calc_id)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -58,7 +58,9 @@ class DriveOqEngineTestCase(unittest.TestCase):
         self.viewer_dock = ViewerDock(IFACE, mock_action)
         self.dlg = DriveOqEngineServerDialog(IFACE, self.viewer_dock)
         self.calc_id = 219
-        self.output_id = 935
+        self.hcurves_id = 934
+        self.hmaps_id = 935
+        self.uhs_id = 937
         # self.dlg.show()
         # self.dlg.raise_()
         # self.dlg.start_polling()
@@ -130,5 +132,17 @@ class DriveOqEngineTestCase(unittest.TestCase):
 
     def test_load_output(self):
         filepath = self.dlg.download_output(
-            self.output_id, 'npz', tempfile.gettempdir())
+            self.hmaps_id, 'npz', tempfile.gettempdir())
         print filepath
+
+    def test_load_hmaps(self):
+        output = dict(id=self.hmaps_id, type='hmaps')
+        self.dlg.on_output_action_btn_clicked(output, 'Load as layer', 'npz')
+
+    def test_load_hcurves(self):
+        output = dict(id=self.hcurves_id, type='hcurves')
+        self.dlg.on_output_action_btn_clicked(output, 'Load as layer', 'npz')
+
+    def test_load_uhs(self):
+        output = dict(id=self.uhs_id, type='uhs')
+        self.dlg.on_output_action_btn_clicked(output, 'Load as layer', 'npz')

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -26,6 +26,7 @@ import numpy
 import collections
 import json
 import os
+import sys
 import locale
 from copy import deepcopy
 from time import time
@@ -98,21 +99,26 @@ def log_msg(message, tag='GEM IRMT Plugin', level='I', message_bar=None,
                     'bar': QgsMessageBar.CRITICAL}}
     if level not in levels:
         raise ValueError('Level must be one of %s' % levels.keys())
-    QgsMessageLog.logMessage(tr(message), tr(tag), levels[level]['log'])
-    if message_bar is not None:
-        if level == 'I':
-            title = 'Info'
-            duration = duration if duration is not None else 8
-        elif level == 'W':
-            title = 'Warning'
-            duration = duration if duration is not None else 0
-        elif level == 'C':
-            title = 'Error'
-            duration = duration if duration is not None else 0
-        message_bar.pushMessage(tr(title),
-                                tr(message),
-                                levels[level]['bar'],
-                                duration)
+
+    # if we are running nosetests, exit on critical errors
+    if 'nose' in sys.modules.keys() and level == 'C':
+        sys.exit(message)
+    else:
+        QgsMessageLog.logMessage(tr(message), tr(tag), levels[level]['log'])
+        if message_bar is not None:
+            if level == 'I':
+                title = 'Info'
+                duration = duration if duration is not None else 8
+            elif level == 'W':
+                title = 'Warning'
+                duration = duration if duration is not None else 0
+            elif level == 'C':
+                title = 'Error'
+                duration = duration if duration is not None else 0
+            message_bar.pushMessage(tr(title),
+                                    tr(message),
+                                    levels[level]['bar'],
+                                    duration)
 
 
 def tr(message):

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -964,3 +964,7 @@ def groupby(npz, rlz, loss_type, taxonomy='All'):
     for i, (lon, lat) in enumerate(sorted(loss_by_site)):
         data[i] = (lon, lat, loss_by_site[lon, lat])
     return data
+
+
+def listdir_fullpath(path):
+    return [os.path.join(path, filename) for filename in os.listdir(path)]


### PR DESCRIPTION
I changed things in order to avoid using any dialogs and creating any layers. This implied to re-write some functionalities that were already present in the dialogs (but that I simplified a lot here, for the simpler purposes).

Instead of loading the outputs as layers (which is tested in the unit tests), here I am just checking that the dtypes are as expected.

TODO: currently the name of the directory that contains the oq-engine demos is hardcoded, as well as the url and port of the connection with engine server. We will also have to set up Travis and/or Jenkins with a working engine server.