### PR TITLE
Fix unintended stripping of the engine hostname

### DIFF
--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -159,8 +159,14 @@ class SettingsDialog(QDialog, FORM_CLASS):
         # if the (stripped) hostname ends with '/', remove it
         platform_hostname = \
             self.platformHostnameEdit.text().strip().rstrip('/')
+
+        # if the (stripped) engine hostname ends with '/engine/', remove it
         engine_hostname = self.engineHostnameEdit.text(
-            ).strip().rstrip('/').rstrip('/engine')
+            ).strip().rstrip('/')
+        engine_hostname = (
+            engine_hostname[:-7] if engine_hostname.endswith('/engine')
+            else engine_hostname)
+
         mySettings.setValue('irmt/developer_mode',
                             self.developermodeCheck.isChecked())
         mySettings.setValue('irmt/platform_hostname', platform_hostname)


### PR DESCRIPTION
The [`rstrip('/engine')` method](https://github.com/gem/oq-irmt-qgis/blob/v2.8.0/svir/dialogs/settings_dialog.py#L162-L163) removes all of the characters in the string '/engine' from the end of the entered hostname. This can result in the following unintended behavior:

```py
>>> 'https://wilson.openquake.org/engine'.strip().rstrip('/').rstrip('/engine')
'https://wilson.openquake.or'
```

This patch fixes the unintended stripping of extra characters from the engine hostname described above.