### PR TITLE
Strip /engine from hostname in user settings

### DIFF
--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -159,7 +159,8 @@ class SettingsDialog(QDialog, FORM_CLASS):
         # if the (stripped) hostname ends with '/', remove it
         platform_hostname = \
             self.platformHostnameEdit.text().strip().rstrip('/')
-        engine_hostname = self.engineHostnameEdit.text().strip().rstrip('/')
+        engine_hostname = self.engineHostnameEdit.text(
+            ).strip().rstrip('/').rstrip('/engine')
         mySettings.setValue('irmt/developer_mode',
                             self.developermodeCheck.isChecked())
         mySettings.setValue('irmt/platform_hostname', platform_hostname)


### PR DESCRIPTION
If the the user copies/pastes the url from the webui into the plugin settings, the final `/engine` has to be removed from the url. I am stripping it before saving the user settings.