### PR TITLE
Log as warning (no msg bar) if cleaning an already deleted combo

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1185,7 +1185,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 # "wrapped C/C++ object of type QComboBox has been deleted"
                 ex_type, ex, tb = sys.exc_info()
                 msg = ''.join(traceback.format_exception(ex_type, ex, tb))
-                log_msg(msg, level='C', message_bar=self.iface.messageBar())
+                # we log it as a warning, but it should not bother the user,
+                # so we are not displaying it in the message bar
+                log_msg(msg, level='W')
 
     def on_plot_hover(self, event):
         if not self.on_container_hover(event, self.plot):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1172,7 +1172,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 # "wrapped C/C++ object of type QComboBox has been deleted"
                 ex_type, ex, tb = sys.exc_info()
                 msg = ''.join(traceback.format_exception(ex_type, ex, tb))
-                log_msg(msg, level='C', message_bar=self.iface.messageBar())
+                # we log it as a warning, but it should not bother the user,
+                # so we are not displaying it in the message bar
+                log_msg(msg, level='W')
 
     def clear_loss_type_cbx(self):
         if self.loss_type_cbx is not None:


### PR DESCRIPTION
Improves the situation highlighted in https://github.com/gem/oq-irmt-qgis/issues/423

The problem occurs when we clean up the viewer dock in order to replace the current widgets (and their contents) with those that are related to another kind of OQ-Engine output. While cleaning up things, it might occur that we attempt to clear a combo box that has already been deleted. In this case, it's good to log a warning, but we should not bother the user too much, so we can avoid displaying the message also in the QGIS message bar.