### PR TITLE
Use 2 buttons to load the same output type in different ways

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -614,7 +614,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 if not (row['type'] == 'gmf_data'
                         and 'event_based' in calculation_mode):
                     num_actions += 1  # needs additional column for loader btn
-            if "%s_show" % row['type'] in OQ_NO_MAP_TYPES:
+            if "%s_aggr" % row['type'] in OQ_NO_MAP_TYPES:
                 num_actions += 1
             max_actions = max(max_actions, num_actions)
 
@@ -650,12 +650,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     self.connect_button_to_action(
                         button, action, output, outtype)
                     self.output_list_tbl.setCellWidget(row, col + 1, button)
-                if "%s_show" % output['type'] in OQ_NO_MAP_TYPES:
+                if "%s_aggr" % output['type'] in OQ_NO_MAP_TYPES:
                     mod_output = copy.deepcopy(output)
-                    mod_output['type'] = "%s_show" % output['type']
+                    mod_output['type'] = "%s_aggr" % output['type']
                     button = QPushButton()
                     self.connect_button_to_action(
-                        button, 'Show', mod_output, outtype)
+                        button, 'Aggregate', mod_output, outtype)
                     self.output_list_tbl.setCellWidget(row, col + 2, button)
         col_names = [key.capitalize() for key in selected_keys]
         empty_col_names = ['' for outtype in range(max_actions)]
@@ -667,10 +667,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.output_list_tbl.resizeRowsToContents()
 
     def connect_button_to_action(self, button, action, output, outtype):
-        if action in ('Load as layer', 'Show'):
+        if action in ('Load as layer', 'Show', 'Aggregate'):
             style = 'background-color: blue; color: white;'
             if action == 'Load as layer':
                 button.setText("Load %s as layer" % outtype)
+            elif action == 'Aggregate':
+                button.setText("Aggregate")
             else:
                 button.setText("Show")
         else:
@@ -686,7 +688,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     def on_output_action_btn_clicked(self, output, action, outtype):
         output_id = output['id']
         output_type = output['type']
-        if action == 'Show':
+        if action in ['Show', 'Aggregate']:
             dest_folder = tempfile.gettempdir()
             if output_type in OQ_NO_MAP_TYPES:
                 self.viewer_dock.load_no_map_output(

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -614,7 +614,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 if not (row['type'] == 'gmf_data'
                         and 'event_based' in calculation_mode):
                     num_actions += 1  # needs additional column for loader btn
-            if "%s_%s" % (row['type'], "show") in OQ_NO_MAP_TYPES:
+            if "%s_show" % row['type'] in OQ_NO_MAP_TYPES:
                 num_actions += 1
             max_actions = max(max_actions, num_actions)
 
@@ -650,9 +650,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     self.connect_button_to_action(
                         button, action, output, outtype)
                     self.output_list_tbl.setCellWidget(row, col + 1, button)
-                if "%s_%s" % (output['type'], "show") in OQ_NO_MAP_TYPES:
+                if "%s_show" % output['type'] in OQ_NO_MAP_TYPES:
                     mod_output = copy.deepcopy(output)
-                    mod_output['type'] = "%s_%s" % (output['type'], "show")
+                    mod_output['type'] = "%s_show" % output['type']
                     button = QPushButton()
                     self.connect_button_to_action(
                         button, 'Show', mod_output, outtype)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -26,6 +26,7 @@ import os
 import json
 import tempfile
 import zipfile
+import copy
 
 from PyQt4.QtCore import (QDir,
                           Qt,
@@ -613,6 +614,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 if not (row['type'] == 'gmf_data'
                         and 'event_based' in calculation_mode):
                     num_actions += 1  # needs additional column for loader btn
+            if "%s_%s" % (row['type'], "show") in OQ_NO_MAP_TYPES:
+                num_actions += 1
             max_actions = max(max_actions, num_actions)
 
         self.output_list_tbl.setRowCount(len(output_list))
@@ -631,23 +634,29 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.connect_button_to_action(button, action, output, outtype)
                 self.output_list_tbl.setCellWidget(row, col, button)
                 self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
-            if output['type'] in (OQ_ALL_LOADABLE_TYPES |
-                                  OQ_RST_TYPES |
-                                  OQ_NO_MAP_TYPES):
-                if output['type'] in OQ_RST_TYPES | OQ_NO_MAP_TYPES:
-                    action = 'Show'
-                else:
-                    action = 'Load as layer'
-                # TODO: remove check when gmf_data will be loadable also for
-                #       event_based
-                if (output['type'] == 'gmf_data'
-                        and calculation_mode == 'event_based'):
-                    continue
-                button = QPushButton()
-                self.connect_button_to_action(
-                    button, action, output, outtype)
-                self.output_list_tbl.setCellWidget(row, col + 1, button)
-                self.calc_list_tbl.setColumnWidth(col, BUTTON_WIDTH)
+                if output['type'] in (OQ_ALL_LOADABLE_TYPES |
+                                      OQ_RST_TYPES |
+                                      OQ_NO_MAP_TYPES):
+                    if output['type'] in OQ_RST_TYPES | OQ_NO_MAP_TYPES:
+                        action = 'Show'
+                    else:
+                        action = 'Load as layer'
+                    # TODO: remove check when gmf_data will be loadable also
+                    #       for event_based
+                    if (output['type'] == 'gmf_data'
+                            and calculation_mode == 'event_based'):
+                        continue
+                    button = QPushButton()
+                    self.connect_button_to_action(
+                        button, action, output, outtype)
+                    self.output_list_tbl.setCellWidget(row, col + 1, button)
+                if "%s_%s" % (output['type'], "show") in OQ_NO_MAP_TYPES:
+                    mod_output = copy.deepcopy(output)
+                    mod_output['type'] = "%s_%s" % (output['type'], "show")
+                    button = QPushButton()
+                    self.connect_button_to_action(
+                        button, 'Show', mod_output, outtype)
+                    self.output_list_tbl.setCellWidget(row, col + 2, button)
         col_names = [key.capitalize() for key in selected_keys]
         empty_col_names = ['' for outtype in range(max_actions)]
         headers = col_names + empty_col_names

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -142,7 +142,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             ('uhs', 'Uniform Hazard Spectra'),
             ('agg_curves-rlzs', 'Aggregated loss curves (realizations)'),
             ('agg_curves-stats', 'Aggregated loss curves (statistics)'),
-            ('dmg_by_asset_show', 'Damage distribution'),
+            ('dmg_by_asset_aggr', 'Damage distribution'),
             ('recovery_curves', 'Recovery Curves')])
         self.output_type_cbx.addItems(self.output_types_names.values())
 
