### PR TITLE
Visualize aggregated losses_by_asset

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -712,7 +712,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             tags = self.losses_by_asset_aggr['tags']
         except KeyError:
             pass
-
         nrows, ncols = losses_array.shape
         table = QTableWidget(nrows, ncols)
         table.setSizePolicy(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -709,6 +709,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
         nrows, ncols = losses_array.shape
         table = QTableWidget(nrows, ncols)
+        table.setSizePolicy(
+            QSizePolicy.Preferred, QSizePolicy.MinimumExpanding)
         table.setHorizontalHeaderLabels(self.rlzs)
         # table.setVerticalHeaderLabels(FIXME)
         table.setEditTriggers(QAbstractItemView.NoEditTriggers)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -51,7 +51,6 @@ from qgis.PyQt.QtGui import (QColor,
                              QAbstractItemView,
                              QTableWidget,
                              QTableWidgetItem,
-                             QAbstractItemView,
                              )
 from qgis.gui import QgsVertexMarker
 from qgis.core import QGis, QgsMapLayer, QgsFeatureRequest
@@ -361,8 +360,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.losses_by_asset_aggr = self.extract_npz(
             self.session, self.hostname, self.calc_id, output_type,
             params=params)
-        # FIXME
-        print(self.losses_by_asset_aggr['array'])
         self.draw_losses_by_asset_aggr()
 
     def update_selected_tag_names(self):
@@ -698,26 +695,40 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.plot.yaxis.grid()
         self.plot_canvas.draw()
 
+    def _to_2d(self, array):
+        # convert 1d array into 2d, unless already 2d
+        if len(array.shape) == 1:
+            array = array[None, :]
+        return array
+
     def draw_losses_by_asset_aggr(self):
         self.plot_canvas.hide()
         clear_widgets_from_layout(self.table_layout)
         losses_array = self.losses_by_asset_aggr['array']
-
-        # convert 1d array into 2d if needed
-        if len(losses_array.shape) == 1:
-            losses_array = losses_array[None, :]
+        losses_array = self._to_2d(losses_array)
+        selected = self.losses_by_asset_aggr['selected']
+        tags = None
+        try:
+            tags = self.losses_by_asset_aggr['tags']
+        except KeyError:
+            pass
 
         nrows, ncols = losses_array.shape
         table = QTableWidget(nrows, ncols)
         table.setSizePolicy(
             QSizePolicy.Preferred, QSizePolicy.MinimumExpanding)
         table.setHorizontalHeaderLabels(self.rlzs)
-        # table.setVerticalHeaderLabels(FIXME)
+        if tags is not None:
+            table.setVerticalHeaderLabels(tags)
         table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         for row in range(nrows):
+            if tags is None:
+                table.setVerticalHeaderItem(row,
+                                            QTableWidgetItem(str(selected)))
             for col in range(ncols):
                 table.setItem(
                     row, col, QTableWidgetItem(str(losses_array[row, col])))
+        table.resizeColumnsToContents()
         self.table_layout.addWidget(table)
 
     def draw(self):
@@ -1328,13 +1339,38 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 csv_file.write(
                     "# Loss type: %s\n" % self.loss_type_cbx.currentText())
                 csv_file.write(
-                    "# %s\n" % self.list_selected_edt.toPlainText())
+                    "# Tags: %s\n" % (
+                        self.list_selected_edt.toPlainText() or 'None'))
                 headers = self.dmg_states
                 writer.writerow(headers)
                 values = self.dmg_by_asset_aggr[
                     'array'][self.rlz_cbx.currentIndex()]
                 writer.writerow(values)
-            # TODO: implement exporter for losses_by_asset_aggr
+            elif self.output_type == 'losses_by_asset_aggr':
+                csv_file.write(
+                    "# Loss type: %s\n" % self.loss_type_cbx.currentText())
+                csv_file.write(
+                    "# Tags: %s\n" % (
+                        self.list_selected_edt.toPlainText() or 'None'))
+                headers = ['tag']
+                headers.extend(self.rlzs)
+                writer.writerow(headers)
+                losses_array = self.losses_by_asset_aggr['array']
+                losses_array = self._to_2d(losses_array)
+                selected = self.losses_by_asset_aggr['selected']
+                tags = None
+                try:
+                    tags = self.losses_by_asset_aggr['tags']
+                except KeyError:
+                    values = list(selected) or ["None"]
+                    values.extend(losses_array[0])
+                    writer.writerow(values)
+                else:
+                    for row_idx, row in enumerate(
+                            self.losses_by_asset_aggr['array']):
+                        values = [tags[row_idx]]
+                        values.extend(losses_array[row_idx])
+                        writer.writerow(values)
             else:
                 raise NotImplementedError(self.output_type)
         msg = 'Data exported to %s' % filename

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -431,6 +431,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         clear_widgets_from_layout(self.table_layout)
         if hasattr(self, 'plot'):
             self.plot.clear()
