### PR TITLE
Use the same layer name for scenario_risk and scenario_damage

### DIFF
--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -105,8 +105,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         self.imt = self.imt_cbx.currentText()
         self.eid = self.eid_sbx.value()
         self.default_field_name = '%s-%s' % (self.imt, self.eid)
-        # layer_name = "gmf_data_%s_eid-%s" % (rlz_or_stat, self.eid)
-        layer_name = "scenario_damage_gmfs_%s_eid-%s" % (rlz_or_stat, self.eid)
+        layer_name = "scenario_gmfs_%s_eid-%s" % (rlz_or_stat, self.eid)
         return layer_name
 
     def get_field_names(self, **kwargs):

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    2.7.2
+    When loading a gmf map, the default name is "scenario_gmfs_rlz-RLZ_eid-EID" both for scenario_risk and scenario_damage
     2.7.1
     * Losses can be aggregated by loss type and multiple tags, producing a table with aggregated values per realization
     2.7.0

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,9 +24,9 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     2.7.2
-    When loading a gmf map, the default name is "scenario_gmfs_rlz-RLZ_eid-EID" both for scenario_risk and scenario_damage
-    2.7.1
+    * When loading a gmf map, the default name is "scenario_gmfs_rlz-RLZ_eid-EID" both for scenario_risk and scenario_damage
     * Added a check on the status code returned by the oq-engine server 'extract' API, displaying an error message in case of failure
+    2.7.1
     * Losses can be aggregated by loss type and multiple tags, producing a table with aggregated values per realization
     2.7.0
     * Added the possibility to visualize oq-engine outputs of types agg_curves-rlzs, agg_curves-stats, dmg_by_asset and losses_by_asset


### PR DESCRIPTION
As requested by Cata, layers for gmfs should not be named `scenario_damage_gmfs_rlz-RLZ_eid-EID`, but, more generically, `scenario_gmfs_rlz-RLZ_eid-EID` (which is good also for `scenario_risk`)