### PR TITLE
Enable minimizing windows of standalone oq applications

### DIFF
--- a/svir/dialogs/standalone_app_dialog.py
+++ b/svir/dialogs/standalone_app_dialog.py
@@ -87,7 +87,7 @@ class StandaloneAppDialog(QDialog):
         self.vlayout.addWidget(self.web_view)
         initial_width = 1050
         self.resize(initial_width, self.width())
-        self.setWindowFlags(self.windowFlags() & Qt.WindowMinimizeButtonHint)
+        self.setWindowFlags(Qt.Window)
 
 
 class CommonApi(QObject):

--- a/svir/dialogs/standalone_app_dialog.py
+++ b/svir/dialogs/standalone_app_dialog.py
@@ -27,6 +27,7 @@ from qgis.PyQt.QtCore import (QUrl,
                               QObject,
                               pyqtSlot,
                               QSettings,
+                              Qt,
                               )
 from qgis.PyQt.QtGui import (QDialog,
                              QVBoxLayout,
@@ -86,6 +87,7 @@ class StandaloneAppDialog(QDialog):
         self.vlayout.addWidget(self.web_view)
         initial_width = 1050
         self.resize(initial_width, self.width())
+        self.setWindowFlags(self.windowFlags() & Qt.WindowMinimizeButtonHint)
 
 
 class CommonApi(QObject):


### PR DESCRIPTION
By default, Qt widgets can not be minimized. This PR adds the possibility to minimize all the embedded OQ standalone applications.