### PR TITLE
Multi branch support for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,15 @@ python:
     - "2.7"
 
 before_install:
+    - if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then BRANCH=$TRAVIS_PULL_REQUEST_BRANCH; else BRANCH=$TRAVIS_BRANCH; fi
+    - if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${BRANCH})" == "" ]; then
+        BRANCH='master';
+      fi;
+    - curl -sO http://artifacts.openquake.org/travis/oqdata-${BRANCH}.zip || ( echo "Dump for ${BRANCH} unavailable"; exit 1 )
+    - git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-engine.git && echo "Running against oq-engine/${BRANCH}"
     - echo "deb http://qgis.org/$QGIS_VERSION trusty main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 073D307A618E5811
     - sudo apt-get update -q
-    - git clone --depth=1 -q https://github.com/gem/oq-engine.git
-    - curl -sO http://artifacts.openquake.org/travis/oqdata.zip
 
 install:
     - sudo apt-get install -q -y xvfb qgis python-mock python-nose python-scipy
@@ -29,7 +33,7 @@ install:
 before_script:
     - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
     - "export DISPLAY=:99.0"
-    - oqe27/bin/oq restore oqdata.zip ~/oqdata
+    - oqe27/bin/oq restore oqdata-${BRANCH}.zip ~/oqdata
     - oqe27/bin/oq webui start --skip-browser &> webui.log &
     - . ./scripts/run-env-linux.sh /usr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
         BRANCH='master';
       fi;
     - curl -sO http://artifacts.openquake.org/travis/oqdata-${BRANCH}.zip || ( echo "Dump for ${BRANCH} unavailable"; exit 1 )
-    - git clone -b ${BRANCH} --depth=1 https://github.com/gem/oq-engine.git && echo "Running against oq-engine/${BRANCH}"
+    - git clone -q -b ${BRANCH} --depth=1 https://github.com/gem/oq-engine.git && echo "Running against oq-engine/${BRANCH}"
     - echo "deb http://qgis.org/$QGIS_VERSION trusty main" | sudo tee -a /etc/apt/sources.list
     - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key 073D307A618E5811
     - sudo apt-get update -q


### PR DESCRIPTION
It first checks that the required branch exists; if not it falls back to `master`.

Than checks that the `oqdata` dump is available on the `artifacts` stow; if not, it fails without wasting time in installing packages and doing stuff until the real error is caught.

It depends on https://github.com/gem/oq-engine/pull/2922