### PR TITLE
Import Qt module from qgis.PyQt.QtCore instead of from qgis.PyQt

### DIFF
--- a/svir/dialogs/download_layer_dialog.py
+++ b/svir/dialogs/download_layer_dialog.py
@@ -27,10 +27,7 @@ import os
 import tempfile
 import shutil
 from xml.etree import ElementTree
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4 import Qt
-# from qgis.PyQt import Qt
-from qgis.PyQt.QtCore import pyqtSlot
+from qgis.PyQt.QtCore import pyqtSlot, Qt
 from qgis.PyQt.QtGui import (QDialog, QDialogButtonBox, QListWidgetItem,
                              QMessageBox)
 from qgis.core import QgsVectorLayer,  QgsMapLayerRegistry

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -36,9 +36,7 @@ from qgis.core import (QgsVectorLayer,
                        QGis,
                        QgsMapLayer,
                        )
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4.QtCore import pyqtSlot, QDir, QSettings, QFileInfo, Qt
-# from qgis.PyQt.QtCore import pyqtSlot, QDir, QSettings, QFileInfo, Qt
+from qgis.PyQt.QtCore import pyqtSlot, QDir, QSettings, QFileInfo, Qt
 from qgis.PyQt.QtGui import (QDialogButtonBox,
                              QDialog,
                              QFileDialog,

--- a/svir/dialogs/recovery_settings_dialog.py
+++ b/svir/dialogs/recovery_settings_dialog.py
@@ -23,9 +23,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4.QtCore import pyqtSlot, QSettings, Qt
-# from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
+from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import (QDialog,
                              QTableWidgetItem,
                              QDialogButtonBox)

--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -23,9 +23,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4.QtCore import pyqtSlot, QSettings, Qt
-# from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
+from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import QDialog, QPalette, QColorDialog, QMessageBox
 
 from qgis.core import QgsGraduatedSymbolRendererV2, QgsProject

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -41,9 +41,7 @@ except ImportError as exc:
         ' a 64bit version of QGIS on Windows, please try using'
         ' a 32bit version instead. %s' % exc)
 
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4.QtCore import pyqtSlot, QSettings, Qt
-# from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
+from qgis.PyQt.QtCore import pyqtSlot, QSettings, Qt
 from qgis.PyQt.QtGui import (QColor,
                              QLabel,
                              QPlainTextEdit,

--- a/svir/ui/list_multiselect_widget.py
+++ b/svir/ui/list_multiselect_widget.py
@@ -13,9 +13,8 @@ __author__ = 'marco@opengis.ch'
 __revision__ = '$Format:%H$'
 __date__ = '9/07/2013'
 
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4 import QtGui, QtCore, Qt
-# from qgis.PyQt import QtGui, QtCore, Qt
+from qgis.PyQt import QtGui, QtCore
+from qgis.PyQt.QtCore import Qt
 
 
 class ListMultiSelectWidget(QtGui.QGroupBox):

--- a/svir/ui/list_multiselect_widget.py
+++ b/svir/ui/list_multiselect_widget.py
@@ -14,7 +14,6 @@ __revision__ = '$Format:%H$'
 __date__ = '9/07/2013'
 
 from qgis.PyQt import QtGui, QtCore
-from qgis.PyQt.QtCore import Qt
 
 
 class ListMultiSelectWidget(QtGui.QGroupBox):
@@ -132,7 +131,7 @@ class ListMultiSelectWidget(QtGui.QGroupBox):
         self._set_list_widget_defaults(self.unselected_widget)
         unselected_label = QtGui.QLabel()
         unselected_label.setText('Unselected')
-        unselected_label.setAlignment(Qt.Qt.AlignCenter)
+        unselected_label.setAlignment(QtCore.Qt.AlignCenter)
         unselected_label.setFont(italic_font)
         unselected_v_layout = QtGui.QVBoxLayout()
         unselected_v_layout.addWidget(unselected_label)
@@ -143,7 +142,7 @@ class ListMultiSelectWidget(QtGui.QGroupBox):
         self._set_list_widget_defaults(self.selected_widget)
         selected_label = QtGui.QLabel()
         selected_label.setText('Selected')
-        selected_label.setAlignment(Qt.Qt.AlignCenter)
+        selected_label.setAlignment(QtCore.Qt.AlignCenter)
         selected_label.setFont(italic_font)
         selected_v_layout = QtGui.QVBoxLayout()
         selected_v_layout.addWidget(selected_label)

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -30,9 +30,7 @@
 
 import re
 import os
-# FIXME: Use wrapper as soon as it works also on Mac OS
-from PyQt4 import Qt
-# from qgis.PyQt import Qt
+from qgis.PyQt.QtCore import Qt
 from qgis.PyQt.QtXml import *
 from qgis.core import *
 


### PR DESCRIPTION
A Qt module exists also under qgis.PyQt and it is similar to the one contained in qgis.PyQt.QtCore, but:
1) in some cases it works on Ubuntu and not on macOS
2) it does not have exactly the same properties that are in the one under QtCore
Using always the Qt module contained in QtCore, I've tested it on Ubuntu and on macOS, and it works. Therefore, I'm removing the ugly workaround introduced in https://github.com/gem/oq-irmt-qgis/pull/363
