### PR TITLE
Workaround to fix importing Qt on Mac OS

### DIFF
--- a/svir/dialogs/download_layer_dialog.py
+++ b/svir/dialogs/download_layer_dialog.py
@@ -27,7 +27,9 @@ import os
 import tempfile
 import shutil
 from xml.etree import ElementTree
-from qgis.PyQt import Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4 import Qt
+# from qgis.PyQt import Qt
 from qgis.PyQt.QtCore import pyqtSlot
 from qgis.PyQt.QtGui import (QDialog, QDialogButtonBox, QListWidgetItem,
                              QMessageBox)

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -36,7 +36,9 @@ from qgis.core import (QgsVectorLayer,
                        QGis,
                        QgsMapLayer,
                        )
-from qgis.PyQt.QtCore import pyqtSlot, QDir, QSettings, QFileInfo, Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4.QtCore import pyqtSlot, QDir, QSettings, QFileInfo, Qt
+# from qgis.PyQt.QtCore import pyqtSlot, QDir, QSettings, QFileInfo, Qt
 from qgis.PyQt.QtGui import (QDialogButtonBox,
                              QDialog,
                              QFileDialog,

--- a/svir/dialogs/recovery_settings_dialog.py
+++ b/svir/dialogs/recovery_settings_dialog.py
@@ -23,7 +23,9 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4.QtCore import pyqtSlot, QSettings, Qt
+# from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import (QDialog,
                              QTableWidgetItem,
                              QDialogButtonBox)

--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -23,7 +23,9 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4.QtCore import pyqtSlot, QSettings, Qt
+# from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import QDialog, QPalette, QColorDialog, QMessageBox
 
 from qgis.core import QgsGraduatedSymbolRendererV2, QgsProject

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -41,7 +41,9 @@ except ImportError as exc:
         ' a 64bit version of QGIS on Windows, please try using'
         ' a 32bit version instead. %s' % exc)
 
-from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4.QtCore import pyqtSlot, QSettings, Qt
+# from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import (QColor,
                              QLabel,
                              QPlainTextEdit,

--- a/svir/ui/list_multiselect_widget.py
+++ b/svir/ui/list_multiselect_widget.py
@@ -13,7 +13,9 @@ __author__ = 'marco@opengis.ch'
 __revision__ = '$Format:%H$'
 __date__ = '9/07/2013'
 
-from qgis.PyQt import QtGui, QtCore, Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4 import QtGui, QtCore, Qt
+# from qgis.PyQt import QtGui, QtCore, Qt
 
 
 class ListMultiSelectWidget(QtGui.QGroupBox):

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -30,7 +30,9 @@
 
 import re
 import os
-from qgis.PyQt import Qt
+# FIXME: Use wrapper as soon as it works also on Mac OS
+from PyQt4 import Qt
+# from qgis.PyQt import Qt
 from qgis.PyQt.QtXml import *
 from qgis.core import *
 


### PR DESCRIPTION
The qgis wrapper that imports from PyQt4 or PyQt5 is working in most cases also on Mac OS, except when importing Qt.
As a workaround, I'm rolling back to how it was in the previous stable version of the plugin:
`from PyQt4 import Qt` 
instad of 
`from qgis.PyQt import Qt`