### PR TITLE
Reduce duplication visualizing losses by asset

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -805,7 +805,14 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         else:  # self.output_type == 'avg_losses-stats_aggr'
             table.setHorizontalHeaderLabels(self.stats)
         if tags is not None:
-            table.setVerticalHeaderLabels(tags)
+            # tags are like
+            # array(['taxonomy=Wood',
+            #        'taxonomy=Adobe',
+            #        'taxonomy=Stone-Masonry',
+            #        'taxonomy=Unreinforced-Brick-Masonry',
+            #        'taxonomy=Concrete'], dtype='|S35')
+            tag_values = [tag.split('=')[1] for tag in tags]
+            table.setVerticalHeaderLabels(tag_values)
         table.setEditTriggers(QAbstractItemView.NoEditTriggers)
         for row in range(nrows):
             for col in range(ncols):
@@ -1443,7 +1450,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 if tags is not None:
                     for row_idx, row in enumerate(
                             self.losses_by_asset_aggr['array']):
-                        values = [tags[row_idx]]
+                        tag = tags[row_idx]
+                        # a tag is like 'taxonomy=Wood'
+                        tag_value = tag.split('=')[1]
+                        values = [tag_value]
                         values.extend(losses_array[row_idx])
                         writer.writerow(values)
                 else:

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1415,7 +1415,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 values = self.dmg_by_asset_aggr[
                     'array'][self.rlz_cbx.currentIndex()]
                 writer.writerow(values)
-            elif self.output_type == 'losses_by_asset_aggr':
+            elif self.output_type in ('losses_by_asset_aggr',
+                                      'avg_losses-stats_aggr'):
                 csv_file.write(
                     "# Loss type: %s\n" % self.loss_type_cbx.currentText())
                 csv_file.write(
@@ -1427,37 +1428,16 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 except KeyError:
                     tags = None
                     headers = []
-                headers.extend(self.rlzs)
+                if self.output_type == 'losses_by_asset_aggr':
+                    headers.extend(self.rlzs)
+                else:  # self.output_type == 'avg_losses-stats_aggr':
+                    headers.extend(self.stats)
                 writer.writerow(headers)
                 losses_array = self.losses_by_asset_aggr['array']
                 losses_array = self._to_2d(losses_array)
                 if tags is not None:
                     for row_idx, row in enumerate(
                             self.losses_by_asset_aggr['array']):
-                        values = [tags[row_idx]]
-                        values.extend(losses_array[row_idx])
-                        writer.writerow(values)
-                else:
-                    writer.writerow(losses_array[0])
-            elif self.output_type == 'avg_losses-stats_aggr':
-                csv_file.write(
-                    "# Loss type: %s\n" % self.loss_type_cbx.currentText())
-                csv_file.write(
-                    "# Tags: %s\n" % (
-                        self.list_selected_edt.toPlainText() or 'None'))
-                try:
-                    tags = self.avg_losses_stats_aggr['tags']
-                    headers = ['tag']
-                except KeyError:
-                    tags = None
-                    headers = []
-                headers.extend(self.stats)
-                writer.writerow(headers)
-                losses_array = self.avg_losses_stats_aggr['array']
-                losses_array = self._to_2d(losses_array)
-                if tags is not None:
-                    for row_idx, row in enumerate(
-                            self.avg_losses_stats_aggr['array']):
                         values = [tags[row_idx]]
                         values.extend(losses_array[row_idx])
                         writer.writerow(values)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -798,7 +798,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         table = QTableWidget(nrows, ncols)
         table.setSizePolicy(
             QSizePolicy.Preferred, QSizePolicy.MinimumExpanding)
-        table.setHorizontalHeaderLabels(self.rlzs)
+        if self.output_type == 'losses_by_asset_aggr':
+            table.setHorizontalHeaderLabels(self.rlzs)
+        else:  # self.output_type == 'avg_losses-stats_aggr'
+            table.setHorizontalHeaderLabels(self.stats)
         if tags is not None:
             table.setVerticalHeaderLabels(tags)
         table.setEditTriggers(QAbstractItemView.NoEditTriggers)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1436,7 +1436,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         self.list_selected_edt.toPlainText() or 'None'))
                 try:
                     tags = self.losses_by_asset_aggr['tags']
-                    headers = ['tag']
+                    tag = tags[0]
+                    # a tag is like 'taxonomy=Wood'
+                    tag_name = tag.split('=')[0]
+                    headers = [tag_name]
                 except KeyError:
                     tags = None
                     headers = []

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -521,7 +521,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.load_dmg_by_asset_aggr(
                 calc_id, session, hostname, output_type)
         elif output_type in ('losses_by_asset_aggr',
-                             'avg_losses-stats-aggr'):
+                             'avg_losses-stats_aggr'):
             self.load_losses_by_asset_aggr(
                 calc_id, session, hostname, output_type)
         else:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=2.14
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.0.2
+version=3.1.0
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.1.0
+    * Reduced code duplication in the management of OQ-Engine outputs losses_by_asset and avg_losses-stats
     3.0.2
     * Fixed styling of scenario damage after aggregating damage by zone
     * Fixed selection/deselection of tag values in aggregate losses/damages visualization in the Data Viewer
@@ -86,7 +88,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=False
+experimental=True
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/427

I've also improved the table (and the corresponding exported csv) for aggregate losses, in case `*` is selected for a tag. Instead of writing in each line something like `taxonomy=Wood`, I'm writing just `Wood`. In the header of the csv, instead of writing `tag`, I'm writing the tag name (e.g. `taxonomy`).