### PR TITLE
Hide output type from the output list (show only the display name)

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -596,7 +596,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             self.download_datastore_btn.setEnabled(False)
             self.download_datastore_btn.setText('Download HDF5 datastore')
             return
-        exclude = ['url', 'outtypes']
+        exclude = ['url', 'outtypes', 'type']
         selected_keys = [key for key in sorted(output_list[0].keys())
                          if key not in exclude]
         max_actions = 0


### PR DESCRIPTION
The output type should remain an internal code used by the plugin but not shown to the user, whereas the output display name should be the one that the user visualizes. At the moment, they are the same, but we will have more readable display names soon (see https://github.com/gem/oq-engine/issues/3032).

The effect of this change can be seen in the following screenshots:
BEFORE
![screenshot from 2017-09-20 11-17-24](https://user-images.githubusercontent.com/350930/30636297-55fca59a-9df5-11e7-9ed2-55717d3defc5.png)
AFTER
![screenshot from 2017-09-20 11-16-35](https://user-images.githubusercontent.com/350930/30636300-57c8257a-9df5-11e7-8120-d4217e045e1a.png)
