### PR TITLE
Visualize scenario damage by tag

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -66,6 +66,7 @@ from svir.utilities.utils import (get_ui_class,
 from svir.recovery_modeling.recovery_modeling import (
     RecoveryModeling, fill_fields_multiselect)
 from svir.ui.list_multiselect_widget import ListMultiSelectWidget
+from svir.ui.list_multiselect_mono_widget import ListMultiSelectMonoWidget
 
 from svir import IS_SCIPY_INSTALLED
 
@@ -281,6 +282,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             QAbstractItemView.SingleSelection)
         self.tag_names_multiselect.unselected_widget.setSelectionMode(
             QAbstractItemView.SingleSelection)
+        self.tag_names_multiselect.select_all_btn.hide()
+        self.tag_names_multiselect.deselect_all_btn.hide()
         self.typeDepVLayout.addWidget(self.tag_names_multiselect)
         self.tag_names_multiselect.unselected_widget.itemClicked.connect(
             self.populate_tag_values_multiselect)
@@ -291,9 +294,12 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def create_tag_values_multiselect(self):
         title = 'Select tag values'
-        self.tag_values_multiselect = ListMultiSelectWidget(title=title)
+        self.tag_values_multiselect = ListMultiSelectMonoWidget(
+            message_bar=self.iface.messageBar(), title=title)
         self.tag_values_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.tag_values_multiselect.select_all_btn.hide()
+        self.tag_values_multiselect.deselect_all_btn.hide()
         self.typeDepVLayout.addWidget(self.tag_values_multiselect)
         self.tag_values_multiselect.selection_changed.connect(
             self.update_selected_tag_values)
@@ -552,6 +558,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         # means = self.dmg_total['array'][rlz][loss_type]['mean']
         # stddevs = self.dmg_total['array'][rlz][loss_type]['stddev']
         means = self.dmg_total['array'][rlz]
+        if any(means < 0):
+            msg = ('The results displayed include negative damage estimates'
+                   ' for one or more damage states. Please check the fragility'
+                   ' model for crossing curves.')
+            log_msg(msg, level='W', message_bar=self.iface.messageBar())
         dmg_states = self.dmg_states
         if self.exclude_no_dmg_ckb.isChecked():
             # exclude the first element, that is 'no damage'

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1099,19 +1099,20 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 os.path.expanduser(
                     '~/loss_curves_%s.csv' % self.current_loss_type),
                 '*.csv')
