### PR TITLE
Set MapUnit only for the size of the simple marker, avoiding markers shifting

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -527,14 +527,14 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             # it is not obvious how to choose the point size in the other
             # cases, so we conservatively keep the default sizing
             return
-        symbol.setOutputUnit(symbol.MapUnit)
-        symbol.setSize(point_size)
+        symbol.symbolLayer(0).setSizeUnit(symbol.MapUnit)
+        symbol.symbolLayer(0).setSize(point_size)
         map_unit_scale = QgsMapUnitScale()
         map_unit_scale.maxSizeMMEnabled = True
         map_unit_scale.minSizeMMEnabled = True
         map_unit_scale.minSizeMM = 0.5
         map_unit_scale.maxSizeMM = 10
-        symbol.setMapUnitScale(map_unit_scale)
+        symbol.symbolLayer(0).setSizeMapUnitScale(map_unit_scale)
 
     def style_maps(self):
         symbol = QgsSymbolV2.defaultSymbol(self.layer.geometryType())

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -31,6 +31,7 @@ changelog=
     * Layers for hazard curves are stored in a more convenient way, keeping a scalar value per cell instead of a json string
     * Integration tests check that all implemented loaders for OQ-Engine outputs are tested at least once
     * Both workflows aggregating loss points by zone are tested on Travis (1: using SAGA; 2: using the fallback algorithm)
+    * Fixed an offset issue with markers
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk, Recovery, Resilience, Risk, Hazard, Earthquake


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/296

I might cherry-pick this into the current "stable" version too.