### PR TITLE
Fixed retrieval of the engine server hostname from settings

### DIFF
--- a/svir/dialogs/standalone_app_dialog.py
+++ b/svir/dialogs/standalone_app_dialog.py
@@ -34,7 +34,7 @@ from qgis.PyQt.QtGui import (QDialog,
                              )
 from qgis.gui import QgsMessageBar
 from svir.ui.gem_qwebview import GemQWebView
-from svir.utilities.shared import DEFAULT_SETTINGS, DEFAULT_ENGINE_PROFILES
+from svir.utilities.shared import DEFAULT_ENGINE_PROFILES
 
 
 class StandaloneAppDialog(QDialog):

--- a/svir/dialogs/standalone_app_dialog.py
+++ b/svir/dialogs/standalone_app_dialog.py
@@ -34,7 +34,7 @@ from qgis.PyQt.QtGui import (QDialog,
                              )
 from qgis.gui import QgsMessageBar
 from svir.ui.gem_qwebview import GemQWebView
-from svir.utilities.shared import DEFAULT_SETTINGS
+from svir.utilities.shared import DEFAULT_SETTINGS, DEFAULT_ENGINE_PROFILES
 
 
 class StandaloneAppDialog(QDialog):
@@ -63,8 +63,14 @@ class StandaloneAppDialog(QDialog):
         self.set_host()
 
     def set_host(self):
-        self.host = QSettings().value(
-            'irmt/engine_hostname', DEFAULT_SETTINGS['engine_hostname'])
+        engine_profiles = json.loads(QSettings().value(
+            'irmt/engine_profiles', DEFAULT_ENGINE_PROFILES))
+        cur_eng_profile = QSettings().value('irmt/current_engine_profile')
+        if cur_eng_profile is None:
+            cur_eng_profile = engine_profiles.keys()[0]
+        engine_profile = engine_profiles[cur_eng_profile]
+        engine_hostname = engine_profile['hostname']
+        self.host = QSettings().value('irmt/engine_hostname', engine_hostname)
 
     def load_homepage(self):
         if self.web_view is not None:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=2.9.3
+version=2.9.4
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    2.9.4
+    * Fixed retrieval of the engine server hostname from settings
     2.9.3
     * Hazard maps, hazard curves and uniform hazard spectra are loaded through the "extract" API offered by the OQ Engine Server,
       instead of using the exported npz
@@ -61,26 +63,6 @@ changelog=
     * Added the possibility to visualize oq-engine outputs of types agg_curves-rlzs, agg_curves-stats, dmg_by_asset and losses_by_asset
     * Damage can be aggregated by realization, loss type and multiple tags, producing a bar plot displaying aggregated damages
       for each damage state (with the possibility to include or exclude "no damage" from the chart)
-    2.6.1
-    * For hazard curves and uniform hazard spectra, it is possible to plot together multiple statistical outputs (e.g. mean and quantiles)
-    * Fixed an offset issue with markers
-    * The plugin works even if scipy is not installed and it requests to install it only on the attempt of using
-      recovery modeling functionalities
-    * Added a button to reset the default plugin settings
-    * While driving the OQ-Engine, notifications are displayed on top of the widget instead of using the main messageBar
-    * The widget driving the OQ-Engine handles also the LocationParseError exception
-    * One single widget loads losses_by_asset or dmg_by_asset and aggregates points by polygons taken from a zonal layer
-    * When the active layer has an assigned output type, other output types can not be selected in the Data Viewer
-    * Fixed an error occurring while switching between a layer that does not use the Data Viewer and one that uses it,
-      that was caused by a missing re-initialization in a corner case
-    2.6.0
-    * The plugin is aligned with OQ-Engine version 2.6
-    * Added a warning message in case of connection with a potentially incompatible version of the OQ-Engine Server
-    * The list of calculations displays the Calculation Mode instead of the Job Type
-    * Loaders for OQ-Engine hazard outputs can read the new format introduced in OQ-Engine version 2.6
-    * Layers for hazard curves are stored in a more convenient way, keeping a scalar value per cell instead of a json string
-    * Integration tests check that all implemented loaders for OQ-Engine outputs are tested at least once
-    * Both workflows aggregating loss points by zone are tested on Travis (1: using SAGA; 2: using the fallback algorithm)
 
 # tags are comma separated with spaces allowed
 tags=GEM, IRMT, SVIR, OpenQuake, Social Vulnerability, Integrated Risk, Recovery, Resilience, Risk, Hazard, Earthquake


### PR DESCRIPTION
The plugin attempted to load a default from a variable that does not exist anymore (after the introduction of connection profiles), so the standalone applications could not set the hostname correctly.
Therefore, in v2.9.3 (just released), if you try to open IPT or TaxtWEB, the plugin breaks.
I propose to publish v2.9.4 right after this quickfix.