@@ -323,7 +323,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
 
-    def filter_dmg_by_asset_show(self):
+    def filter_dmg_by_asset_aggr(self):
         params = {}
         for tag_name in self.tags:
             if self.tags[tag_name]['selected']:
@@ -332,10 +332,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'aggdamages/%s' % self.loss_type_cbx.currentText()
-        self.dmg_by_asset_show = self.extract_npz(
+        self.dmg_by_asset_aggr = self.extract_npz(
             self.session, self.hostname, self.calc_id, output_type,
             params=params)
-        self.draw_dmg_by_asset_show()
+        self.draw_dmg_by_asset_aggr()
 
     def update_selected_tag_names(self):
         for tag_name in self.tag_names_multiselect.get_selected_items():
@@ -345,7 +345,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
         self.update_list_selected_edt()
-        self.filter_dmg_by_asset_show()
+        self.filter_dmg_by_asset_aggr()
 
     def update_selected_tag_values(self):
         for tag_value in self.tag_values_multiselect.get_selected_items():
@@ -353,7 +353,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         for tag_value in self.tag_values_multiselect.get_unselected_items():
             self.tags[self.current_tag_name]['values'][tag_value] = False
         self.update_list_selected_edt()
-        self.filter_dmg_by_asset_show()
+        self.filter_dmg_by_asset_aggr()
 
     def create_list_selected_edt(self):
         self.list_selected_edt = QPlainTextEdit('Selected tags:')
@@ -400,7 +400,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.create_loss_type_selector()
         elif new_output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.create_loss_type_selector()
-        elif new_output_type == 'dmg_by_asset_show':
+        elif new_output_type == 'dmg_by_asset_aggr':
             self.create_loss_type_selector()
             self.create_rlz_selector()
             self.create_tag_names_multiselect()
@@ -437,13 +437,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.change_output_type(output_type)
         if output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.load_agg_curves(calc_id, session, hostname, output_type)
-        elif output_type == 'dmg_by_asset_show':
-            self.load_dmg_by_asset_show(
+        elif output_type == 'dmg_by_asset_aggr':
+            self.load_dmg_by_asset_aggr(
                 calc_id, session, hostname, output_type)
         else:
             raise NotImplementedError(output_type)
 
-    def load_dmg_by_asset_show(self, calc_id, session, hostname, output_type):
+    def load_dmg_by_asset_aggr(self, calc_id, session, hostname, output_type):
         composite_risk_model_attrs = self.extract_npz(
             session, hostname, calc_id, 'composite_risk_model.attrs')
         self.dmg_states = composite_risk_model_attrs['damage_states']
@@ -482,7 +482,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect.set_unselected_items([])
         self.tag_values_multiselect.set_selected_items([])
 
-        self.filter_dmg_by_asset_show()
+        self.filter_dmg_by_asset_aggr()
 
     def load_agg_curves(self, calc_id, session, hostname, output_type):
         self.agg_curves = self.extract_npz(
@@ -558,11 +558,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 loc=location, fancybox=True, shadow=True, fontsize='small')
         self.plot_canvas.draw()
 
-    def draw_dmg_by_asset_show(self):
+    def draw_dmg_by_asset_aggr(self):
         '''
         Plots the total damage distribution
         '''
-        if len(self.dmg_by_asset_show['array']) == 0:
+        if len(self.dmg_by_asset_aggr['array']) == 0:
             msg = 'No assets satisfy the selected criteria'
             log_msg(msg, level='W', message_bar=self.iface.messageBar())
             self.plot.clear()
@@ -570,9 +570,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             return
         rlz = self.rlz_cbx.currentIndex()
         # TODO: re-add error bars when stddev will become available again
-        # means = self.dmg_by_asset_show['array'][rlz]['mean']
-        # stddevs = self.dmg_by_asset_show['array'][rlz]['stddev']
-        means = self.dmg_by_asset_show['array'][rlz]
+        # means = self.dmg_by_asset_aggr['array'][rlz]['mean']
+        # stddevs = self.dmg_by_asset_aggr['array'][rlz]['stddev']
+        means = self.dmg_by_asset_aggr['array'][rlz]
         if (means < 0).any():
             msg = ('The results displayed include negative damage estimates'
                    ' for one or more damage states. Please check the fragility'
@@ -1058,8 +1058,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.current_loss_type = self.loss_type_cbx.currentText()
         if self.output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.draw_agg_curves(self.output_type)
-        elif self.output_type == 'dmg_by_asset_show':
-            self.filter_dmg_by_asset_show()
+        elif self.output_type == 'dmg_by_asset_aggr':
+            self.filter_dmg_by_asset_aggr()
         else:
             self.was_loss_type_switched = True
             self.redraw_current_selection()
@@ -1081,11 +1081,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                              self.n_simulations_sbx.value())
 
     def on_rlz_changed(self):
-        self.filter_dmg_by_asset_show()
+        self.filter_dmg_by_asset_aggr()
 
     @pyqtSlot(int)
     def on_exclude_no_dmg_ckb_state_changed(self, state):
-        self.filter_dmg_by_asset_show()
+        self.filter_dmg_by_asset_aggr()
 
     @pyqtSlot()
     def on_export_data_button_clicked(self):
@@ -1119,7 +1119,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                                         self.current_loss_type,
                                         self.calc_id)),
                 '*.csv')