+            self.plot_canvas.show()
             self.plot_canvas.draw()
 
         if new_output_type == 'hcurves':
@@ -698,6 +699,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.plot_canvas.draw()
 
     def draw_losses_by_asset_aggr(self):
+        self.plot_canvas.hide()
         clear_widgets_from_layout(self.table_layout)
         losses_array = self.losses_by_asset_aggr['array']
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -37,7 +37,7 @@ from matplotlib.backends.backend_qt4agg import (
 from matplotlib.lines import Line2D
 
 
-from qgis.PyQt.QtCore import pyqtSlot, QSettings
+from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import (QColor,
                              QLabel,
                              QPlainTextEdit,
@@ -323,6 +323,14 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                                  if not tag_values[tag_value]]
         self.tag_values_multiselect.set_selected_items(selected_tag_values)
         self.tag_values_multiselect.set_unselected_items(unselected_tag_values)
+        unselected_items = [
+            self.tag_values_multiselect.unselected_widget.item(i) for i in
+            range(self.tag_values_multiselect.unselected_widget.count())]
+        if self.tag_with_all_values:
+            for i in range(len(unselected_items)):
+                item = unselected_items[i]
+                if item.text() == "*":
+                    item.setFlags(Qt.ItemIsEnabled)
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
 
@@ -378,6 +386,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if self.output_type == 'dmg_by_asset_aggr':
             self.filter_dmg_by_asset_aggr()
         elif self.output_type == 'losses_by_asset_aggr':
+            if "*" in self.tag_values_multiselect.get_selected_items():
+                self.tag_with_all_values = self.current_tag_name
+            elif (self.tag_with_all_values == self.current_tag_name and
+                    "*" in self.tag_values_multiselect.get_unselected_items()):
+                self.tag_with_all_values = None
             self.filter_losses_by_asset_aggr()
 
     def create_list_selected_edt(self):
@@ -465,6 +478,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.calc_id = calc_id
         self.session = session
         self.hostname = hostname
+        self.current_tag_name = None
+        self.tag_with_all_values = None
         self.change_output_type(output_type)
         if output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             self.load_agg_curves(calc_id, session, hostname, output_type)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -331,6 +331,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 item = unselected_items[i]
                 if item.text() == "*":
                     item.setFlags(Qt.ItemIsEnabled)
+                    item.setBackgroundColor(QColor('darkGray'))
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -707,7 +707,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         clear_widgets_from_layout(self.table_layout)
         losses_array = self.losses_by_asset_aggr['array']
         losses_array = self._to_2d(losses_array)
-        selected = self.losses_by_asset_aggr['selected']
         tags = None
         try:
             tags = self.losses_by_asset_aggr['tags']
@@ -722,9 +721,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             table.setVerticalHeaderLabels(tags)
         table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         for row in range(nrows):
-            if tags is None:
-                table.setVerticalHeaderItem(row,
-                                            QTableWidgetItem(str(selected)))
             for col in range(ncols):
                 table.setItem(
                     row, col, QTableWidgetItem(str(losses_array[row, col])))
@@ -1352,25 +1348,24 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 csv_file.write(
                     "# Tags: %s\n" % (
                         self.list_selected_edt.toPlainText() or 'None'))
-                headers = ['tag']
+                try:
+                    tags = self.losses_by_asset_aggr['tags']
+                    headers = ['tag']
+                except KeyError:
+                    tags = None
+                    headers = []
                 headers.extend(self.rlzs)
                 writer.writerow(headers)
                 losses_array = self.losses_by_asset_aggr['array']
                 losses_array = self._to_2d(losses_array)
-                selected = self.losses_by_asset_aggr['selected']
-                tags = None
-                try:
-                    tags = self.losses_by_asset_aggr['tags']
-                except KeyError:
-                    values = list(selected) or ["None"]
-                    values.extend(losses_array[0])
-                    writer.writerow(values)
-                else:
+                if tags is not None:
                     for row_idx, row in enumerate(
                             self.losses_by_asset_aggr['array']):
                         values = [tags[row_idx]]
                         values.extend(losses_array[row_idx])
                         writer.writerow(values)
+                else:
+                    writer.writerow(losses_array[0])
             else:
                 raise NotImplementedError(self.output_type)
         msg = 'Data exported to %s' % filename

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -51,6 +51,7 @@ from qgis.PyQt.QtGui import (QColor,
                              QAbstractItemView,
                              QTableWidget,
                              QTableWidgetItem,
+                             QAbstractItemView,
                              )
 from qgis.gui import QgsVertexMarker
 from qgis.core import QGis, QgsMapLayer, QgsFeatureRequest
@@ -708,6 +709,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         table = QTableWidget(nrows, ncols)
         table.setHorizontalHeaderLabels(self.rlzs)
         # table.setVerticalHeaderLabels(FIXME)
+        table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         for row in range(nrows):
             for col in range(ncols):
                 table.setItem(

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=2.7.0
+version=2.7.1
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,9 +23,12 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    2.7.1
+    * Losses can be aggregated by loss type and multiple tags, producing a table with aggregated values per realization
     2.7.0
-    * Added the possibility to visualize oq-engine outputs of types agg_curves-rlzs, agg_curves-stats and dmg_total
-    * Damage can be aggregated by realization, loss type and multiple tags
+    * Added the possibility to visualize oq-engine outputs of types agg_curves-rlzs, agg_curves-stats, dmg_by_asset and losses_by_asset
+    * Damage can be aggregated by realization, loss type and multiple tags, producing a bar plot displaying aggregated damages
+      for each damage state (with the possibility to include or exclude "no damage" from the chart)
     2.6.1
     * For hazard curves and uniform hazard spectra, it is possible to plot together multiple statistical outputs (e.g. mean and quantiles)
     * Fixed an offset issue with markers

--- a/svir/ui/list_multiselect_mono_widget.py
+++ b/svir/ui/list_multiselect_mono_widget.py
@@ -26,7 +26,6 @@
 
 from qgis.PyQt.QtGui import QAbstractItemView
 from svir.ui.list_multiselect_widget import ListMultiSelectWidget
-from svir.utilities.utils import log_msg
 
 
 class ListMultiSelectMonoWidget(ListMultiSelectWidget):

--- a/svir/ui/ui_viewer_dock.ui
+++ b/svir/ui/ui_viewer_dock.ui
@@ -95,6 +95,9 @@
          </layout>
         </item>
         <item>
+         <layout class="QVBoxLayout" name="table_layout"/>
+        </item>
+        <item>
          <layout class="QVBoxLayout" name="plot_layout"/>
         </item>
         <item>

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -221,7 +221,8 @@ OQ_NPZ_LOADABLE_TYPES = set([
 OQ_ALL_LOADABLE_TYPES = OQ_CSV_LOADABLE_TYPES | OQ_NPZ_LOADABLE_TYPES
 OQ_RST_TYPES = set(['fullreport'])
 OQ_NO_MAP_TYPES = set(
-    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_aggr'])
+    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_aggr',
+     'losses_by_asset_aggr'])
 
 
 DEFAULT_SETTINGS = dict(


### PR DESCRIPTION
A second button ("Aggregate") is added for OQ-Engine outputs of type losses_by_asset.
In the Data Viewer, it is possible to select the loss type and a set of tags.
Only for one tag name, it is possible to select a `*` tag value, meaning that losses have to be aggregated for each tag value separately. It is also possible to select a single tag value for multiple tag names.
The result is a table in which each column corresponds to one of the available gsims, and there are 3 possible cases:

1. if only one tag name is selected, and value `*` is chosen, each row corresponds to one of the tag values for that tag name

2. if many tag names are selected, with a single value for each, the table will contain a single row, showing the aggregated losses for that combination

3. If many tag names are chosen, and for one of them the `*` value is chosen, each row of the table will display the aggregated losses for one of the values for the starred tag, compliant with the constrains given by the single values for the other tags

If the constraints produce an empty interception, the corresponding table rows will be empty.