### PR TITLE
Fix a bug occurring while redrawing curves in a corner case

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -623,10 +623,14 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         if (self.iface.activeLayer() is not None
                 and self.iface.activeLayer().type() == QgsMapLayer.VectorLayer
                 and self.iface.activeLayer().geometryType() == QGis.Point):
-            self.iface.activeLayer().selectionChanged.connect(self.redraw)
+            self.iface.activeLayer().selectionChanged.connect(
+                self.set_selection)
 
             if self.output_type in ['hcurves', 'uhs']:
                 for rlz_or_stat in self.stats_multiselect.get_selected_items():
+                    self.current_selection[rlz_or_stat] = {}
+                for rlz_or_stat \
+                        in self.stats_multiselect.get_unselected_items():
                     self.current_selection[rlz_or_stat] = {}
                 self.stats_multiselect.set_selected_items([])
                 self.stats_multiselect.set_unselected_items([])
@@ -654,12 +658,15 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
             elif self.output_type == 'recovery_curves':
                 fill_fields_multiselect(
                     self.fields_multiselect, self.iface.activeLayer())
+            else:  # no plots for this layer
+                self.current_selection = {}
             if self.iface.activeLayer().selectedFeatureCount() > 0:
                 self.set_selection()
 
     def remove_connects(self):
         try:
-            self.iface.activeLayer().selectionChanged.disconnect(self.redraw)
+            self.iface.activeLayer().selectionChanged.disconnect(
+                self.set_selection)
         except (TypeError, AttributeError):
             pass
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -668,6 +668,11 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
             self.iface.activeLayer().selectionChanged.disconnect(
                 self.set_selection)
         except (TypeError, AttributeError):
+            # AttributeError may occur if the signal selectionChanged has
+            # already been destroyed. In that case, we don't need to disconnect
+            # it. TypeError may occur when attempting to disconnect something
+            # that was not connected. Also in this case, we don't need to
+            # disconnect anything
             pass
 
     def set_selection(self):

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -40,6 +40,8 @@ changelog=
     * The widget driving the OQ-Engine handles also the LocationParseError exception
     * One single widget loads losses_by_asset or dmg_by_asset and aggregates points by polygons taken from a zonal layer
     * When the active layer has an assigned output type, other output types can not be selected in the Data Viewer
+    * Fixed an error occurring while switching between a layer that does not use the Data Viewer and one that uses it,
+      that was caused by a missing re-initialization in a corner case
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk, Recovery, Resilience, Risk, Hazard, Earthquake


### PR DESCRIPTION
The error occurred when performing this sequence of actions:
1) draw curves from a layer that uses the Data Viewer
2) select a layer that does not use the Data Viewer
3) draw curves from another layer (not the same used at number 1) that uses the Data Viewer.
I was caused by the fact that the object keeping track of the current selection was not reinitialized when switching the active layer to one that does not use the Data Viewer.

In addition to the fix, I've also made some minor changes that make the logic slightly more readable.