### PR TITLE
Use environ variable SELECTED_OTYPE to test only a chosen output type

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -46,6 +46,8 @@ changelog=
     * Added integration tests loading outputs of oq-engine demos
     * The 'load as layer' button is disabled for gmf_data produced by event_based calculations
     * The list of oq-engine calculations displays the calculation mode instead of the job type
+    * Environment parameters SELECTED_OTYPE and SELECTED_CALC_ID can be used to test only a specific output
+      type or a specific calculation
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk, Recovery, Resilience, Risk, Hazard, Earthquake

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -84,6 +84,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         calc_id = calc['id']
         output_list = self.get_output_list(calc_id)
         for output in output_list:
+            if (self.selected_otype is not None
+                    and output['type'] != self.selected_otype):
+                continue
             try:
                 self.load_output(calc, output)
             except Exception:
@@ -167,6 +170,18 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             print('\n\n\tSELECTED_CALC_ID is set.'
                   ' Running tests only for calculation #%s'
                   % selected_calc_id)
+        if selected_calc_id is not None:
+            calc_list = [calc for calc in calc_list
+                         if calc['id'] == selected_calc_id]
+        self.selected_otype = os.environ.get('SELECTED_OTYPE')
+        if (self.selected_otype not in OQ_ALL_LOADABLE_TYPES
+                and self.selected_otype != 'fullreport'):
+            print('\n\tSELECTED_OTYPE was not set or is not valid.'
+                  ' Running tests for all the available output types.')
+            self.selected_otype = None
+        else:
+            print('\n\tSELECTED_OTYPE is set.'
+                  ' Running tests only for %s' % self.selected_otype)
         if selected_calc_id is not None:
             calc_list = [calc for calc in calc_list
                          if calc['id'] == selected_calc_id]

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -182,9 +182,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         else:
             print('\n\tSELECTED_OTYPE is set.'
                   ' Running tests only for %s' % self.selected_otype)
-        if selected_calc_id is not None:
-            calc_list = [calc for calc in calc_list
-                         if calc['id'] == selected_calc_id]
         for calc in calc_list:
             print('\nCalculation %s: %s' % (calc['id'], calc['description']))
             self.load_calc_outputs(calc)


### PR DESCRIPTION
In addition to SELECTED_CALC_ID, with this PR you can use another environmental variable (SELCTED_OTYPE) to run integration tests only for a specific output type. This is very useful for debugging.