### PR TITLE
Extract hazard

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -763,7 +763,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 if output_type not in OUTPUT_TYPE_LOADERS:
                     raise NotImplementedError(output_type)
                 dlg = OUTPUT_TYPE_LOADERS[output_type](
-                    self.iface, self.viewer_dock, output_type, filepath)
+                    self.iface, self.viewer_dock,
+                    self.session, self.hostname, self.current_calc_id,
+                    output_type, filepath)
                 dlg.exec_()
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -39,12 +39,13 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load dmg_by_asset from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='dmg_by_asset',
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='dmg_by_asset',
                  path=None, mode=None, zonal_layer_path=None):
         assert output_type == 'dmg_by_asset'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode,
-            zonal_layer_path)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode, zonal_layer_path)
         self.setWindowTitle('Load scenario damage by asset from NPZ, as layer')
         self.create_load_selected_only_ckb()
         self.load_selected_only_ckb.setEnabled(False)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -51,6 +51,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         self.create_rlz_or_stat_selector()
         self.create_imt_selector()
         self.create_eid_selector()
+        # TODO: use the extract api instead of reading from npz
         if self.path:
             self.npz_file = numpy.load(self.path, 'r')
             self.populate_out_dep_widgets()

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -38,11 +38,12 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load gmf_data from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='gmf_data',
-                 path=None, mode=None):
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='gmf_data', path=None, mode=None):
         assert output_type == 'gmf_data'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode)
         self.setWindowTitle(
             'Load ground motion fields from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -22,13 +22,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy
 from qgis.core import QgsFeature, QgsGeometry, QgsPoint
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (LayerEditingManager,
                                   log_msg,
                                   WaitCursorManager,
+                                  extract_array,
                                   )
 from svir.utilities.shared import DEBUG
 
@@ -38,11 +38,12 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load hazard curves from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='hcurves',
-                 path=None, mode=None):
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='hcurves', path=None, mode=None):
         assert output_type == 'hcurves'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode)
         self.setWindowTitle(
             'Load hazard curves from NPZ, as layer')
         self.create_num_sites_indicator()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -28,7 +28,7 @@ from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (LayerEditingManager,
                                   log_msg,
                                   WaitCursorManager,
-                                  extract_array,
+                                  extract_npz,
                                   )
 from svir.utilities.shared import DEBUG
 
@@ -44,12 +44,17 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         LoadOutputAsLayerDialog.__init__(
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
+
+        # FIXME: add layout only for output types that load from file
+        self.remove_file_hlayout()
+
         self.setWindowTitle(
-            'Load hazard curves from NPZ, as layer')
+            'Load hazard curves as layer')
         self.create_num_sites_indicator()
-        if self.path:
-            self.npz_file = numpy.load(self.path, 'r')
-            self.populate_out_dep_widgets()
+        self.npz_file = extract_npz(
+            session, hostname, calc_id, output_type,
+            message_bar=iface.messageBar(), params=None)
+        self.populate_out_dep_widgets()
         self.adjustSize()
         self.set_ok_button()
 

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -22,13 +22,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy
 from qgis.core import QgsFeature, QgsGeometry, QgsPoint
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (WaitCursorManager,
                                   LayerEditingManager,
                                   log_msg,
+                                  extract_npz,
                                   )
 from svir.utilities.shared import DEBUG
 
@@ -44,16 +44,21 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         LoadOutputAsLayerDialog.__init__(
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
+
+        # FIXME: add layout only for output types that load from file
+        self.remove_file_hlayout()
+
         self.setWindowTitle(
-            'Load hazard maps from NPZ, as layer')
+            'Load hazard maps as layer')
         self.create_load_selected_only_ckb()
         self.create_num_sites_indicator()
         self.create_rlz_or_stat_selector()
         self.create_imt_selector()
         self.create_poe_selector()
-        if self.path:
-            self.npz_file = numpy.load(self.path, 'r')
-            self.populate_out_dep_widgets()
+        self.npz_file = extract_npz(
+            session, hostname, calc_id, output_type,
+            message_bar=iface.messageBar(), params=None)
+        self.populate_out_dep_widgets()
         self.adjustSize()
         self.set_ok_button()
 

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -38,11 +38,12 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load hazard maps from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='hmaps',
-                 path=None, mode=None):
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='hmaps', path=None, mode=None):
         assert output_type == 'hmaps'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode)
         self.setWindowTitle(
             'Load hazard maps from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -39,12 +39,13 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load losses by asset from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='losses_by_asset',
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='losses_by_asset',
                  path=None, mode=None, zonal_layer_path=None):
         assert output_type == 'losses_by_asset'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode,
