### PR TITLE
Deselect tag values for tags that are unselected

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -404,6 +404,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.tags[tag_name]['selected'] = True
         for tag_name in self.tag_names_multiselect.get_unselected_items():
             self.tags[tag_name]['selected'] = False
+            # deselect all tag values for tags that are unselected
+            for value in self.tags[tag_name]['values']:
+                self.tags[tag_name]['values'][value] = False
         self.tag_values_multiselect.setEnabled(
             tag_name in list(self.tag_names_multiselect.get_selected_items()))
         self.update_list_selected_edt()


### PR DESCRIPTION
Before this change, I was saving the selection associated to each tag, regardless from the fact the tag is currently selected or not. It was reasonable, because this way you could deselect one tag and then reselect it, without losing the association between that tag and the corresponding selected values. This caused a problem, though, when the `*` is selected for one tag, and then the user deselects that tag and wants to select the `*` for a different tag. Since it's currently forbidden to have the `*` selected for multiple tags, it was impossible to do the selection, unless you re-select the previous tag, remove the `*`, and then apply the `*` to the new tag. This happened to Cata, and she couldn't intuitively find out how to do the trick. Therefore, I'm changing the approach here, keeping deselected all the values associated to a deselected tag.