-        elif self.output_type == 'dmg_by_asset_show':
+        elif self.output_type == 'dmg_by_asset_aggr':
             filename = QFileDialog.getSaveFileName(
                 self,
                 self.tr('Export data'),
@@ -1210,7 +1210,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     row = [return_period]
                     row.extend([value for value in values[i]])
                     writer.writerow(row)
-            elif self.output_type == 'dmg_by_asset_show':
+            elif self.output_type == 'dmg_by_asset_aggr':
                 csv_file.write(
                     "# Realization: %s\n" % self.rlz_cbx.currentText())
                 csv_file.write(
@@ -1219,7 +1219,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     "# %s\n" % self.list_selected_edt.toPlainText())
                 headers = self.dmg_states
                 writer.writerow(headers)
-                values = self.dmg_by_asset_show[
+                values = self.dmg_by_asset_aggr[
                     'array'][self.rlz_cbx.currentIndex()]
                 writer.writerow(values)
             else:
@@ -1233,8 +1233,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.layer_changed()
         if self.output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.draw_agg_curves(self.output_type)
-        elif self.output_type == 'dmg_by_asset_show':
-            self.filter_dmg_by_asset_show()
+        elif self.output_type == 'dmg_by_asset_aggr':
+            self.filter_dmg_by_asset_aggr()
 
     @pyqtSlot(int)
     def on_output_type_cbx_currentIndexChanged(self, index):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -142,7 +142,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             ('uhs', 'Uniform Hazard Spectra'),
             ('agg_curves-rlzs', 'Aggregated loss curves (realizations)'),
             ('agg_curves-stats', 'Aggregated loss curves (statistics)'),
-            ('dmg_total', 'Total damage distribution'),
+            ('dmg_by_asset_show', 'Damage distribution'),
             ('recovery_curves', 'Recovery Curves')])
         self.output_type_cbx.addItems(self.output_types_names.values())
 