-        elif self.output_type in OQ_NO_MAP_TYPES:
-            if self.output_type == 'dmg_total':
-                # TODO: we might get the original csv from the engine
-                log_msg('This functionality is not implemented. You might'
-                        ' consider downloading the csv directly from the'
-                        ' OQ-Engine.', message_bar=self.iface.messageBar())
-                return
+        elif self.output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             filename = QFileDialog.getSaveFileName(
                 self,
                 self.tr('Export data'),
                 os.path.expanduser(
                     '~/%s_%s.csv' % (self.output_type,
                                      self.current_loss_type)),
+                '*.csv')
+        elif self.output_type == 'dmg_total':
+            filename = QFileDialog.getSaveFileName(
+                self,
+                self.tr('Export data'),
+                os.path.expanduser(
+                    '~/%s_%s.csv' % (self.output_type, self.calc_id)),
                 '*.csv')
         elif self.output_type == 'recovery_curves':
             filename = QFileDialog.getSaveFileName(
@@ -1198,11 +1199,16 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     row.extend([value for value in values[i]])
                     writer.writerow(row)
             elif self.output_type == 'dmg_total':
-                # TODO: we might get the original csv from the engine
-                log_msg('This functionality is not implemented. You might'
-                        ' consider downloading the csv directly from the'
-                        ' OQ-Engine.', message_bar=self.iface.messageBar())
-                return
+                csv_file.write(
+                    "# Realization: %s\n" % self.rlz_cbx.currentText())
+                csv_file.write(
+                    "# Loss type: %s\n" % self.loss_type_cbx.currentText())
+                csv_file.write(
+                    "# %s\n" % self.list_selected_edt.toPlainText())
+                headers = self.dmg_states
+                writer.writerow(headers)
+                values = self.dmg_total['array'][self.rlz_cbx.currentIndex()]
+                writer.writerow(values)
             else:
                 raise NotImplementedError(self.output_type)
         msg = 'Data exported to %s' % filename

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -48,6 +48,7 @@ from qgis.PyQt.QtGui import (QColor,
                              QCheckBox,
                              QDockWidget,
                              QFileDialog,
+                             QAbstractItemView,
                              )
 from qgis.gui import QgsVertexMarker
 from qgis.core import QGis, QgsMapLayer, QgsFeatureRequest
@@ -276,6 +277,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_names_multiselect = ListMultiSelectWidget(title=title)
         self.tag_names_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.tag_names_multiselect.selected_widget.setSelectionMode(
+            QAbstractItemView.SingleSelection)
+        self.tag_names_multiselect.unselected_widget.setSelectionMode(
+            QAbstractItemView.SingleSelection)
         self.typeDepVLayout.addWidget(self.tag_names_multiselect)
         self.tag_names_multiselect.unselected_widget.itemClicked.connect(
             self.populate_tag_values_multiselect)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -359,7 +359,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.list_selected_edt = QPlainTextEdit('Selected tags:')
         self.list_selected_edt.setSizePolicy(
             QSizePolicy.Minimum, QSizePolicy.Minimum)
-        self.list_selected_edt.setMaximumHeight(50)
+        self.list_selected_edt.setMaximumHeight(30)
         self.list_selected_edt.setReadOnly(True)
         self.typeDepVLayout.addWidget(self.list_selected_edt)
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -477,6 +477,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.loss_type_cbx.blockSignals(False)
 
         self.tag_names_multiselect.set_unselected_items(self.tags.keys())
+        self.tag_names_multiselect.set_selected_items([])
+        self.tag_values_multiselect.set_unselected_items([])
+        self.tag_values_multiselect.set_selected_items([])
 
         self.filter_dmg_total()
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -289,6 +289,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.populate_tag_values_multiselect)
         self.tag_names_multiselect.selected_widget.itemClicked.connect(
             self.populate_tag_values_multiselect)
+        self.tag_names_multiselect.unselected_widget.itemDoubleClicked.connect(
+            self.populate_tag_values_multiselect)
+        self.tag_names_multiselect.selected_widget.itemDoubleClicked.connect(
+            self.populate_tag_values_multiselect)
         self.tag_names_multiselect.selection_changed.connect(
             self.update_selected_tag_names)
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -552,6 +552,12 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         '''
         Plots the total damage distribution
         '''
+        if len(self.dmg_total['array']) == 0:
+            msg = 'No assets satisfy the selected criteria'
+            log_msg(msg, level='W', message_bar=self.iface.messageBar())
+            self.plot.clear()
+            self.plot_canvas.draw()
+            return
         rlz = self.rlz_cbx.currentIndex()
         # TODO: re-add error bars when stddev will become available again
         # loss_type = self.loss_type_cbx.currentText()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -424,6 +424,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         return numpy.load(io.BytesIO(resp_content))
 
     def load_no_map_output(self, calc_id, session, hostname, output_type):
+        self.calc_id = calc_id
+        self.session = session
+        self.hostname = hostname
+        self.change_output_type(output_type)
         if output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.load_agg_curves(calc_id, session, hostname, output_type)
         elif output_type == 'dmg_total':
@@ -432,10 +436,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             raise NotImplementedError(output_type)
 
     def load_dmg_total(self, calc_id, session, hostname, output_type):
-        self.calc_id = calc_id
-        self.session = session
-        self.hostname = hostname
-        self.change_output_type(output_type)
         composite_risk_model_attrs = self.extract_npz(
             session, hostname, calc_id, 'composite_risk_model.attrs')
         self.dmg_states = composite_risk_model_attrs['damage_states']
@@ -474,7 +474,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.filter_dmg_total()
 
     def load_agg_curves(self, calc_id, session, hostname, output_type):
-        self.change_output_type(output_type)
         self.agg_curves = self.extract_npz(
             session, hostname, calc_id, output_type)
         loss_types = self.agg_curves['array'].dtype.names
