### PR TITLE
Minor GUI improvements

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -670,7 +670,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         if action in ('Load as layer', 'Show', 'Aggregate'):
             style = 'background-color: blue; color: white;'
             if action == 'Load as layer':
-                button.setText("Load %s as layer" % outtype)
+                button.setText("Load layer")
             elif action == 'Aggregate':
                 button.setText("Aggregate")
             else:

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1426,6 +1426,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         event.accept()
 
     def change_output_type(self, output_type):
+        self.setVisible(True)
+        self.raise_()
         if output_type not in self.output_types_names:
             output_type = ''
         # get the index of the item that has the given string

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     2.7.2
+    * When loading a OQ-Engine output, if the Data Viewer was hidden, it becomes visible
     * When loading a gmf map, the default name is "scenario_gmfs_rlz-RLZ_eid-EID" both for scenario_risk and scenario_damage
     * Added a check on the status code returned by the oq-engine server 'extract' API, displaying an error message in case of failure
     2.7.1


### PR DESCRIPTION
Referring to https://github.com/gem/oq-irmt-qgis/issues/326:

1) there was a corner case in which it looked like some outputs were not displayed: it was because the Data Viewer can be hidden by the user. With this change, whenever a OQ-Engine output is loaded, the data viewer is automatically set visible, so the user can immediately notice that something has actually happened after pressing the button to load the output

2) Cata believes the label "Load npz as layer" can sound a little confusing to a user who has no idea of what a npz is. Therefore, we agreed to change the label into the simpler "Load layer"