@@ -323,7 +323,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
 
-    def filter_dmg_total(self):
+    def filter_dmg_by_asset_show(self):
         params = {}
         for tag_name in self.tags:
             if self.tags[tag_name]['selected']:
@@ -332,10 +332,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'aggdamages/%s' % self.loss_type_cbx.currentText()
-        self.dmg_total = self.extract_npz(
+        self.dmg_by_asset_show = self.extract_npz(
             self.session, self.hostname, self.calc_id, output_type,
             params=params)
-        self.draw_dmg_total()
+        self.draw_dmg_by_asset_show()
 
     def update_selected_tag_names(self):
         for tag_name in self.tag_names_multiselect.get_selected_items():
@@ -345,7 +345,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
         self.update_list_selected_edt()
-        self.filter_dmg_total()
+        self.filter_dmg_by_asset_show()
 
     def update_selected_tag_values(self):
         for tag_value in self.tag_values_multiselect.get_selected_items():
@@ -353,7 +353,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         for tag_value in self.tag_values_multiselect.get_unselected_items():
             self.tags[self.current_tag_name]['values'][tag_value] = False
         self.update_list_selected_edt()
-        self.filter_dmg_total()
+        self.filter_dmg_by_asset_show()
 
     def create_list_selected_edt(self):
         self.list_selected_edt = QPlainTextEdit('Selected tags:')
@@ -400,7 +400,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.create_loss_type_selector()
         elif new_output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.create_loss_type_selector()
-        elif new_output_type == 'dmg_total':
+        elif new_output_type == 'dmg_by_asset_show':
             self.create_loss_type_selector()
             self.create_rlz_selector()
             self.create_tag_names_multiselect()
@@ -437,12 +437,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.change_output_type(output_type)
         if output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.load_agg_curves(calc_id, session, hostname, output_type)
-        elif output_type == 'dmg_total':
-            self.load_dmg_total(calc_id, session, hostname, output_type)
+        elif output_type == 'dmg_by_asset_show':
+            self.load_dmg_by_asset_show(
+                calc_id, session, hostname, output_type)
         else:
             raise NotImplementedError(output_type)
 
-    def load_dmg_total(self, calc_id, session, hostname, output_type):
+    def load_dmg_by_asset_show(self, calc_id, session, hostname, output_type):
         composite_risk_model_attrs = self.extract_npz(
             session, hostname, calc_id, 'composite_risk_model.attrs')
         self.dmg_states = composite_risk_model_attrs['damage_states']
@@ -481,7 +482,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect.set_unselected_items([])
         self.tag_values_multiselect.set_selected_items([])
 
-        self.filter_dmg_total()
+        self.filter_dmg_by_asset_show()
 
     def load_agg_curves(self, calc_id, session, hostname, output_type):
         self.agg_curves = self.extract_npz(
@@ -557,11 +558,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 loc=location, fancybox=True, shadow=True, fontsize='small')
         self.plot_canvas.draw()
 
-    def draw_dmg_total(self):
+    def draw_dmg_by_asset_show(self):
         '''
         Plots the total damage distribution
         '''
-        if len(self.dmg_total['array']) == 0:
+        if len(self.dmg_by_asset_show['array']) == 0:
             msg = 'No assets satisfy the selected criteria'
             log_msg(msg, level='W', message_bar=self.iface.messageBar())
             self.plot.clear()
@@ -569,9 +570,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             return
         rlz = self.rlz_cbx.currentIndex()
         # TODO: re-add error bars when stddev will become available again
-        # means = self.dmg_total['array'][rlz]['mean']
-        # stddevs = self.dmg_total['array'][rlz]['stddev']
-        means = self.dmg_total['array'][rlz]
+        # means = self.dmg_by_asset_show['array'][rlz]['mean']
+        # stddevs = self.dmg_by_asset_show['array'][rlz]['stddev']
+        means = self.dmg_by_asset_show['array'][rlz]
         if (means < 0).any():
             msg = ('The results displayed include negative damage estimates'
                    ' for one or more damage states. Please check the fragility'
@@ -1057,8 +1058,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.current_loss_type = self.loss_type_cbx.currentText()
         if self.output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.draw_agg_curves(self.output_type)
-        elif self.output_type == 'dmg_total':
-            self.filter_dmg_total()
+        elif self.output_type == 'dmg_by_asset_show':
+            self.filter_dmg_by_asset_show()
         else:
             self.was_loss_type_switched = True
             self.redraw_current_selection()
@@ -1080,11 +1081,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                              self.n_simulations_sbx.value())
 
     def on_rlz_changed(self):
-        self.filter_dmg_total()
+        self.filter_dmg_by_asset_show()
 
     @pyqtSlot(int)
     def on_exclude_no_dmg_ckb_state_changed(self, state):
-        self.filter_dmg_total()
+        self.filter_dmg_by_asset_show()
 
     @pyqtSlot()
     def on_export_data_button_clicked(self):
@@ -1118,7 +1119,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                                         self.current_loss_type,
                                         self.calc_id)),
                 '*.csv')