-            zonal_layer_path)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode, zonal_layer_path)
         self.setWindowTitle(
             'Load losses by asset from NPZ, aggregated by location, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -72,7 +72,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     Modal dialog to load an oq-engine output as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type=None,
+    def __init__(self, iface, viewer_dock,
+                 session, hostname, calc_id, output_type=None,
                  path=None, mode=None, zonal_layer_path=None):
         # sanity check
         if output_type not in OQ_ALL_LOADABLE_TYPES:
@@ -80,6 +81,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.iface = iface
         self.viewer_dock = viewer_dock
         self.path = path
+        self.session = session
+        self.hostname = hostname
+        self.calc_id = calc_id
         self.output_type = output_type
         self.mode = mode  # if 'testing' it will avoid some user interaction
         self.zonal_layer_path = zonal_layer_path

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -513,6 +513,12 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         cbx.setItemData(last_index, zonal_layer_plus_stats.id())
         cbx.setCurrentIndex(last_index)
 
+    # FIXME: create file_hlayout only in widgets that need it
+    def remove_file_hlayout(self):
+        for i in reversed(range(self.file_hlayout.count())):
+            self.file_hlayout.itemAt(i).widget().setParent(None)
+        self.vlayout.removeItem(self.file_hlayout)
+
     def accept(self):
         if self.output_type in OQ_NPZ_LOADABLE_TYPES:
             self.load_from_npz()

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -36,11 +36,12 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
     Modal dialog to load ruptures from an oq-engine output, as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='ruptures',
-                 path=None, mode=None):
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='ruptures', path=None, mode=None):
         assert output_type == 'ruptures'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode)
         self.create_save_as_shp_ckb()
         self.setWindowTitle('Load ruptures from CSV, as layer')
         self.adjustSize()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -39,11 +39,12 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
     as layer
     """
 
-    def __init__(self, iface, viewer_dock, output_type='uhs',
-                 path=None, mode=None):
+    def __init__(self, iface, viewer_dock, session, hostname, calc_id,
+                 output_type='uhs', path=None, mode=None):
         assert output_type == 'uhs'
         LoadOutputAsLayerDialog.__init__(
-            self, iface, viewer_dock, output_type, path, mode)
+            self, iface, viewer_dock, session, hostname, calc_id,
+            output_type, path, mode)
         self.setWindowTitle(
             'Load uniform hazard spectra from NPZ, as layer')
         self.create_num_sites_indicator()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -22,13 +22,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy
 from qgis.core import QgsFeature, QgsGeometry, QgsPoint
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (LayerEditingManager,
                                   log_msg,
                                   WaitCursorManager,
+                                  extract_npz,
                                   )
 from svir.utilities.shared import DEBUG
 
@@ -45,14 +45,19 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         LoadOutputAsLayerDialog.__init__(
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
+
+        # FIXME: add layout only for output types that load from file
+        self.remove_file_hlayout()
+
         self.setWindowTitle(
-            'Load uniform hazard spectra from NPZ, as layer')
+            'Load uniform hazard spectra as layer')
         self.create_num_sites_indicator()
         self.create_load_selected_only_ckb()
         self.create_poe_selector()
-        if self.path:
-            self.npz_file = numpy.load(self.path, 'r')
-            self.populate_out_dep_widgets()
+        self.npz_file = extract_npz(
+            session, hostname, calc_id, output_type,
+            message_bar=iface.messageBar(), params=None)
+        self.populate_out_dep_widgets()
         self.adjustSize()
         self.set_ok_button()
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -66,7 +66,7 @@ from svir.utilities.utils import (get_ui_class,
                                   log_msg,
                                   clear_widgets_from_layout,
                                   warn_scipy_missing,
-                                  extract_array,
+                                  extract_npz,
                                   )
 from svir.recovery_modeling.recovery_modeling import (
     RecoveryModeling, fill_fields_multiselect)
@@ -356,7 +356,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'aggdamages/%s' % self.loss_type_cbx.currentText()
-        self.dmg_by_asset_aggr = extract_array(
+        self.dmg_by_asset_aggr = extract_npz(
             self.session, self.hostname, self.calc_id, output_type,
             message_bar=self.iface.messageBar(), params=params)
         if self.dmg_by_asset_aggr is None:
@@ -372,7 +372,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'agglosses/%s' % self.loss_type_cbx.currentText()
-        self.losses_by_asset_aggr = extract_array(
+        self.losses_by_asset_aggr = extract_npz(
             self.session, self.hostname, self.calc_id, output_type,
             message_bar=self.iface.messageBar(), params=params)
         if self.losses_by_asset_aggr is None:
@@ -507,13 +507,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             raise NotImplementedError(output_type)
 
     def load_dmg_by_asset_aggr(self, calc_id, session, hostname, output_type):
-        composite_risk_model_attrs = extract_array(
+        composite_risk_model_attrs = extract_npz(
             session, hostname, calc_id, 'composite_risk_model.attrs',
             message_bar=self.iface.messageBar())
         if composite_risk_model_attrs is None:
             return
         self.dmg_states = composite_risk_model_attrs['damage_states']
-        tags_npz = extract_array(
+        tags_npz = extract_npz(
             session, hostname, calc_id, 'assetcol/tags',
             message_bar=self.iface.messageBar())
         if tags_npz is None:
@@ -532,7 +532,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self.tags[tag_name]['values'][tag_value] = False
         self.update_list_selected_edt()
 
-        rlzs_npz = extract_array(
+        rlzs_npz = extract_npz(
             session, hostname, calc_id, 'realizations',
             message_bar=self.iface.messageBar())
         if rlzs_npz is None:
@@ -558,18 +558,18 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def load_losses_by_asset_aggr(
             self, calc_id, session, hostname, output_type):
-        composite_risk_model_attrs = extract_array(
+        composite_risk_model_attrs = extract_npz(
             session, hostname, calc_id, 'composite_risk_model.attrs',
             message_bar=self.iface.messageBar())
         if composite_risk_model_attrs is None:
             return
-        rlzs_npz = extract_array(
+        rlzs_npz = extract_npz(
             session, hostname, calc_id, 'realizations',
             message_bar=self.iface.messageBar())
         if rlzs_npz is None:
             return
         self.rlzs = rlzs_npz['array']['gsims']
-        tags_npz = extract_array(
+        tags_npz = extract_npz(
             session, hostname, calc_id, 'assetcol/tags',
             message_bar=self.iface.messageBar())
         if tags_npz is None:
@@ -603,7 +603,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.filter_losses_by_asset_aggr()
 
     def load_agg_curves(self, calc_id, session, hostname, output_type):
-        self.agg_curves = extract_array(
+        self.agg_curves = extract_npz(
             session, hostname, calc_id, output_type,
             message_bar=self.iface.messageBar())
         if self.agg_curves is None:

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -358,7 +358,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'aggdamages/%s' % self.loss_type_cbx.currentText()
-        self.dmg_by_asset_aggr = self.extract_npz(
+        self.dmg_by_asset_aggr = self.extract_array(
             self.session, self.hostname, self.calc_id, output_type,
             params=params)
         if self.dmg_by_asset_aggr is None:
@@ -374,7 +374,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         # NOTE: this would not work for multiple values per tag
                         params[tag_name] = value
         output_type = 'agglosses/%s' % self.loss_type_cbx.currentText()
-        self.losses_by_asset_aggr = self.extract_npz(
+        self.losses_by_asset_aggr = self.extract_array(
             self.session, self.hostname, self.calc_id, output_type,
             params=params)
         if self.losses_by_asset_aggr is None:
@@ -488,7 +488,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         # else.
         self.output_type = new_output_type
 
-    def extract_npz(
+    def extract_array(
             self, session, hostname, calc_id, output_type, params=None):
         url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
         resp = session.get(url, params=params)
@@ -525,12 +525,12 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             raise NotImplementedError(output_type)
 
     def load_dmg_by_asset_aggr(self, calc_id, session, hostname, output_type):
-        composite_risk_model_attrs = self.extract_npz(
+        composite_risk_model_attrs = self.extract_array(
             session, hostname, calc_id, 'composite_risk_model.attrs')
         if composite_risk_model_attrs is None:
             return
         self.dmg_states = composite_risk_model_attrs['damage_states']
-        tags_npz = self.extract_npz(
+        tags_npz = self.extract_array(
             session, hostname, calc_id, 'assetcol/tags')
         if tags_npz is None:
             return
@@ -548,7 +548,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self.tags[tag_name]['values'][tag_value] = False
         self.update_list_selected_edt()
 
-        rlzs_npz = self.extract_npz(
+        rlzs_npz = self.extract_array(
             session, hostname, calc_id, 'realizations')
         if rlzs_npz is None:
             return
@@ -573,16 +573,16 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def load_losses_by_asset_aggr(
             self, calc_id, session, hostname, output_type):
-        composite_risk_model_attrs = self.extract_npz(
+        composite_risk_model_attrs = self.extract_array(
             session, hostname, calc_id, 'composite_risk_model.attrs')
         if composite_risk_model_attrs is None:
             return
-        rlzs_npz = self.extract_npz(
+        rlzs_npz = self.extract_array(
             session, hostname, calc_id, 'realizations')
         if rlzs_npz is None:
             return
         self.rlzs = rlzs_npz['array']['gsims']
-        tags_npz = self.extract_npz(
+        tags_npz = self.extract_array(
             session, hostname, calc_id, 'assetcol/tags')
         if tags_npz is None:
             return
@@ -615,7 +615,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.filter_losses_by_asset_aggr()
 
     def load_agg_curves(self, calc_id, session, hostname, output_type):
-        self.agg_curves = self.extract_npz(
+        self.agg_curves = self.extract_array(
             session, hostname, calc_id, output_type)
         if self.agg_curves is None:
             return

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=2.9.2
+version=2.9.3
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,9 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    2.9.3
+    * Hazard maps, hazard curves and uniform hazard spectra are loaded through the "extract" API offered by the OQ Engine Server,
+      instead of using the exported npz
     2.9.2
     * If a selected OQ-Engine calculation is running, the corresponding outputs will be listed as soon as the calculation is complete.
     * Fixed the button showing parameters of a OQ-Engine calculation

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -286,7 +286,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         layer.select([1, 2])
         # probably we have the wrong layer selected (uhs produce many layers)
         self.viewer_dock.write_export_file(exported_file_path)
-        # NOTE: we are only checking that the exported CSV has at least 3 rows
+        # NOTE: we are only checking that the exported CSV has at least 2 rows
         # and 3 columns per row. We are avoiding more precise checks, because
         # CSV tests are very fragile. On different platforms the numbers could
         # be slightly different. With different versions of

--- a/svir/test/unit/test_load_oq_engine_output_as_layer.py
+++ b/svir/test/unit/test_load_oq_engine_output_as_layer.py
@@ -61,6 +61,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_gmf(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-195-gmf_data_70.npz')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadGmfDataAsLayerDialog(
             IFACE, self.viewer_dock,
             Mock(), Mock(), Mock(), 'gmf_data', filepath)
@@ -71,6 +74,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(
             self.data_dir_name, 'hazard', 'ruptures',
             'output-607-ruptures_162.csv')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadRupturesAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'ruptures',
             filepath, mode='testing')
@@ -87,6 +93,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_losses_by_asset_only_selected_taxonomy_and_loss_type(self):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-399-losses_by_asset_123.npz')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadLossesByAssetAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'losses_by_asset',
             filepath)
@@ -104,6 +113,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_losses_by_asset_all_taxonomies_only_selected_loss_type(self):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-399-losses_by_asset_123.npz')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadLossesByAssetAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'losses_by_asset',
             filepath)
@@ -123,6 +135,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
                                        'output-399-losses_by_asset_123.npz')
         zonal_layer_path = os.path.join(self.data_dir_name, 'risk',
                                         'zonal_layer.shp')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadLossesByAssetAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'losses_by_asset',
             loss_layer_path,
@@ -157,6 +172,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_dmg_by_asset_only_selected_taxonomy(self):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-1614-dmg_by_asset_356.npz')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadDmgByAssetAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'dmg_by_asset',
             filepath)
@@ -178,6 +196,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
     def test_load_dmg_by_asset_all_taxonomies(self):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-1614-dmg_by_asset_356.npz')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadDmgByAssetAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'dmg_by_asset',
             filepath)
@@ -201,6 +222,9 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
                                       'output-1614-dmg_by_asset_356.npz')
         zonal_layer_path = os.path.join(self.data_dir_name, 'risk',
                                         'zonal_layer.shp')
+        # TODO: in the future, we will move this to integration tests, using
+        #       session, hostname  and calc_id and the extract api, instead of
+        #       mocking
         dlg = LoadDmgByAssetAsLayerDialog(
             IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'dmg_by_asset',
             dmg_layer_path, zonal_layer_path=zonal_layer_path)

--- a/svir/test/unit/test_load_oq_engine_output_as_layer.py
+++ b/svir/test/unit/test_load_oq_engine_output_as_layer.py
@@ -29,6 +29,7 @@ import os
 import unittest
 import tempfile
 import csv
+from mock import Mock
 from numpy.testing import assert_almost_equal
 
 from qgis.PyQt.QtGui import QAction
@@ -37,14 +38,8 @@ from svir.dialogs.load_dmg_by_asset_as_layer_dialog import (
     LoadDmgByAssetAsLayerDialog)
 from svir.dialogs.load_ruptures_as_layer_dialog import (
     LoadRupturesAsLayerDialog)
-from svir.dialogs.load_hmaps_as_layer_dialog import (
-    LoadHazardMapsAsLayerDialog)
-from svir.dialogs.load_hcurves_as_layer_dialog import (
-    LoadHazardCurvesAsLayerDialog)
 from svir.dialogs.load_gmf_data_as_layer_dialog import (
     LoadGmfDataAsLayerDialog)
-from svir.dialogs.load_uhs_as_layer_dialog import (
-    LoadUhsAsLayerDialog)
 from svir.dialogs.load_losses_by_asset_as_layer_dialog import (
     LoadLossesByAssetAsLayerDialog)
 from svir.dialogs.viewer_dock import ViewerDock
@@ -63,64 +58,22 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         mock_action = QAction(IFACE.mainWindow())
         self.viewer_dock = ViewerDock(IFACE, mock_action)
 
-    def test_load_hazard_map(self):
-        filepath = os.path.join(
-            self.data_dir_name, 'hazard', 'output-3-hmaps_1.npz')
-        dlg = LoadHazardMapsAsLayerDialog(
-            IFACE, self.viewer_dock, 'hmaps', filepath)
-        dlg.accept()
-        # hazard maps have nothing to do with the Data Viewer
-
     def test_load_gmf(self):
         filepath = os.path.join(self.data_dir_name, 'hazard',
                                 'output-195-gmf_data_70.npz')
         dlg = LoadGmfDataAsLayerDialog(
-            IFACE, self.viewer_dock, 'gmf_data', filepath)
+            IFACE, self.viewer_dock,
+            Mock(), Mock(), Mock(), 'gmf_data', filepath)
         dlg.accept()
         # ground motion fields have nothing to do with the Data Viewer
-
-    def test_load_hazard_curves(self):
-        filepath = os.path.join(self.data_dir_name, 'hazard',
-                                'output-121-hcurves_27.npz')
-        dlg = LoadHazardCurvesAsLayerDialog(
-            IFACE, self.viewer_dock, 'hcurves', filepath)
-        dlg.accept()
-        self._set_output_type('Hazard Curves')
-        self._change_selection()
-        # test changing intensity measure type
-        layer = IFACE.activeLayer()
-        # select the first 2 features (the same used to produce the reference
-        # csv)
-        layer.select([1, 2])
-        imt = 'SA(0.1)'
-        idx = self.viewer_dock.imt_cbx.findText(imt)
-        self.assertNotEqual(idx, -1, 'IMT %s not found' % imt)
-        self.viewer_dock.imt_cbx.setCurrentIndex(idx)
-        # test exporting the current selection to csv
-        _, exported_file_path = tempfile.mkstemp(suffix=".csv")
-        self._test_export()
-
-    def test_load_uhs_only_selected_poe(self):
-        filepath = os.path.join(self.data_dir_name, 'hazard',
-                                'output-125-uhs_27.npz')
-        dlg = LoadUhsAsLayerDialog(
-            IFACE, self.viewer_dock, 'uhs', filepath)
-        dlg.load_selected_only_ckb.setChecked(True)
-        idx = dlg.poe_cbx.findText('0.1')
-        self.assertEqual(idx, 0, 'POE 0.1 was not found')
-        dlg.poe_cbx.setCurrentIndex(idx)
-        dlg.accept()
-        self._set_output_type('Uniform Hazard Spectra')
-        self._change_selection()
-        # test exporting the current selection to csv
-        self._test_export()
 
     def test_load_ruptures(self):
         filepath = os.path.join(
             self.data_dir_name, 'hazard', 'ruptures',
             'output-607-ruptures_162.csv')
         dlg = LoadRupturesAsLayerDialog(
-            IFACE, self.viewer_dock, 'ruptures', filepath, mode='testing')
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'ruptures',
+            filepath, mode='testing')
         dlg.save_as_shp_ckb.setChecked(True)
         dlg.accept()
         current_layer = IFACE.activeLayer()
@@ -135,7 +88,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-399-losses_by_asset_123.npz')
         dlg = LoadLossesByAssetAsLayerDialog(
-            IFACE, self.viewer_dock, 'losses_by_asset', filepath)
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'losses_by_asset',
+            filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('"Concrete"')
         self.assertNotEqual(taxonomy_idx, -1,
@@ -151,7 +105,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-399-losses_by_asset_123.npz')
         dlg = LoadLossesByAssetAsLayerDialog(
-            IFACE, self.viewer_dock, 'losses_by_asset', filepath)
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'losses_by_asset',
+            filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('All')
         self.assertNotEqual(taxonomy_idx, -1, 'Taxonomy All was not found')
@@ -169,7 +124,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         zonal_layer_path = os.path.join(self.data_dir_name, 'risk',
                                         'zonal_layer.shp')
         dlg = LoadLossesByAssetAsLayerDialog(
-            IFACE, self.viewer_dock, 'losses_by_asset', loss_layer_path,
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'losses_by_asset',
+            loss_layer_path,
             zonal_layer_path=zonal_layer_path)
         dlg.load_selected_only_ckb.setChecked(True)
         dlg.zonal_layer_gbx.setChecked(True)
@@ -202,7 +158,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-1614-dmg_by_asset_356.npz')
         dlg = LoadDmgByAssetAsLayerDialog(
-            IFACE, self.viewer_dock, 'dmg_by_asset', filepath)
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'dmg_by_asset',
+            filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('"Concrete"')
         self.assertNotEqual(taxonomy_idx, -1,
@@ -222,7 +179,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         filepath = os.path.join(self.data_dir_name, 'risk',
                                 'output-1614-dmg_by_asset_356.npz')
         dlg = LoadDmgByAssetAsLayerDialog(
-            IFACE, self.viewer_dock, 'dmg_by_asset', filepath)
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'dmg_by_asset',
+            filepath)
         dlg.load_selected_only_ckb.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('All')
         self.assertNotEqual(taxonomy_idx, -1, 'Taxonomy All was not found')
@@ -244,8 +202,8 @@ class LoadOQEngineOutputAsLayerTestCase(unittest.TestCase):
         zonal_layer_path = os.path.join(self.data_dir_name, 'risk',
                                         'zonal_layer.shp')
         dlg = LoadDmgByAssetAsLayerDialog(
-            IFACE, self.viewer_dock, 'dmg_by_asset', dmg_layer_path,
-            zonal_layer_path=zonal_layer_path)
+            IFACE, self.viewer_dock, Mock(), Mock(), Mock(), 'dmg_by_asset',
+            dmg_layer_path, zonal_layer_path=zonal_layer_path)
         dlg.load_selected_only_ckb.setChecked(True)
         dlg.zonal_layer_gbx.setChecked(True)
         taxonomy_idx = dlg.taxonomy_cbx.findText('All')

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -29,6 +29,7 @@ import os
 import sys
 import locale
 import zlib
+import io
 from copy import deepcopy
 from time import time
 from pprint import pformat
@@ -1059,3 +1060,20 @@ def get_checksum(file_path):
     data = open(file_path, 'rb').read()
     checksum = zlib.adler32(data, 0) & 0xffffffff
     return checksum
+
+
+def extract_array(
+        session, hostname, calc_id, output_type, message_bar, params=None):
+    url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
+    resp = session.get(url, params=params)
+    if not resp.ok:
+        msg = "Unable to extract %s with parameters %s: %s" % (
+            url, params, resp.reason)
+        log_msg(msg, level='C', message_bar=message_bar)
+        return
+    resp_content = resp.content
+    if not resp_content:
+        msg = 'GET %s returned an empty content!' % url
+        log_msg(msg, level='C', message_bar=message_bar)
+        return
+    return numpy.load(io.BytesIO(resp_content))

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1062,7 +1062,7 @@ def get_checksum(file_path):
     return checksum
 
 
-def extract_array(
+def extract_npz(
         session, hostname, calc_id, output_type, message_bar, params=None):
     url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
     resp = session.get(url, params=params)


### PR DESCRIPTION
Layers for hazard maps, hazard curves and uniform hazard spectra were previously obtained downloading npz files and loading data from them. With this change, the "extract" api is used instead. This is in the direction of using the "extract" api both for risk and hazard engine outputs. In future PRs we plan to do the same for other outputs that still use the exported npz files.