### PR TITLE
Use Docker for running tests in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,14 @@ install:
     - pip -q install -U pip
     - pip -q install -r oq-engine/requirements-py35-linux64.txt
     - pip -q install -e oq-engine
-    - docker build -t qgis-builder -f docker/Dockerfile docker/
+    - docker build --build-arg uid=$(id -u) -t qgis-builder -f docker/Dockerfile docker/
 
 before_script:
     - oq restore oqdata-${BRANCH}.zip ~/oqdata
     - oq webui start --skip-browser 0.0.0.0:8800 &> webui.log &
 
 script:
-    - docker run --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder test
+    - docker run -e OQ_ENGINE_HOST='http://172.17.0.1:8800' --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder test
 
 after_success:
     - docker run --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder build_apidoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - pip -q install -U pip
     - pip -q install -r oq-engine/requirements-py35-linux64.txt
     - pip -q install -e oq-engine
-    - docker pull openquake/qgis-builder:ltr
+    - docker build -t qgis-builder -f docker/Dockerfile docker/
 
 before_script:
     - oq restore oqdata-${BRANCH}.zip ~/oqdata

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 
 before_script:
     - oq restore oqdata-${BRANCH}.zip ~/oqdata
-    - oq webui start --skip-browser 0.0.0.0:8800 &> webui.log &
+    - oq webui start 0.0.0.0:8800 --skip-browser &> webui.log &
 
 script:
     - docker run -e OQ_ENGINE_HOST='http://172.17.0.1:8800' --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
     # - QGIS_VERSION=debian
 
 dist: trusty
-sudo: true
+services: docker
 
 language: python
 
@@ -18,36 +18,23 @@ before_install:
       fi;
     - curl -sfLO https://artifacts.openquake.org/travis/oqdata-${BRANCH}.zip || ( echo "Dump for ${BRANCH} unavailable"; exit 1 )
     - git clone -q -b ${BRANCH} --depth=1 https://github.com/gem/oq-engine.git && echo "Running against oq-engine/${BRANCH}"
-    - echo "deb http://qgis.org/$QGIS_VERSION trusty main" | sudo tee -a /etc/apt/sources.list
-    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45
-    - sudo add-apt-repository -y ppa:openquake/saga
-    - sudo apt-get update -q
 
 install:
-    - sudo apt-get install -q -y xvfb qgis python-mock python-nose python-nose-exclude python-scipy saga python-saga
-    - export PYTHONPATH=$TRAVIS_BUILD_DIR:$PYTHONPATH
     - pip -q install -U pip
     - pip -q install -r oq-engine/requirements-py35-linux64.txt
     - pip -q install -e oq-engine
+    - docker pull openquake/qgis-builder:ltr
 
 before_script:
-    - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
-    - "export DISPLAY=:99.0"
     - oq restore oqdata-${BRANCH}.zip ~/oqdata
-    - oq webui start --skip-browser &> webui.log &
-    # We need to switch to Python 2.7 and have visibility on system packages
-    # because QGIS 2 uses Python 2.7 and its python libraries are installed via apt.
-    # Travis already provides a venv with these features
-    - source $HOME/virtualenv/python2.7_with_system_site_packages/bin/activate
-    - . ./scripts/run-env-linux.sh /usr
+    - oq webui start --skip-browser 0.0.0.0:8800 &> webui.log &
 
 script:
-    - cd $TRAVIS_BUILD_DIR/svir && make test
+    - docker run --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder test
 
 after_success:
-    - pip install sphinx==1.4.9 sphinx_rtd_theme
-    - cd $TRAVIS_BUILD_DIR/svir && make build_apidoc
-    - cd $TRAVIS_BUILD_DIR/svir && make build_manual_html
+    - docker run --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder build_apidoc
+    - docker run --rm -v $TRAVIS_BUILD_DIR:/io qgis-builder build_manual_html
 
 after_script:
     - cat $TRAVIS_BUILD_DIR/webui.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,5 +30,6 @@ WORKDIR /io
 
 ENV DISPLAY=:99
 ENV PYTHONPATH=/io
+ENV PYTHONIOENCODING=utf_8
 
 ENTRYPOINT ["/bin/bash", "/io/docker/run_make.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN echo "deb     http://qgis.org/debian-ltr xenial main" >> /etc/apt/sources.li
     apt-key adv --keyserver keyserver.ubuntu.com --recv-key CAEB3DC3BDF7FB45 && \
     apt update && \
     apt upgrade -y && \
-    apt install -y build-essential git sudo software-properties-common xvfb zip \
+    apt -q install -y build-essential git sudo software-properties-common xvfb zip \
                    python-qt4-dev pyqt4-dev-tools \
                    python-pip python-mock python-nose \
                    python-nose-exclude python-scipy \

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -53,7 +53,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.session = Session()
-        self.hostname = 'http://172.17.0.1:8800'
+        self.hostname = os.environ.get('OQ_ENGINE_HOST',
+                                       'http://localhost:8800')
         mock_action = QAction(IFACE.mainWindow())
         self.viewer_dock = ViewerDock(IFACE, mock_action)
 

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -190,16 +190,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             else:
                 raise RuntimeError('The ok button is disabled')
         elif output_type in OQ_NO_MAP_TYPES:
-            # TODO: do not skip when encoding issue is fixed
-            if output_type in ('losses_by_asset_aggr', 'dmg_by_asset_aggr'):
-                print('\tLoading output type %s...' % output_type)
-                skipped_attempt = {
-                    'calc_id': calc_id,
-                    'calc_description': calc['description'],
-                    'output_type': output_type}
-                self.skipped_attempts.append(skipped_attempt)
-                print('\t\tSKIPPED')
-                return
             print('\tLoading output type %s...' % output_type)
             self.viewer_dock.load_no_map_output(
                 calc_id, self.session, self.hostname, output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -53,7 +53,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     def setUp(self):
         self.session = Session()
-        self.hostname = 'http://localhost:8800'
+        self.hostname = 'http://172.17.0.1:8800'
         mock_action = QAction(IFACE.mainWindow())
         self.viewer_dock = ViewerDock(IFACE, mock_action)
 


### PR DESCRIPTION
Recycle the work done in #111 to run tests in Travis via Docker: this allow us to use Ubuntu 16.04 and avoid issues with integration tests (now it's possible to revert #402 ).