### PR TITLE
Remove connects while unloading plugin and partially fix some skipped tests

### DIFF
--- a/svir/calculations/process_layer.py
+++ b/svir/calculations/process_layer.py
@@ -85,7 +85,7 @@ class ProcessLayer():
         ppdata = pformat(
             [feature.attributes()
              for feature in self.layer.getFeatures()])
-        logger_func(spacer + ppdata)
+        logger_func(spacer + ppdata + spacer)
 
     def has_same_projection_as(self, other_layer):
         """

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -22,6 +22,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+import qgis  # NOQA: it loads the environment
+
 import os.path
 import tempfile
 import uuid
@@ -586,6 +588,8 @@ class Irmt:
 
         # remove connects
         self.iface.currentLayerChanged.disconnect(self.current_layer_changed)
+        self.iface.newProjectCreated.disconnect(self.current_layer_changed)
+        self.iface.projectRead.disconnect(self.current_layer_changed)
         QgsMapLayerRegistry.instance().layersAdded.disconnect(
             self.layers_added)
         QgsMapLayerRegistry.instance().layersRemoved.disconnect(

--- a/svir/test/unit/test_load_oq_engine_output_as_layer.py
+++ b/svir/test/unit/test_load_oq_engine_output_as_layer.py
@@ -23,6 +23,8 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 # import qgis libs so that we set the correct sip api version
+import qgis  # NOQA
+
 import os
 import unittest
 import tempfile
@@ -170,6 +172,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
             IFACE, self.viewer_dock, 'losses_by_asset', loss_layer_path,
             zonal_layer_path=zonal_layer_path)
         dlg.load_selected_only_ckb.setChecked(True)
+        dlg.zonal_layer_gbx.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('All')
         self.assertNotEqual(taxonomy_idx, -1, 'Taxonomy All was not found')
         dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
@@ -244,6 +247,7 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
             IFACE, self.viewer_dock, 'dmg_by_asset', dmg_layer_path,
             zonal_layer_path=zonal_layer_path)
         dlg.load_selected_only_ckb.setChecked(True)
+        dlg.zonal_layer_gbx.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('All')
         self.assertNotEqual(taxonomy_idx, -1, 'Taxonomy All was not found')
         dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)


### PR DESCRIPTION
A couple of signals were not disconnected while unloading the plugin. There's a remote probability that it might be the cause of some issues while upgrading the plugin.

Meanwhile, I've also fixed a couple of tests, that still cause a segmentation fault (so they are still skipped) but that now pass if unskipped. Unfortunately, I still haven't found a way to avoid the segfault.