### PR TITLE
Skip any operation on the 'fid' field

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1040,7 +1040,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     or self.output_type == 'uhs'):
                 self.field_names = [
                     field.name()
-                    for field in self.iface.activeLayer().fields()]
+                    for field in self.iface.activeLayer().fields()
+                    if field.name() != 'fid']
                 ordinates = dict()
                 marker = dict()
                 line_style = dict()
@@ -1148,16 +1149,17 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     self.current_selection[rlz_or_stat] = {}
                 self.stats_multiselect.set_selected_items([])
                 self.stats_multiselect.set_unselected_items([])
+                self.field_names = [
+                    field.name()
+                    for field in self.iface.activeLayer().fields()
+                    if field.name() != 'fid']
                 if self.output_type == 'hcurves':
                     # fields names are like 'max_PGA_0.005'
                     imts = sorted(set(
-                        [field.name().split('_')[1]
-                         for field in self.iface.activeLayer().fields()]))
+                        [field_name.split('_')[1]
+                         for field_name in self.field_names()]))
                     self.imt_cbx.clear()
                     self.imt_cbx.addItems(imts)
-                self.field_names = [
-                    field.name()
-                    for field in self.iface.activeLayer().fields()]
                 self.rlzs_or_stats = sorted(set(
                     [field_name.split('_')[0]
                      for field_name in self.field_names]))
@@ -1348,6 +1350,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     selected_imt = self.imt_cbx.currentText()
                 field_names = []
                 for field in self.iface.activeLayer().fields():
+                    if field.name == 'fid':
+                        continue
                     if self.output_type == 'hcurves':
                         # field names are like 'mean_PGA_0.005'
                         rlz_or_stat, imt, iml = field.name().split('_')

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1157,7 +1157,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     # fields names are like 'max_PGA_0.005'
                     imts = sorted(set(
                         [field_name.split('_')[1]
-                         for field_name in self.field_names()]))
+                         for field_name in self.field_names]))
                     self.imt_cbx.clear()
                     self.imt_cbx.addItems(imts)
                 self.rlzs_or_stats = sorted(set(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1350,7 +1350,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     selected_imt = self.imt_cbx.currentText()
                 field_names = []
                 for field in self.iface.activeLayer().fields():
-                    if field.name == 'fid':
+                    if field.name() == 'fid':
                         continue
                     if self.output_type == 'hcurves':
                         # field names are like 'mean_PGA_0.005'


### PR DESCRIPTION
When a layer is saved (i.e. as a GeoPackage or a Shapefile) a column 'fid' is added to the attribute table.
This is breaking the plugin when trying to plot curves because a `split('_')` is performed and a `key` which does not exists is then retrieved.

Whit this PR we are skipping operations on the `fid` field if it does exits.

Up to you @ptormene if you want to backport the fix to 2.8.