### PR TITLE
Remove button to open the glossary for GEM taxonomy

### DIFF
--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -232,14 +232,6 @@ class Irmt:
                            enable=self.experimental_enabled(),
                            submenu='OQ Engine',
                            add_to_toolbar=True)
-        # Action to drive taxonomy
-        self.add_menu_item("taxonomy",
-                           ":/plugins/irmt/taxonomy.svg",
-                           u"OpenQuake Glossary for GEM Taxonomy",
-                           self.taxonomy,
-                           enable=self.experimental_enabled(),
-                           submenu='OQ Engine',
-                           add_to_toolbar=True)
         # Action to drive the oq-engine server
         self.add_menu_item("drive_engine_server",
                            ":/plugins/irmt/drive_oqengine.svg",


### PR DESCRIPTION
The glossary will be opened automatically from TaxtWEB.
Cata believes it's useless to have an additional button to explicitly open the taxonomy.