@@ -1104,8 +1103,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self,
                 self.tr('Export data'),
                 os.path.expanduser(
-                    '~/%s_%s.csv' % (self.output_type,
-                                     self.current_loss_type)),
+                    '~/%s_%s_%s.csv' % (self.output_type,
+                                        self.current_loss_type,
+                                        self.calc_id)),
                 '*.csv')
         elif self.output_type == 'dmg_total':
             filename = QFileDialog.getSaveFileName(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -332,6 +332,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.list_selected_edt = QPlainTextEdit('Selected tags:')
         self.list_selected_edt.setSizePolicy(
             QSizePolicy.Minimum, QSizePolicy.Minimum)
+        self.list_selected_edt.setMaximumHeight(50)
         self.list_selected_edt.setReadOnly(True)
         self.typeDepVLayout.addWidget(self.list_selected_edt)
 
@@ -341,7 +342,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             if self.tags[tag_name]['selected']:
                 for tag_value in self.tags[tag_name]['values']:
                     if self.tags[tag_name]['values'][tag_value]:
-                        selected_tags_str += '&%s=%s' % (tag_name, tag_value)
+                        selected_tags_str += '%s="%s" ' % (tag_name, tag_value)
         self.list_selected_edt.setPlainText(selected_tags_str)
 
     def refresh_feature_selection(self):
@@ -426,11 +427,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             tag_name, tag_value = tag.split('=')
             if tag_name not in self.tags:
                 self.tags[tag_name] = {
-                    'selected': True,
-                    'values': {tag_value: True}}  # True means selected
+                    'selected': False,
+                    'values': {tag_value: False}}  # False means unselected
             else:
-                # True means selected
-                self.tags[tag_name]['values'][tag_value] = True
+                # False means unselected
+                self.tags[tag_name]['values'][tag_value] = False
         self.update_list_selected_edt()
 
         num_rlzs = self.dmg_total['array'].shape[0]
@@ -446,7 +447,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.loss_type_cbx.addItems(loss_types)
         self.loss_type_cbx.blockSignals(False)
 
-        self.tag_names_multiselect.set_selected_items(self.tags.keys())
+        self.tag_names_multiselect.set_unselected_items(self.tags.keys())
 
         self.draw_dmg_total()
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1132,7 +1132,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     '~/recovery_curves_%s.csv' %
                     self.approach_cbx.currentText()),
                 '*.csv')
-        if filename is not None:
+        if filename:
             self.write_export_file(filename)
 
     def write_export_file(self, filename):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -377,10 +377,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         layer.selectByIds(selected_feats)
 
     def set_output_type_and_its_gui(self, new_output_type):
-        if (self.output_type is not None
-                and self.output_type == new_output_type):
-            return
-
         # clear type dependent widgets
         # NOTE: typeDepVLayout contains typeDepHLayout1 and typeDepHLayout2,
         #       that will be cleared recursively

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -317,6 +317,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             if not self.tags[tag_name]['values'][tag_value]]
         self.tag_values_multiselect.set_selected_items(selected_tag_values)
         self.tag_values_multiselect.set_unselected_items(unselected_tag_values)
+        self.tag_values_multiselect.setEnabled(
+            tag_name in list(self.tag_names_multiselect.get_selected_items()))
 
     def filter_dmg_total(self):
         params = {}
@@ -336,6 +338,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.tags[tag_name]['selected'] = True
         for tag_name in self.tag_names_multiselect.get_unselected_items():
             self.tags[tag_name]['selected'] = False
+        self.tag_values_multiselect.setEnabled(
+            tag_name in list(self.tag_names_multiselect.get_selected_items()))
         self.update_list_selected_edt()
         self.filter_dmg_total()
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -313,12 +313,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.current_tag_name = tag_name
         self.tag_values_multiselect.setTitle(
             'Select values for tag: %s' % tag_name)
