### PR TITLE
Visualize agg_curves-rlzs and agg_curves-stats oq-engine outputs

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -681,10 +681,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             dest_folder = tempfile.gettempdir()
             if output_type == 'agg_curves-rlzs':
                 self.viewer_dock.load_agg_curves_rlzs(
-                    self.current_output_calc_id)
+                    self.current_output_calc_id, self.session, self.hostname)
             elif output_type == 'agg_curves-stats':
                 self.viewer_dock.load_agg_curves_stats(
-                    self.current_output_calc_id)
+                    self.current_output_calc_id, self.session, self.hostname)
             elif outtype == 'rst':
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -682,6 +682,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             if output_type == 'agg_curves-rlzs':
                 self.viewer_dock.load_agg_curves_rlzs(
                     self.current_output_calc_id)
+            elif output_type == 'agg_curves-stats':
+                self.viewer_dock.load_agg_curves_stats(
+                    self.current_output_calc_id)
             elif outtype == 'rst':
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -133,9 +133,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         #       the timer whenever the button to open the dialog is pressed
         self.finished.connect(self.stop_polling)
 
+        print("Adding messagebar")
         self.message_bar = QgsMessageBar(self)
         self.layout().insertWidget(0, self.message_bar)
 
+        print("Attempt login")
         self.attempt_login()
 
     def attempt_login(self):

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -56,7 +56,7 @@ from svir.third_party.requests.exceptions import (ConnectionError,
 from svir.third_party.requests.packages.urllib3.exceptions import (
     LocationParseError)
 from svir.utilities.settings import get_engine_credentials
-from svir.utilities.shared import OQ_ALL_LOADABLE_TYPES
+from svir.utilities.shared import OQ_ALL_LOADABLE_TYPES, OQ_RST_TYPES
 from svir.utilities.utils import (WaitCursorManager,
                                   engine_login,
                                   log_msg,
@@ -602,8 +602,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         max_actions = 0
         for row in output_list:
             num_actions = len(row['outtypes'])
-            if (row['type'] in OQ_ALL_LOADABLE_TYPES
-                    or row['type'] == 'fullreport'):
+            if row['type'] in OQ_ALL_LOADABLE_TYPES | OQ_RST_TYPES:
                 # TODO: remove check when gmf_data will be loadable also for
                 #       event_based
                 if not (row['type'] == 'gmf_data'
@@ -627,8 +626,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.connect_button_to_action(button, action, output, outtype)
                 self.output_list_tbl.setCellWidget(row, col, button)
                 self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
-            if (output['type'] in OQ_ALL_LOADABLE_TYPES
-                    or output['type'] == 'fullreport'):
+            if output['type'] in OQ_ALL_LOADABLE_TYPES | OQ_RST_TYPES:
                 if output['type'] == 'fullreport':
                     action = 'Show'
                 else:

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -680,9 +680,17 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         if action == 'Show':
             dest_folder = tempfile.gettempdir()
             if output_type in OQ_NO_MAP_TYPES:
-                self.viewer_dock.load_agg_curves(
-                    self.current_output_calc_id, self.session, self.hostname,
-                    output_type)
+                try:
+                    self.viewer_dock.load_agg_curves(
+                        self.current_output_calc_id, self.session,
+                        self.hostname, output_type)
+                except ValueError as exc:
+                    msg = ("Unable to load the output: [%s]. Please check if"
+                           " the OpenQuake Engine Server is running on Python"
+                           " 3. In that case, since this plugin runs on"
+                           " Python 2, it would be impossible to unpickle the"
+                           " output." % exc.message)
+                    log_msg(msg, level="C", message_bar=self.message_bar)
             elif outtype == 'rst':
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -58,7 +58,7 @@ from svir.third_party.requests.packages.urllib3.exceptions import (
 from svir.utilities.settings import get_engine_credentials
 from svir.utilities.shared import (OQ_ALL_LOADABLE_TYPES,
                                    OQ_RST_TYPES,
-                                   OQ_QUERYABLE_TYPES,
+                                   OQ_NO_MAP_TYPES,
                                    )
 from svir.utilities.utils import (WaitCursorManager,
                                   engine_login,
@@ -607,7 +607,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             num_actions = len(row['outtypes'])
             if row['type'] in (OQ_ALL_LOADABLE_TYPES |
                                OQ_RST_TYPES |
-                               OQ_QUERYABLE_TYPES):
+                               OQ_NO_MAP_TYPES):
                 # TODO: remove check when gmf_data will be loadable also for
                 #       event_based
                 if not (row['type'] == 'gmf_data'
@@ -633,8 +633,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
             if output['type'] in (OQ_ALL_LOADABLE_TYPES |
                                   OQ_RST_TYPES |
-                                  OQ_QUERYABLE_TYPES):
-                if output['type'] in OQ_RST_TYPES | OQ_QUERYABLE_TYPES:
+                                  OQ_NO_MAP_TYPES):
+                if output['type'] in OQ_RST_TYPES | OQ_NO_MAP_TYPES:
                     action = 'Show'
                 else:
                     action = 'Load as layer'
@@ -679,12 +679,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         output_type = output['type']
         if action == 'Show':
             dest_folder = tempfile.gettempdir()
-            if output_type == 'agg_curves-rlzs':
-                self.viewer_dock.load_agg_curves_rlzs(
-                    self.current_output_calc_id, self.session, self.hostname)
-            elif output_type == 'agg_curves-stats':
-                self.viewer_dock.load_agg_curves_stats(
-                    self.current_output_calc_id, self.session, self.hostname)
+            if output_type in OQ_NO_MAP_TYPES:
+                self.viewer_dock.load_agg_curves(
+                    self.current_output_calc_id, self.session, self.hostname,
+                    output_type)
             elif outtype == 'rst':
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -133,11 +133,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         #       the timer whenever the button to open the dialog is pressed
         self.finished.connect(self.stop_polling)
 
-        print("Adding messagebar")
         self.message_bar = QgsMessageBar(self)
         self.layout().insertWidget(0, self.message_bar)
 
-        print("Attempt login")
         self.attempt_login()
 
     def attempt_login(self):

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -56,7 +56,10 @@ from svir.third_party.requests.exceptions import (ConnectionError,
 from svir.third_party.requests.packages.urllib3.exceptions import (
     LocationParseError)
 from svir.utilities.settings import get_engine_credentials
-from svir.utilities.shared import OQ_ALL_LOADABLE_TYPES, OQ_RST_TYPES
+from svir.utilities.shared import (OQ_ALL_LOADABLE_TYPES,
+                                   OQ_RST_TYPES,
+                                   OQ_QUERYABLE_TYPES,
+                                   )
 from svir.utilities.utils import (WaitCursorManager,
                                   engine_login,
                                   log_msg,
@@ -602,7 +605,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         max_actions = 0
         for row in output_list:
             num_actions = len(row['outtypes'])
-            if row['type'] in OQ_ALL_LOADABLE_TYPES | OQ_RST_TYPES:
+            if row['type'] in (OQ_ALL_LOADABLE_TYPES |
+                               OQ_RST_TYPES |
+                               OQ_QUERYABLE_TYPES):
                 # TODO: remove check when gmf_data will be loadable also for
                 #       event_based
                 if not (row['type'] == 'gmf_data'
@@ -626,8 +631,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.connect_button_to_action(button, action, output, outtype)
                 self.output_list_tbl.setCellWidget(row, col, button)
                 self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
-            if output['type'] in OQ_ALL_LOADABLE_TYPES | OQ_RST_TYPES:
-                if output['type'] == 'fullreport':
+            if output['type'] in (OQ_ALL_LOADABLE_TYPES |
+                                  OQ_RST_TYPES |
+                                  OQ_QUERYABLE_TYPES):
+                if output['type'] in OQ_RST_TYPES | OQ_QUERYABLE_TYPES:
                     action = 'Show'
                 else:
                     action = 'Load as layer'
@@ -672,7 +679,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         output_type = output['type']
         if action == 'Show':
             dest_folder = tempfile.gettempdir()
-            if outtype == 'rst':
+            if output_type == 'agg_curves-rlzs':
+                self.viewer_dock.load_agg_curves_rlzs(
+                    self.current_output_calc_id)
+            elif outtype == 'rst':
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)
                 if not filepath:

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -295,7 +295,16 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
     def load_agg_curves(self, calc_id, session, hostname, output_type):
         self.change_output_type(output_type)
         url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
-        self.agg_curves = pickle.loads(session.get(url).content)
+        response = session.get(url).content
+        try:
+            self.agg_curves = pickle.loads(response)
+        except ValueError as exc:
+            msg = ("Unable to load the output: [%s]. Please check if the"
+                   " OpenQuake Engine Server is running on Python 3. In that"
+                   " case, since this plugin runs on Python 2, it would be"
+                   " impossible to unpickle the output." % exc.message)
+            log_msg(msg, level="C", message_bar=self.iface.messageBar())
+            return
         loss_types = self.agg_curves.dtype.names
         self.loss_type_cbx.clear()
         self.loss_type_cbx.addItems(loss_types)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -296,15 +296,7 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         self.change_output_type(output_type)
         url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
         response = session.get(url).content
-        try:
-            self.agg_curves = pickle.loads(response)
-        except ValueError as exc:
-            msg = ("Unable to load the output: [%s]. Please check if the"
-                   " OpenQuake Engine Server is running on Python 3. In that"
-                   " case, since this plugin runs on Python 2, it would be"
-                   " impossible to unpickle the output." % exc.message)
-            log_msg(msg, level="C", message_bar=self.iface.messageBar())
-            return
+        self.agg_curves = pickle.loads(response)
         loss_types = self.agg_curves.dtype.names
         self.loss_type_cbx.clear()
         self.loss_type_cbx.addItems(loss_types)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -295,13 +295,9 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
     def load_agg_curves(self, calc_id, session, hostname, output_type):
         self.change_output_type(output_type)
         url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
-        print("Calling url: %s" % url)
         response = session.get(url).content
-        print("Response: %s" % response)
         self.agg_curves = pickle.loads(response)
-        print(self.agg_curves.array)
         loss_types = self.agg_curves.dtype.names
-        print("Loss types: %s" % loss_types)
         self.loss_type_cbx.blockSignals(True)
         self.loss_type_cbx.clear()
         self.loss_type_cbx.blockSignals(False)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -298,7 +298,9 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         response = session.get(url).content
         self.agg_curves = pickle.loads(response)
         loss_types = self.agg_curves.dtype.names
+        self.loss_type_cbx.blockSignals(True)
         self.loss_type_cbx.clear()
+        self.loss_type_cbx.blockSignals(False)
         self.loss_type_cbx.addItems(loss_types)
 
     def draw_agg_curves(self, output_type):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -48,11 +48,9 @@ from PyQt4.QtGui import (QColor,
 from qgis.gui import QgsVertexMarker
 from qgis.core import QGis, QgsMapLayer, QgsFeatureRequest
 
-from svir.third_party import requests
 from svir.utilities.shared import (TEXTUAL_FIELD_TYPES,
                                    OQ_ALL_LOADABLE_TYPES,
                                    OQ_QUERYABLE_TYPES,
-                                   DEFAULT_SETTINGS,
                                    )
 from svir.utilities.utils import (get_ui_class,
                                   reload_attrib_cbx,
@@ -294,24 +292,18 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
         # else.
         self.output_type = new_output_type
 
-    def load_agg_curves_rlzs(self, calc_id):
+    def load_agg_curves_rlzs(self, calc_id, session, hostname):
         self.change_output_type('agg_curves-rlzs')
-        # TODO: handle case of engine server requiring login
-        hostname = QSettings().value(
-            'irmt/engine_hostname', DEFAULT_SETTINGS['engine_hostname'])
         url = '%s/v1/calc/%s/extract/agg_curves-rlzs' % (hostname, calc_id)
-        self.agg_curves_rlzs = pickle.loads(requests.get(url).content)
+        self.agg_curves_rlzs = pickle.loads(session.get(url).content)
         loss_types = self.agg_curves_rlzs.dtype.names
         self.loss_type_cbx.clear()
         self.loss_type_cbx.addItems(loss_types)
 
-    def load_agg_curves_stats(self, calc_id):
+    def load_agg_curves_stats(self, calc_id, session, hostname):
         self.change_output_type('agg_curves-stats')
-        # TODO: handle case of engine server requiring login
-        hostname = QSettings().value(
-            'irmt/engine_hostname', DEFAULT_SETTINGS['engine_hostname'])
         url = '%s/v1/calc/%s/extract/agg_curves-stats' % (hostname, calc_id)
-        self.agg_curves_stats = pickle.loads(requests.get(url).content)
+        self.agg_curves_stats = pickle.loads(session.get(url).content)
         loss_types = self.agg_curves_stats.dtype.names
         self.loss_type_cbx.clear()
         self.loss_type_cbx.addItems(loss_types)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -295,9 +295,13 @@ class ViewerDock(QtGui.QDockWidget, FORM_CLASS):
     def load_agg_curves(self, calc_id, session, hostname, output_type):
         self.change_output_type(output_type)
         url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
+        print("Calling url: %s" % url)
         response = session.get(url).content
+        print("Response: %s" % response)
         self.agg_curves = pickle.loads(response)
+        print(self.agg_curves.array)
         loss_types = self.agg_curves.dtype.names
+        print("Loss types: %s" % loss_types)
         self.loss_type_cbx.blockSignals(True)
         self.loss_type_cbx.clear()
         self.loss_type_cbx.blockSignals(False)

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -431,6 +431,7 @@ class Irmt:
     def reset_engine_login(self):
         if self.drive_oq_engine_server_dlg is not None:
             self.drive_oq_engine_server_dlg.is_logged_in = False
+            self.drive_oq_engine_server_dlg.clear_output_list()
 
     def show_manual(self):
         base_url = os.path.abspath(os.path.join(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -158,6 +158,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             else:
                 raise RuntimeError('The ok button is disabled')
         elif output_type == 'agg_curves-rlzs':
+            print('\tLoading output type %s...' % output_type)
             drive_engine_dlg = DriveOqEngineServerDialog(
                 IFACE, self.viewer_dock)
             self.viewer_dock.load_agg_curves_rlzs(
@@ -168,6 +169,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             print('\t\tok')
             return
         elif output_type == 'agg_curves-stats':
+            print('\tLoading output type %s...' % output_type)
             drive_engine_dlg = DriveOqEngineServerDialog(
                 IFACE, self.viewer_dock)
             self.viewer_dock.load_agg_curves_stats(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -163,6 +163,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             os.close(tmpfile_handler)
             print('\t\tok')
             return
+        elif output_type == 'agg_curves-stats':
+            self.viewer_dock.load_agg_curves_stats(calc_id)
+            tmpfile_handler, tmpfile_name = tempfile.mkstemp()
+            self.viewer_dock.write_export_file(tmpfile_name)
+            os.close(tmpfile_handler)
+            print('\t\tok')
+            return
         else:
             self.not_implemented_loaders.add(output_type)
             print('\tLoader for output type %s is not implemented'

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -160,15 +160,15 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 raise RuntimeError('The ok button is disabled')
         elif output_type in OQ_NO_MAP_TYPES:
             print('\tLoading output type %s...' % output_type)
-            drive_engine_dlg = DriveOqEngineServerDialog(
-                IFACE, self.viewer_dock)
-            self.viewer_dock.load_agg_curves(
-                calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
-                output_type)
+            # drive_engine_dlg = DriveOqEngineServerDialog(
+            #     IFACE, self.viewer_dock)
+            # self.viewer_dock.load_agg_curves(
+            #     calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
+            #     output_type)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
-            self.viewer_dock.write_export_file(tmpfile_name)
+            # self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)
-            print('\t\tok')
+            print('\t\tFIXME')
             return
         else:
             self.not_implemented_loaders.add(output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -41,8 +41,7 @@ from svir.utilities.shared import (OQ_ALL_LOADABLE_TYPES,
                                    OQ_NO_MAP_TYPES,
                                    )
 from svir.test.utilities import get_qgis_app
-from svir.dialogs.drive_oq_engine_server_dialog import (
-    OUTPUT_TYPE_LOADERS, DriveOqEngineServerDialog)
+from svir.dialogs.drive_oq_engine_server_dialog import OUTPUT_TYPE_LOADERS
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 from svir.dialogs.viewer_dock import ViewerDock
 
@@ -160,15 +159,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 raise RuntimeError('The ok button is disabled')
         elif output_type in OQ_NO_MAP_TYPES:
             print('\tLoading output type %s...' % output_type)
-            drive_engine_dlg = DriveOqEngineServerDialog(
-                IFACE, self.viewer_dock)
-            # self.viewer_dock.load_agg_curves(
-            #     calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
-            #     output_type)
+            self.viewer_dock.load_agg_curves(
+                calc_id, self.session, self.hostname, output_type)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
-            # self.viewer_dock.write_export_file(tmpfile_name)
+            self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)
-            print('\t\tFIXME')
+            print('\t\tok')
             return
         else:
             self.not_implemented_loaders.add(output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -40,7 +40,8 @@ from svir.utilities.shared import (OQ_ALL_LOADABLE_TYPES,
                                    OQ_RST_TYPES,
                                    )
 from svir.test.utilities import get_qgis_app
-from svir.dialogs.drive_oq_engine_server_dialog import OUTPUT_TYPE_LOADERS
+from svir.dialogs.drive_oq_engine_server_dialog import (
+    OUTPUT_TYPE_LOADERS, DriveOqEngineServerDialog)
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 from svir.dialogs.viewer_dock import ViewerDock
 
@@ -157,14 +158,20 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             else:
                 raise RuntimeError('The ok button is disabled')
         elif output_type == 'agg_curves-rlzs':
-            self.viewer_dock.load_agg_curves_rlzs(calc_id)
+            drive_engine_dlg = DriveOqEngineServerDialog(
+                IFACE, self.viewer_dock)
+            self.viewer_dock.load_agg_curves_rlzs(
+                calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)
             print('\t\tok')
             return
         elif output_type == 'agg_curves-stats':
-            self.viewer_dock.load_agg_curves_stats(calc_id)
+            drive_engine_dlg = DriveOqEngineServerDialog(
+                IFACE, self.viewer_dock)
+            self.viewer_dock.load_agg_curves_stats(
+                calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -160,8 +160,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 raise RuntimeError('The ok button is disabled')
         elif output_type in OQ_NO_MAP_TYPES:
             print('\tLoading output type %s...' % output_type)
-            # drive_engine_dlg = DriveOqEngineServerDialog(
-            #     IFACE, self.viewer_dock)
+            drive_engine_dlg = DriveOqEngineServerDialog(
+                IFACE, self.viewer_dock)
             # self.viewer_dock.load_agg_curves(
             #     calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
             #     output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -165,6 +165,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self.viewer_dock.load_agg_curves(
                 calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
                 output_type)
+            print(self.viewer_dock.agg_curves.array)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -165,7 +165,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self.viewer_dock.load_agg_curves(
                 calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
                 output_type)
-            print(self.viewer_dock.agg_curves.array)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -36,6 +36,7 @@ from svir.third_party.requests import Session
 from svir.utilities.shared import (OQ_ALL_LOADABLE_TYPES,
                                    OQ_CSV_LOADABLE_TYPES,
                                    OQ_NPZ_LOADABLE_TYPES,
+                                   OQ_RST_TYPES,
                                    )
 from svir.test.utilities import get_qgis_app
 from svir.dialogs.drive_oq_engine_server_dialog import OUTPUT_TYPE_LOADERS
@@ -105,16 +106,15 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
     def load_output(self, calc, output):
         calc_id = calc['id']
         output_type = output['type']
-        if (output_type in OQ_ALL_LOADABLE_TYPES
-                or output_type == 'fullreport'):
+        if output_type in OQ_ALL_LOADABLE_TYPES | OQ_RST_TYPES:
             if output_type in OQ_CSV_LOADABLE_TYPES:
                 print('\tLoading output type %s...' % output_type)
                 filepath = self.download_output(output['id'], 'csv')
             elif output_type in OQ_NPZ_LOADABLE_TYPES:
                 print('\tLoading output type %s...' % output_type)
                 filepath = self.download_output(output['id'], 'npz')
-            elif output_type == 'fullreport':
-                print('\tLoading fullreport...')
+            elif output_type in OQ_RST_TYPES:
+                print('\tLoading output type %s...' % output_type)
                 # TODO: do not skip this when encoding issue is solved
                 #       engine-side
                 if calc['description'] == u'Classical PSHA — Area Source':
@@ -176,8 +176,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             calc_list = [calc for calc in calc_list
                          if calc['id'] == selected_calc_id]
         self.selected_otype = os.environ.get('SELECTED_OTYPE')
-        if (self.selected_otype not in OQ_ALL_LOADABLE_TYPES
-                and self.selected_otype != 'fullreport'):
+        if (self.selected_otype not in OQ_ALL_LOADABLE_TYPES | OQ_RST_TYPES):
             print('\n\tSELECTED_OTYPE was not set or is not valid.'
                   ' Running tests for all the available output types.')
             self.selected_otype = None

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -38,6 +38,7 @@ from svir.utilities.shared import (OQ_ALL_LOADABLE_TYPES,
                                    OQ_CSV_LOADABLE_TYPES,
                                    OQ_NPZ_LOADABLE_TYPES,
                                    OQ_RST_TYPES,
+                                   OQ_NO_MAP_TYPES,
                                    )
 from svir.test.utilities import get_qgis_app
 from svir.dialogs.drive_oq_engine_server_dialog import (
@@ -157,23 +158,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 return
             else:
                 raise RuntimeError('The ok button is disabled')
-        elif output_type == 'agg_curves-rlzs':
+        elif output_type in OQ_NO_MAP_TYPES:
             print('\tLoading output type %s...' % output_type)
             drive_engine_dlg = DriveOqEngineServerDialog(
                 IFACE, self.viewer_dock)
-            self.viewer_dock.load_agg_curves_rlzs(
-                calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname)
-            tmpfile_handler, tmpfile_name = tempfile.mkstemp()
-            self.viewer_dock.write_export_file(tmpfile_name)
-            os.close(tmpfile_handler)
-            print('\t\tok')
-            return
-        elif output_type == 'agg_curves-stats':
-            print('\tLoading output type %s...' % output_type)
-            drive_engine_dlg = DriveOqEngineServerDialog(
-                IFACE, self.viewer_dock)
-            self.viewer_dock.load_agg_curves_stats(
-                calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname)
+            self.viewer_dock.load_agg_curves(
+                calc_id, drive_engine_dlg.session, drive_engine_dlg.hostname,
+                output_type)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -220,7 +220,7 @@ OQ_NPZ_LOADABLE_TYPES = set([
     'hmaps', 'hcurves', 'uhs', 'gmf_data', 'dmg_by_asset', 'losses_by_asset'])
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
 OQ_RST_TYPES = set(['fullreport'])
-OQ_QUERYABLE_TYPES = set(['agg_curves-rlzs', 'agg_curves-stats'])
+OQ_NO_MAP_TYPES = set(['agg_curves-rlzs', 'agg_curves-stats'])
 
 
 DEFAULT_SETTINGS = dict(

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -220,6 +220,7 @@ OQ_NPZ_LOADABLE_TYPES = set([
     'hmaps', 'hcurves', 'uhs', 'gmf_data', 'dmg_by_asset', 'losses_by_asset'])
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
 OQ_RST_TYPES = set(['fullreport'])
+OQ_QUERYABLE_TYPES = set(['agg_curves-rlzs'])
 
 
 DEFAULT_SETTINGS = dict(

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -220,7 +220,7 @@ OQ_NPZ_LOADABLE_TYPES = set([
     'hmaps', 'hcurves', 'uhs', 'gmf_data', 'dmg_by_asset', 'losses_by_asset'])
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
 OQ_RST_TYPES = set(['fullreport'])
-OQ_QUERYABLE_TYPES = set(['agg_curves-rlzs'])
+OQ_QUERYABLE_TYPES = set(['agg_curves-rlzs', 'agg_curves-stats'])
 
 
 DEFAULT_SETTINGS = dict(

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -219,6 +219,7 @@ OQ_CSV_LOADABLE_TYPES = set(['ruptures'])
 OQ_NPZ_LOADABLE_TYPES = set([
     'hmaps', 'hcurves', 'uhs', 'gmf_data', 'dmg_by_asset', 'losses_by_asset'])
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
+OQ_RST_TYPES = set(['fullreport'])
 
 
 DEFAULT_SETTINGS = dict(


### PR DESCRIPTION
For these outputs, I am leveraging the api introduced in https://github.com/gem/oq-engine/pull/2929

TODO:
- [x] add a clear error message in case the engine server runs on Python3 (pickled objects are incompatible)
- [ ] tests run locally on my machine, but for some reason they don't on Travis