-        elif self.output_type == 'dmg_total':
+        elif self.output_type == 'dmg_by_asset_show':
             filename = QFileDialog.getSaveFileName(
                 self,
                 self.tr('Export data'),
@@ -1209,7 +1210,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     row = [return_period]
                     row.extend([value for value in values[i]])
                     writer.writerow(row)
-            elif self.output_type == 'dmg_total':
+            elif self.output_type == 'dmg_by_asset_show':
                 csv_file.write(
                     "# Realization: %s\n" % self.rlz_cbx.currentText())
                 csv_file.write(
@@ -1218,7 +1219,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     "# %s\n" % self.list_selected_edt.toPlainText())
                 headers = self.dmg_states
                 writer.writerow(headers)
-                values = self.dmg_total['array'][self.rlz_cbx.currentIndex()]
+                values = self.dmg_by_asset_show[
+                    'array'][self.rlz_cbx.currentIndex()]
                 writer.writerow(values)
             else:
                 raise NotImplementedError(self.output_type)
@@ -1231,8 +1233,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.layer_changed()
         if self.output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.draw_agg_curves(self.output_type)
-        elif self.output_type == 'dmg_total':
-            self.filter_dmg_total()
+        elif self.output_type == 'dmg_by_asset_show':
+            self.filter_dmg_by_asset_show()
 
     @pyqtSlot(int)
     def on_output_type_cbx_currentIndexChanged(self, index):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -107,10 +107,10 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print(ex)
             else:
                 self.untested_otypes.discard(output['type'])
-            output_type_show = "%s_show" % output['type']
-            if output_type_show in OQ_NO_MAP_TYPES:
+            output_type_aggr = "%s_aggr" % output['type']
+            if output_type_aggr in OQ_NO_MAP_TYPES:
                 mod_output = copy.deepcopy(output)
-                mod_output['type'] = output_type_show
+                mod_output['type'] = output_type_aggr
                 try:
                     self.load_output(calc, mod_output)
                 except Exception:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -107,6 +107,23 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print(ex)
             else:
                 self.untested_otypes.discard(output['type'])
+            output_type_show = "%s_show" % output['type']
+            if output_type_show in OQ_NO_MAP_TYPES:
+                mod_output = copy.deepcopy(output)
+                mod_output['type'] = output_type_show
+                try:
+                    self.load_output(calc, mod_output)
+                except Exception:
+                    ex_type, ex, tb = sys.exc_info()
+                    failed_attempt = {'calc_id': calc_id,
+                                      'calc_description': calc['description'],
+                                      'output_type': mod_output['type'],
+                                      'traceback': tb}
+                    self.failed_attempts.append(failed_attempt)
+                    traceback.print_tb(failed_attempt['traceback'])
+                    print(ex)
+                else:
+                    self.untested_otypes.discard(output['type'])
 
     def load_output(self, calc, output):
         calc_id = calc['id']

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -221,7 +221,7 @@ OQ_NPZ_LOADABLE_TYPES = set([
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
 OQ_RST_TYPES = set(['fullreport'])
 OQ_NO_MAP_TYPES = set(
-    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_total'])
+    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_show'])
 
 
 DEFAULT_SETTINGS = dict(

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -221,7 +221,7 @@ OQ_NPZ_LOADABLE_TYPES = set([
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
 OQ_RST_TYPES = set(['fullreport'])
 OQ_NO_MAP_TYPES = set(
-    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_show'])
+    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_aggr'])
 
 
 DEFAULT_SETTINGS = dict(


### PR DESCRIPTION
`dmg_total` is going to be excluded from the available OQ-Engine outputs, and the corresponding functionalities will be conceptually included in the `dmg_by_asset` output. Therefore, `dmg_by_asset` needs to have 2 different buttons: the first one loads the output as layer; the second one displays bar charts interrogating the OQ-Engine through the new `extract` API. Before this PR, the plugin assumed that each engine output could be read in only one way. I changed the logic to obtain, from one single output type, also a modified version (e.g. from `dmg_by_asset`, also a `dmg_by_asset_show`) that can be handled separately.