### PR TITLE
Update link following the release of new website

### DIFF
--- a/svir/help/source/11_upload_project_to_platform.rst
+++ b/svir/help/source/11_upload_project_to_platform.rst
@@ -26,7 +26,7 @@ the web is accomplished using the OQ-Platform (:numref:`fig-after-uploading`)
 and the Social Vulnerability and Integrated Risk Viewer (see
 the `web application <https://platform.openquake.org/irv_viewer/>`_
 and the corresponding `documentation
-<http://www.globalquakemodel.org/openquake/support/documentation/platform/irv/>`_).
+<http://storage.globalquakemodel.org/openquake/support/documentation/platform/irv/>`_).
 
 .. _fig-after-uploading:
 


### PR DESCRIPTION
Plugin side I found only this reference to be fixed, plus a couple of references to the main page of the website www.globalquakemodel.org that will remain as they were.