### PR TITLE
Add file selector only for outputs that need it (currently, those that read from CSV)...

### DIFF
--- a/svir/dialogs/load_basic_csv_as_layer_dialog.py
+++ b/svir/dialogs/load_basic_csv_as_layer_dialog.py
@@ -41,11 +41,15 @@ class LoadBasicCsvAsLayerDialog(LoadOutputAsLayerDialog):
         LoadOutputAsLayerDialog.__init__(
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
+        self.create_file_hlayout()
         self.create_file_size_indicator()
         self.setWindowTitle('Load %s from CSV, as layer' % output_type)
         self.populate_out_dep_widgets()
         self.adjustSize()
         self.set_ok_button()
+        self.file_browser_tbn.setEnabled(True)
+        if self.path:
+            self.path_le.setText(self.path)
 
     def set_ok_button(self):
         self.ok_button.setEnabled(bool(self.path))

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -49,9 +49,6 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode, zonal_layer_path)
 
-        # FIXME: add layout only for output types that load from file
-        self.remove_file_hlayout()
-
         self.setWindowTitle('Load scenario damage by asset as layer')
         self.create_load_selected_only_ckb()
         self.load_selected_only_ckb.setEnabled(False)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -45,9 +45,6 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
 
-        # FIXME: add layout only for output types that load from file
-        self.remove_file_hlayout()
-
         self.setWindowTitle(
             'Load ground motion fields from NPZ, as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -45,9 +45,6 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
 
-        # FIXME: add layout only for output types that load from file
-        self.remove_file_hlayout()
-
         self.setWindowTitle(
             'Load hazard curves as layer')
         self.create_num_sites_indicator()

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -45,9 +45,6 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
 
-        # FIXME: add layout only for output types that load from file
-        self.remove_file_hlayout()
-
         self.setWindowTitle(
             'Load hazard maps as layer')
         self.create_load_selected_only_ckb()

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -50,9 +50,6 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode, zonal_layer_path)
 
