### PR TITLE
When a OQ-Engine calculation is removed, clear corresponding GUI elements

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -354,26 +354,28 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.list_of_outputs_lbl.setText('List of outputs')
         self.download_datastore_btn.setEnabled(False)
         self.download_datastore_btn.setText(
-            'Download HDF5 datastore for calculation')
+            'Download HDF5 datastore')
+        self.show_calc_params_btn.setEnabled(False)
+        self.show_calc_params_btn.setText(
+            'Show calculation parameters')
 
     def update_output_list(self, calc_id):
         calc_status = self.get_calc_status(calc_id)
-        if calc_status['status'] == 'complete':
-            self.clear_output_list()
-            output_list = self.get_output_list(calc_id)
-            self.list_of_outputs_lbl.setText(
-                'List of outputs for calculation %s' % calc_id)
-            # from engine2.5 to engine2.6, job_type was changed into
-            # calculation_mode. This check prevents the plugin to break wnen
-            # using an old version of the engine.
-            self.show_output_list(
-                output_list, calc_status.get('calculation_mode', 'unknown'))
-            self.download_datastore_btn.setEnabled(True)
-            self.download_datastore_btn.setText(
-                'Download HDF5 datastore for calculation %s'
-                % self.current_output_calc_id)
-        else:
-            self.clear_output_list()
+        self.clear_output_list()
+        if calc_status['status'] != 'complete':
+            return
+        output_list = self.get_output_list(calc_id)
+        self.list_of_outputs_lbl.setText(
+            'List of outputs for calculation %s' % calc_id)
+        # from engine2.5 to engine2.6, job_type was changed into
+        # calculation_mode. This check prevents the plugin to break wnen
+        # using an old version of the engine.
+        self.show_output_list(
+            output_list, calc_status.get('calculation_mode', 'unknown'))
+        self.download_datastore_btn.setEnabled(True)
+        self.download_datastore_btn.setText(
+            'Download HDF5 datastore for calculation %s'
+            % self.current_output_calc_id)
 
     def on_calc_action_btn_clicked(self, calc_id, action):
         # NOTE: while scrolling through the list of calculations, the tool
@@ -451,6 +453,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         if resp.ok:
             msg = 'Calculation %s successfully removed' % calc_id
             log_msg(msg, level='I', message_bar=self.message_bar)
+            if self.current_output_calc_id == calc_id:
+                self.current_output_calc_id = None
+                self.clear_output_list()
+            if self.current_pointed_calc_id == calc_id:
+                self.current_pointed_calc_id = None
+                self.clear_output_list()
             self.refresh_calc_list()
         else:
             msg = 'Unable to remove calculation %s' % calc_id

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=2.8.1
+version=2.9.0
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    2.9.0
+    * When a OQ-Engine calculation is removed, the corresponding buttons and its list of outputs are properly cleared.
     2.8.1
     * When interacting with the OQ-Engine or the OQ-Platform, the plugin will attempt first to use the default credentials.
       It will open the settings dialog automatically, in case the login fails with the default settings.


### PR DESCRIPTION
In some corner cases, it was possible to press buttons pointing to elements that had been removed, causing exceptions. I fixed those cases. I also made some minor refactoring.