### PR TITLE
Add 'Realization' label above the corresponding dropdown

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -100,10 +100,12 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.output_dep_vlayout.addWidget(self.num_sites_lbl)
 
     def create_rlz_or_stat_selector(self):
+        self.rlz_or_stat_lbl = QLabel('Realization')
         self.rlz_or_stat_cbx = QComboBox()
         self.rlz_or_stat_cbx.setEnabled(False)
         self.rlz_or_stat_cbx.currentIndexChanged['QString'].connect(
             self.on_rlz_or_stat_changed)
+        self.output_dep_vlayout.addWidget(self.rlz_or_stat_lbl)
         self.output_dep_vlayout.addWidget(self.rlz_or_stat_cbx)
 
     def create_imt_selector(self):


### PR DESCRIPTION
Cata pointed out that, otherwise, the label showing the number of sites could be wrongly interpreted as the label describing the dropdown menu with the list of realizations.