-        # FIXME: add layout only for output types that load from file
-        self.remove_file_hlayout()
-
         if self.output_type == 'losses_by_asset':
             self.setWindowTitle(
                 'Load losses by asset, aggregated by location, as layer')

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -54,6 +54,7 @@ from qgis.PyQt.QtGui import (QDialogButtonBox,
                              QVBoxLayout,
                              QToolButton,
                              QGroupBox,
+                             QLineEdit,
                              )
 from svir.calculations.process_layer import ProcessLayer
 from svir.calculations.aggregate_loss_by_zone import (
@@ -65,7 +66,6 @@ from svir.utilities.shared import (OQ_CSV_TO_LAYER_TYPES,
                                    )
 from svir.utilities.utils import (get_ui_class,
                                   get_style,
-                                  clear_widgets_from_layout,
                                   log_msg,
                                   tr,
                                   get_file_size,
@@ -100,20 +100,29 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # Disable ok_button until all user options are set
         self.ok_button = self.buttonBox.button(QDialogButtonBox.Ok)
         self.ok_button.setDisabled(True)
-        self.file_browser_tbn.setEnabled(True)
-        if self.path:
-            self.path_le.setText(self.path)
-        clear_widgets_from_layout(self.output_dep_vlayout)
+
+    def create_file_hlayout(self):
+        self.file_hlayout = QHBoxLayout()
+        self.file_lbl = QLabel('File to load')
+        self.file_browser_tbn = QToolButton()
+        self.file_browser_tbn.setText('...')
+        self.file_browser_tbn.clicked.connect(self.on_file_browser_tbn_clicked)
+        self.path_le = QLineEdit()
+        self.path_le.setEnabled(False)
+        self.file_hlayout.addWidget(self.file_lbl)
+        self.file_hlayout.addWidget(self.file_browser_tbn)
+        self.file_hlayout.addWidget(self.path_le)
+        self.vlayout.addLayout(self.file_hlayout)
 
     def create_num_sites_indicator(self):
         self.num_sites_msg = 'Number of sites: %s'
         self.num_sites_lbl = QLabel(self.num_sites_msg % '')
-        self.output_dep_vlayout.addWidget(self.num_sites_lbl)
+        self.vlayout.addWidget(self.num_sites_lbl)
 
     def create_file_size_indicator(self):
         self.file_size_msg = 'File size: %s'
         self.file_size_lbl = QLabel(self.file_size_msg % '')
-        self.output_dep_vlayout.addWidget(self.file_size_lbl)
+        self.vlayout.addWidget(self.file_size_lbl)
 
     def create_rlz_or_stat_selector(self):
         self.rlz_or_stat_lbl = QLabel('Realization')
@@ -121,8 +130,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.rlz_or_stat_cbx.setEnabled(False)
         self.rlz_or_stat_cbx.currentIndexChanged['QString'].connect(
             self.on_rlz_or_stat_changed)
-        self.output_dep_vlayout.addWidget(self.rlz_or_stat_lbl)
-        self.output_dep_vlayout.addWidget(self.rlz_or_stat_cbx)
+        self.vlayout.addWidget(self.rlz_or_stat_lbl)
+        self.vlayout.addWidget(self.rlz_or_stat_cbx)
 
     def create_imt_selector(self):
         self.imt_lbl = QLabel('Intensity Measure Type')
@@ -130,8 +139,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.imt_cbx.setEnabled(False)
         self.imt_cbx.currentIndexChanged['QString'].connect(
             self.on_imt_changed)
-        self.output_dep_vlayout.addWidget(self.imt_lbl)
-        self.output_dep_vlayout.addWidget(self.imt_cbx)
+        self.vlayout.addWidget(self.imt_lbl)
+        self.vlayout.addWidget(self.imt_cbx)
 
     def create_poe_selector(self):
         self.poe_lbl = QLabel('Probability of Exceedance')
@@ -139,8 +148,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.poe_cbx.setEnabled(False)
         self.poe_cbx.currentIndexChanged['QString'].connect(
             self.on_poe_changed)
-        self.output_dep_vlayout.addWidget(self.poe_lbl)
-        self.output_dep_vlayout.addWidget(self.poe_cbx)
+        self.vlayout.addWidget(self.poe_lbl)
+        self.vlayout.addWidget(self.poe_cbx)
 
     def create_loss_type_selector(self):
         self.loss_type_lbl = QLabel('Loss Type')
@@ -148,15 +157,15 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.loss_type_cbx.setEnabled(False)
         self.loss_type_cbx.currentIndexChanged['QString'].connect(
             self.on_loss_type_changed)
-        self.output_dep_vlayout.addWidget(self.loss_type_lbl)
-        self.output_dep_vlayout.addWidget(self.loss_type_cbx)
+        self.vlayout.addWidget(self.loss_type_lbl)
+        self.vlayout.addWidget(self.loss_type_cbx)
 
     def create_eid_selector(self):
         self.eid_lbl = QLabel('Event ID')
         self.eid_sbx = QSpinBox()
         self.eid_sbx.setEnabled(False)
-        self.output_dep_vlayout.addWidget(self.eid_lbl)
-        self.output_dep_vlayout.addWidget(self.eid_sbx)
+        self.vlayout.addWidget(self.eid_lbl)
+        self.vlayout.addWidget(self.eid_sbx)
 
     def create_dmg_state_selector(self):
         self.dmg_state_lbl = QLabel('Damage state')
@@ -164,31 +173,31 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.dmg_state_cbx.setEnabled(False)
         self.dmg_state_cbx.currentIndexChanged['QString'].connect(
             self.on_dmg_state_changed)
-        self.output_dep_vlayout.addWidget(self.dmg_state_lbl)
-        self.output_dep_vlayout.addWidget(self.dmg_state_cbx)
+        self.vlayout.addWidget(self.dmg_state_lbl)
+        self.vlayout.addWidget(self.dmg_state_cbx)
 
     def create_taxonomy_selector(self):
         self.taxonomy_lbl = QLabel('Taxonomy')
         self.taxonomy_cbx = QComboBox()
         self.taxonomy_cbx.setEnabled(False)
-        self.output_dep_vlayout.addWidget(self.taxonomy_lbl)
-        self.output_dep_vlayout.addWidget(self.taxonomy_cbx)
+        self.vlayout.addWidget(self.taxonomy_lbl)
+        self.vlayout.addWidget(self.taxonomy_cbx)
 
     def create_style_by_selector(self):
         self.style_by_lbl = QLabel('Style by')
         self.style_by_cbx = QComboBox()
-        self.output_dep_vlayout.addWidget(self.style_by_lbl)
-        self.output_dep_vlayout.addWidget(self.style_by_cbx)
+        self.vlayout.addWidget(self.style_by_lbl)
+        self.vlayout.addWidget(self.style_by_cbx)
 
     def create_load_selected_only_ckb(self):
         self.load_selected_only_ckb = QCheckBox("Load only the selected items")
         self.load_selected_only_ckb.setChecked(True)
-        self.output_dep_vlayout.addWidget(self.load_selected_only_ckb)
+        self.vlayout.addWidget(self.load_selected_only_ckb)
 
     def create_save_as_shp_ckb(self):
         self.save_as_shp_ckb = QCheckBox("Save the loaded layer as shapefile")
         self.save_as_shp_ckb.setChecked(False)
-        self.output_dep_vlayout.addWidget(self.save_as_shp_ckb)
+        self.vlayout.addWidget(self.save_as_shp_ckb)
 
     def create_zonal_layer_selector(self):
         self.zonal_layer_gbx = QGroupBox()
@@ -211,7 +220,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.zone_id_field_cbx = QComboBox()
         self.zonal_layer_gbx_v_layout.addWidget(self.zone_id_field_lbl)
         self.zonal_layer_gbx_v_layout.addWidget(self.zone_id_field_cbx)
-        self.output_dep_vlayout.addWidget(self.zonal_layer_gbx)
+        self.vlayout.addWidget(self.zonal_layer_gbx)
         self.zonal_layer_tbn.clicked.connect(
             self.on_zonal_layer_tbn_clicked)
         self.zonal_layer_cbx.currentIndexChanged[int].connect(
@@ -604,12 +613,6 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         last_index = cbx.count() - 1
         cbx.setItemData(last_index, zonal_layer_plus_stats.id())
         cbx.setCurrentIndex(last_index)
-
-    # FIXME: create file_hlayout only in widgets that need it
-    def remove_file_hlayout(self):
-        for i in reversed(range(self.file_hlayout.count())):
-            self.file_hlayout.itemAt(i).widget().setParent(None)
-        self.vlayout.removeItem(self.file_hlayout)
 
     def show_file_size(self):
         file_size = get_file_size(self.path)

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -47,6 +47,7 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
             ('Tectonic region type', 'trt'),
             ('Magnitude', 'mag'),
         ])
+        self.create_file_hlayout()
         self.create_file_size_indicator()
         self.create_save_as_shp_ckb()
         self.create_style_by_selector()
@@ -54,6 +55,9 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
         self.setWindowTitle('Load ruptures from CSV, as layer')
         self.adjustSize()
         self.set_ok_button()
+        self.file_browser_tbn.setEnabled(True)
+        if self.path:
+            self.path_le.setText(self.path)
 
     def set_ok_button(self):
         self.ok_button.setEnabled(bool(self.path))

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -46,9 +46,6 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
             self, iface, viewer_dock, session, hostname, calc_id,
             output_type, path, mode)
 
-        # FIXME: add layout only for output types that load from file
-        self.remove_file_hlayout()
-
         self.setWindowTitle(
             'Load uniform hazard spectra as layer')
         self.create_num_sites_indicator()

--- a/svir/ui/ui_load_output_as_layer.ui
+++ b/svir/ui/ui_load_output_as_layer.ui
@@ -15,36 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QVBoxLayout" name="vlayout">
-     <item>
-      <layout class="QHBoxLayout" name="file_hlayout">
-       <item>
-        <widget class="QLabel" name="file_lbl">
-         <property name="text">
-          <string>File to load</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QToolButton" name="file_browser_tbn">
-         <property name="text">
-          <string>...</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="path_le">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="output_dep_vlayout"/>
-     </item>
-    </layout>
+    <layout class="QVBoxLayout" name="vlayout"/>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
...instead of removing it from those that do not need it.
It's logically cleaner like this. From the user's perspective, nothing should have changed.