### PR TITLE
Add warning about field names containing parentheses

### DIFF
--- a/svir/dialogs/transformation_dialog.py
+++ b/svir/dialogs/transformation_dialog.py
@@ -30,7 +30,7 @@ from svir.calculations.transformation_algs import (RANK_VARIANTS,
                                                    QUADRATIC_VARIANTS,
                                                    LOG10_VARIANTS,
                                                    TRANSFORMATION_ALGS)
-from svir.utilities.utils import get_ui_class
+from svir.utilities.utils import get_ui_class, log_msg
 from svir.utilities.shared import NUMERIC_FIELD_TYPES
 from svir.calculations.process_layer import ProcessLayer
 from svir.ui.list_multiselect_widget import ListMultiSelectWidget
@@ -184,10 +184,23 @@ class TransformationDialog(QDialog, FORM_CLASS):
             self.attr_name_user_def = False
 
     def fill_fields_multiselect(self):
-        names_plus_aliases = [
-            '%s (%s)' % (field.name(),
-                         self.iface.activeLayer().attributeAlias(field_idx))
-            for field_idx, field in enumerate(
-                self.iface.activeLayer().fields())
-            if field.typeName() in NUMERIC_FIELD_TYPES]
+        names_plus_aliases = []
+        for field_idx, field in enumerate(self.iface.activeLayer().fields()):
+            if field.typeName() in NUMERIC_FIELD_TYPES:
+                if '(' in field.name():
+                    msg = (
+                        'Please remove parentheses from the name of field'
+                        ' %s before attempting to transform it, otherwise'
+                        ' the tool will not be able to distinguish between'
+                        ' the alias and the part of the name included'
+                        ' between parentheses. For instance, you may'
+                        ' replace "(" with "[" to avoid ambiguity.'
+                        % field.name())
+                    log_msg(
+                        msg, level='W', message_bar=self.iface.messageBar())
+                else:
+                    name_plus_alias = '%s (%s)' % (
+                        field.name(),
+                        self.iface.activeLayer().attributeAlias(field_idx))
+                    names_plus_aliases.append(name_plus_alias)
         self.fields_multiselect.set_unselected_items(names_plus_aliases)

--- a/svir/help/source/07_transform_attribute.rst
+++ b/svir/help/source/07_transform_attribute.rst
@@ -128,6 +128,10 @@ be truncated to 10 characters.
     with the format `name (alias)`. If no alias is specified for the field, the
     parenthesis will be empty. The plugin automatically assigns to the
     transformed field the same alias of the original one (if available).
+    Please make sure that the names of the fields to be transformed do not
+    contain parentheses, otherwise the plugin would erroneously interpret them
+    as containers for the alias; therefore the selected name would be incomplete
+    (being taken excluding the parentheses) and it would not be found in the layer.
 
 If the checkbox :guilabel:`Let all project definitions utilize transformed
 values` is checked, all the project definitions associated with the active

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -40,6 +40,8 @@ changelog=
       tree when no other numeric fields are available
     * Fixed case of highlighting a calculation that is no more in the list
     * Replaced the csv importer for damage by asset with an importer from npz that also aggregates data by site
+    * When a field contanins "(" it will not be listed between those that can be transformed, and
+      a warning will suggest the user to replace the parenthesis with a square bracket before transforming the field
     1.8.25
     * The list of OQ-Engine calculations is automatically scrolled to view the latest clicked row
     * The IRMT viewer dock can be shown/hidden by an additional button in the plugin's toolbar


### PR DESCRIPTION
Closes #280

When the field transformation widget is opened, if the active layer contains fields that have a parenthesis in their name, those fields will not be listed between those that can be transformed, and a warning message will be displayed, suggesting to replace the parenthesis with a square bracket.