### PR TITLE
Fix missing declaration of a dict happening in batch recovery not aggregating by zone

### DIFF
--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -216,6 +216,11 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
              self.zone_field_name) = add_zone_id_to_points(
                 self.iface, self.dmg_by_asset_layer,
                 self.svi_layer, self.zone_field_name)
+        else:
+            # the layer containing points was not modified by the zonal
+            # aggregation, so the field names remained as the original ones
+            point_attrs_dict = {field.name(): field.name()
+                                for field in self.dmg_by_asset_layer.fields()}
         with WaitCursorManager('Generating recovery curves...',
                                self.iface.messageBar()):
             self.calculate_community_level_recovery_curve(


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/344

A recent change added the `point_attrs_dict`, keeping a mapping between the original field names in the layer containing dmg_by_asset points and the possibly laundered names obtained after aggregating those points by zones. Afterwards, that dict is used by the method that calculates recovery curves.
In case points are not aggregated by zone, before this PR there was an attempt to use the dict while it was not declared. With this change I am declaring the dict where needed, mapping the original field names with themselves (since they remained unchanged).