-        selected_tag_values = [
-            tag_value for tag_value in self.tags[tag_name]['values']
-            if self.tags[tag_name]['values'][tag_value]]
-        unselected_tag_values = [
-            tag_value for tag_value in self.tags[tag_name]['values']
-            if not self.tags[tag_name]['values'][tag_value]]
+        tag_values = self.tags[tag_name]['values']
+        selected_tag_values = [tag_value for tag_value in tag_values
+                               if tag_values[tag_value]]
+        unselected_tag_values = [tag_value for tag_value in tag_values
+                                 if not tag_values[tag_value]]
         self.tag_values_multiselect.set_selected_items(selected_tag_values)
         self.tag_values_multiselect.set_unselected_items(unselected_tag_values)
         self.tag_values_multiselect.setEnabled(
@@ -330,6 +329,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             if self.tags[tag_name]['selected']:
                 for value in self.tags[tag_name]['values']:
                     if self.tags[tag_name]['values'][value]:
+                        # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'aggdamages/%s' % self.loss_type_cbx.currentText()
         self.dmg_total = self.extract_npz(
@@ -569,11 +569,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             return
         rlz = self.rlz_cbx.currentIndex()
         # TODO: re-add error bars when stddev will become available again
-        # loss_type = self.loss_type_cbx.currentText()
-        # means = self.dmg_total['array'][rlz][loss_type]['mean']
-        # stddevs = self.dmg_total['array'][rlz][loss_type]['stddev']
+        # means = self.dmg_total['array'][rlz]['mean']
+        # stddevs = self.dmg_total['array'][rlz]['stddev']
         means = self.dmg_total['array'][rlz]
-        if any(means < 0):
+        if (means < 0).any():
             msg = ('The results displayed include negative damage estimates'
                    ' for one or more damage states. Please check the fragility'
                    ' model for crossing curves.')
@@ -582,22 +581,24 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if self.exclude_no_dmg_ckb.isChecked():
             # exclude the first element, that is 'no damage'
             means = means[1:]
+            # TODO: re-add error bars when stddev will become available again
             # stddevs = stddevs[1:]
             dmg_states = dmg_states[1:]
 
         indX = numpy.arange(len(dmg_states))  # the x locations for the groups
-        error_config = {'ecolor': '0.3', 'linewidth': '2'}
+        # TODO: re-add error bars when stddev will become available again
+        # error_config = {'ecolor': '0.3', 'linewidth': '2'}
         bar_width = 0.3
         if self.bw_chk.isChecked():
             color = 'lightgray'
         else:
             color = 'IndianRed'
         self.plot.clear()
+        # TODO: re-add error bars when stddev will become available again
         # self.plot.bar(indX, height=means, width=bar_width,
         #               yerr=stddevs, error_kw=error_config, color=color,
         #               linewidth=1.5, alpha=0.6)
-        self.plot.bar(indX, height=means, width=bar_width,
-                      error_kw=error_config, color=color,
+        self.plot.bar(indX, height=means, width=bar_width, color=color,
                       linewidth=1.5, alpha=0.6)
         self.plot.set_title('Damage distribution')
         self.plot.set_xlabel('Damage state')

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -389,6 +389,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         # NOTE: typeDepVLayout contains typeDepHLayout1 and typeDepHLayout2,
         #       that will be cleared recursively
         clear_widgets_from_layout(self.typeDepVLayout)
+        if hasattr(self, 'plot'):
+            self.plot.clear()
+            self.plot_canvas.draw()
 
         if new_output_type == 'hcurves':
             self.create_imt_selector()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -40,6 +40,7 @@ from matplotlib.lines import Line2D
 from qgis.PyQt.QtCore import pyqtSlot, QSettings
 from qgis.PyQt.QtGui import (QColor,
                              QLabel,
+                             QPlainTextEdit,
                              QComboBox,
                              QSizePolicy,
                              QSpinBox,
@@ -311,6 +312,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.tags[tag_name]['selected'] = True
         for tag_name in self.tag_names_multiselect.get_unselected_items():
             self.tags[tag_name]['selected'] = False
+        self.update_list_selected_edt()
         self.draw_dmg_total()
 
     def update_selected_tag_values(self):
@@ -318,13 +320,24 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.tags[self.current_tag_name]['values'][tag_value] = True
         for tag_value in self.tag_values_multiselect.get_unselected_items():
             self.tags[self.current_tag_name]['values'][tag_value] = False
+        self.update_list_selected_edt()
         self.draw_dmg_total()
 
-    def create_list_selected_lbl(self):
-        self.list_selected_lbl = QLabel('Selected tags:')
-        self.list_selected_lbl.setSizePolicy(
+    def create_list_selected_edt(self):
+        self.list_selected_edt = QPlainTextEdit('Selected tags:')
+        self.list_selected_edt.setSizePolicy(
             QSizePolicy.Minimum, QSizePolicy.Minimum)
-        self.typeDepVLayout.addWidget(self.list_selected_lbl)
+        self.list_selected_edt.setReadOnly(True)
+        self.typeDepVLayout.addWidget(self.list_selected_edt)
+
+    def update_list_selected_edt(self):
+        selected_tags_str = ''
+        for tag_name in self.tags:
+            if self.tags[tag_name]['selected']:
+                for tag_value in self.tags[tag_name]['values']:
+                    if self.tags[tag_name]['values'][tag_value]:
+                        selected_tags_str += '&%s=%s' % (tag_name, tag_value)
+        self.list_selected_edt.setPlainText(selected_tags_str)
 
     def refresh_feature_selection(self):
         if not list(self.stats_multiselect.get_selected_items()):
@@ -360,7 +373,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.create_rlz_selector()
             self.create_tag_names_multiselect()
             self.create_tag_values_multiselect()
-            self.create_list_selected_lbl()
+            self.create_list_selected_edt()
             self.create_exclude_no_dmg_ckb()
         elif new_output_type == 'uhs':
             self.create_stats_multiselect()
@@ -413,6 +426,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             else:
                 # True means selected
                 self.tags[tag_name]['values'][tag_value] = True
+        self.update_list_selected_edt()
 
         num_rlzs = self.dmg_total['array'].shape[0]
         rlzs = ['rlz-%s' % rlz for rlz in range(num_rlzs)]

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,7 @@ email=staff.it@globalquakemodel.org
 changelog=
     2.7.0
     * Added the possibility to visualize oq-engine outputs of types agg_curves-rlzs, agg_curves-stats and dmg_total
+    * Damage can be aggregated by realization, loss type and multiple tags
     2.6.1
     * For hazard curves and uniform hazard spectra, it is possible to plot together multiple statistical outputs (e.g. mean and quantiles)
     * Fixed an offset issue with markers

--- a/svir/ui/list_multiselect_mono_widget.py
+++ b/svir/ui/list_multiselect_mono_widget.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""
+/***************************************************************************
+ Svir
+                                 A QGIS plugin
+ OpenQuake Social Vulnerability and Integrated Risk
+                              -------------------
+        begin                : 2017-10-04
+        copyright            : (C) 2017 by GEM Foundation
+        email                : devops@openquake.org
+ ***************************************************************************/
+
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from qgis.PyQt.QtGui import QAbstractItemView
+from svir.ui.list_multiselect_widget import ListMultiSelectWidget
+from svir.utilities.utils import log_msg
+
+
+class ListMultiSelectMonoWidget(ListMultiSelectWidget):
+    """
+    This is a strange multiselect widget in which you can actually select
+    only one item. A combo box might be used instead. The purpose of using
+    this is to make it simpler to migrate to an actual multiselect afterwards,
+    once multiple items can be handled server-side.
+    """
+    def __init__(self, message_bar, parent=None, title=None):
+        self.message_bar = message_bar
+        super(ListMultiSelectMonoWidget, self).__init__(parent, title)
+        self.unselected_widget.setSelectionMode(
+            QAbstractItemView.SingleSelection)
+
+    def _select(self):
+        if self.selected_widget.count():
+            msg = 'You can select only one value per tag'
+            log_msg(msg, level='W', message_bar=self.message_bar)
+            return
+        super(ListMultiSelectMonoWidget, self)._select()

--- a/svir/ui/list_multiselect_mono_widget.py
+++ b/svir/ui/list_multiselect_mono_widget.py
@@ -44,7 +44,5 @@ class ListMultiSelectMonoWidget(ListMultiSelectWidget):
 
     def _select(self):
         if self.selected_widget.count():
-            msg = 'You can select only one value per tag'
-            log_msg(msg, level='W', message_bar=self.message_bar)
-            return
+            self.unselected_widget.addItem(self.selected_widget.takeItem(0))
         super(ListMultiSelectMonoWidget, self)._select()


### PR DESCRIPTION
The user can select a realization, a loss type and many tags (only one value per tag can be selected), and a bar chart is plotted, displaying the number of assets in each damage state. Also the "Export data" functionality is implemented.

The ListMultiSelectMonoWidget is a subclass of ListMultiSelectWidget, that enables to select only one tag value at a time. If you select another value, it is swapped with the one that was previously selected. I could have used combo boxes instead, but the current solution will make it very easy, in the future, to enable the tool to select multiple values per tag (if the engine will allow to filter by multiple values per tag).

Error bars are not displayed, because the engine is currently unable to provide standard deviations for the selected data. I've added some comments, that will be useful if the engine will provide this functionality.