### PR TITLE
Add calc_id to layers as customProperty and put it in exported filename

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -342,7 +342,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             else:
                 return investigation_time
         else:
-            # some output do not need the investigation time
+            # some outputs do not need the investigation time
             return None
 
     def build_layer(self, rlz_or_stat=None, taxonomy=None, poe=None,
@@ -377,6 +377,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         if investigation_time is not None:
             self.layer.setCustomProperty('investigation_time',
                                          investigation_time)
+        self.layer.setCustomProperty('calc_id', self.calc_id)
         QgsMapLayerRegistry.instance().addMapLayer(self.layer)
         self.iface.setActiveLayer(self.layer)
         self.iface.zoomToActiveLayer()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1107,6 +1107,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self.redraw_current_selection)
 
             if self.output_type in ['hcurves', 'uhs']:
+                self.calc_id = self.iface.activeLayer().customProperty(
+                    'calc_id')
                 for rlz_or_stat in self.stats_multiselect.get_selected_items():
                     self.current_selection[rlz_or_stat] = {}
                 self.stats_multiselect.set_selected_items([])
@@ -1241,13 +1243,15 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self,
                 self.tr('Export data'),
                 os.path.expanduser(
-                    '~/hazard_curves_%s.csv' % self.current_imt),
+                    '~/hazard_curves_%s_%s.csv' % (
+                        self.current_imt, self.calc_id)),
                 '*.csv')
         elif self.output_type == 'uhs':
             filename = QFileDialog.getSaveFileName(
                 self,
                 self.tr('Export data'),
-                os.path.expanduser('~/uniform_hazard_spectra.csv'),
+                os.path.expanduser(
+                    '~/uniform_hazard_spectra_%s.csv' % self.calc_id),
                 '*.csv')
         elif self.output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
             filename = QFileDialog.getSaveFileName(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1320,7 +1320,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 headers = ['lon', 'lat']
                 headers.extend(field_names)
                 writer.writerow(headers)
-                for feature in self.iface.activeLayer().getFeatures():
+                for feature in self.iface.activeLayer().selectedFeatures():
                     values = [feature.attribute(field_name)
                               for field_name in field_names]
                     lon = feature.geometry().asPoint().x()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -26,6 +26,8 @@ changelog=
     2.9.6
     * When loading hazard maps from OQ-Engine, values for all intensity measure types and probabilities of exceedance can be stored
       in a single layer.
+    * Layers built from OQ-Engine outputs have the custom property 'calc_id' storing the id of the corresponding OQ-Engine calculation.
+    * The names of files exported by the Data Viewer contain the id of the corresponding OQ-Engine calculation.
     2.9.5
     * Several updates to the user manual
     * Fixed bug in the GUI initialization for visualizing aggregate loss curves


### PR DESCRIPTION
1. also layers that have nothing to do with the Data Viewer will contain the calc_id as a custom property, that can be retrieved through the Python Console (calc_id = iface.activeLayer().customProperty('calc_id')). Perhaps I should also provide a more intuitive way for the user to get the calc_id (for instance, a contextual menu, or I could add it to the layer name before the investigation time)
2. while exporting curves with the Data Viewer, the exported file name will contain the calc_id (fixes https://github.com/gem/oq-irmt-qgis/issues/320)