### PR TITLE
Substitute LayerEditingManager with the native QGIS edit manager

### DIFF
--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -30,6 +30,7 @@ from qgis.core import (QgsVectorLayer,
                        QgsSpatialIndex,
                        QgsFeatureRequest,
                        QGis,
+                       edit,
                        )
 from qgis.analysis import QgsZonalStatistics
 
@@ -40,7 +41,7 @@ import processing
 
 from svir.calculations.process_layer import ProcessLayer
 
-from svir.utilities.utils import (LayerEditingManager,
+from svir.utilities.utils import (
                                   tr,
                                   TraceTimeManager,
                                   clear_progress_message_bar,
@@ -163,9 +164,7 @@ def calculate_zonal_stats(loss_layer,
                 # we get a dict, from which we find the actual attribute name
                 # in the only dict value
                 zone_id_in_zones_attr_name = attr_dict.values()[0]
-                with LayerEditingManager(zonal_layer,
-                                         'Copy feature id into the new field',
-                                         DEBUG):
+                with edit(zonal_layer):
                     unique_id_idx = zonal_layer.fieldNameIndex(
                             zone_id_in_zones_attr_name)
                     for feat in zonal_layer.getFeatures():
@@ -325,9 +324,7 @@ def _add_zone_id_to_points_internal(iface, loss_layer, zonal_layer,
             progress.setValue(progress_perc)
             spatial_index.insertFeature(loss_feature)
     clear_progress_message_bar(iface.messageBar(), msg_bar_item)
-    with LayerEditingManager(loss_layer_plus_zones,
-                             tr("Label each point with the zone id"),
-                             DEBUG):
+    with edit(loss_layer_plus_zones):
         # to show the overall progress, cycling through zones
         tot_zones = zonal_layer.featureCount()
         msg = tr("Step 3 of 3: labeling points by zone id...")
@@ -512,9 +509,7 @@ def calculate_vector_stats_aggregating_by_zone_id(
         tot_zones = zonal_layer.featureCount()
         msg_bar_item, progress = create_progress_message_bar(
                 iface.messageBar(), msg)
-        with LayerEditingManager(zonal_layer,
-                                 msg,
-                                 DEBUG):
+        with edit(zonal_layer):
             if extra:
                 count_idx = zonal_layer.fieldNameIndex(
                         loss_attrs_dict['count'])
@@ -638,7 +633,7 @@ def purge_zones_without_loss_points(
     msg_bar_item, progress = create_progress_message_bar(
             iface.messageBar(), msg)
 
-    with LayerEditingManager(zonal_layer, msg, DEBUG):
+    with edit(zonal_layer):
         for current_zone, zone_feature in enumerate(zonal_layer.getFeatures()):
             progress_percent = current_zone / float(tot_zones) * 100
             progress.setValue(progress_percent)

--- a/svir/calculations/calculate_utils.py
+++ b/svir/calculations/calculate_utils.py
@@ -23,7 +23,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 from copy import deepcopy
-from qgis.core import QgsField, QgsExpression
+from qgis.core import QgsField, QgsExpression, edit
 
 from qgis.PyQt.QtCore import QVariant, QPyNullVariant
 
@@ -36,7 +36,7 @@ from svir.utilities.shared import (DOUBLE_FIELD_TYPE_NAME,
                                    IGNORING_WEIGHT_OPERATORS,
                                    DiscardedFeature)
 from svir.calculations.process_layer import ProcessLayer
-from svir.utilities.utils import LayerEditingManager, log_msg
+from svir.utilities.utils import log_msg
 
 
 class InvalidNode(Exception):
@@ -226,9 +226,7 @@ def calculate_node(
             # attempt to retrieve a formula from the description and to
             # calculate the field values based on that formula
             expression.prepare(layer.fields())
-            with LayerEditingManager(layer,
-                                     'Calculating %s' % node_attr_name,
-                                     DEBUG):
+            with edit(layer):
                 for feat in layer.getFeatures():
                     value = expression.evaluate(feat)
                     if value == QPyNullVariant(float):
@@ -240,9 +238,7 @@ def calculate_node(
             return discarded_feats
     # the existance of children should already be checked
     children = node['children']
-    with LayerEditingManager(layer,
-                             'Calculating %s' % node_attr_name,
-                             DEBUG):
+    with edit(layer):
         for feat in layer.getFeatures():
             # If a feature contains any NULL value, discard_feat will
             # be set to True and the corresponding node value will be

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -24,16 +24,14 @@
 
 import numpy
 import collections
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, edit
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (WaitCursorManager,
-                                  LayerEditingManager,
                                   log_msg,
                                   extract_npz,
                                   get_loss_types,
                                   )
-from svir.utilities.shared import DEBUG
 
 
 class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
@@ -136,7 +134,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         return field_names
 
     def add_field_to_layer(self, field_name):
-        # NOTE: add_numeric_attribute uses LayerEditingManager
+        # NOTE: add_numeric_attribute uses the native qgis editing manager
         added_field_name = add_numeric_attribute(
             field_name, self.layer)
         return added_field_name
@@ -146,7 +144,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         loss_type = kwargs['loss_type']
         taxonomy = kwargs['taxonomy']
         dmg_state = kwargs['dmg_state']
-        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+        with edit(self.layer):
             feats = []
             grouped_by_site = self.group_by_site(
                 self.npz_file, rlz_or_stat, loss_type, dmg_state, taxonomy)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -22,15 +22,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, edit
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (WaitCursorManager,
-                                  LayerEditingManager,
                                   log_msg,
                                   extract_npz,
                                   )
-from svir.utilities.shared import DEBUG
 
 
 class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
@@ -121,7 +119,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         return added_field_name
 
     def read_npz_into_layer(self, field_names, **kwargs):
-        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+        with edit(self.layer):
             feats = []
             fields = self.layer.pendingFields()
             layer_field_names = [field.name() for field in fields]

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -22,15 +22,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, edit
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
-from svir.utilities.utils import (LayerEditingManager,
+from svir.utilities.utils import (
                                   log_msg,
                                   WaitCursorManager,
                                   extract_npz,
                                   )
-from svir.utilities.shared import DEBUG
 
 
 class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
@@ -92,7 +91,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         return added_field_name
 
     def read_npz_into_layer(self, field_names, **kwargs):
-        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+        with edit(self.layer):
             lons = self.npz_file['all']['lon']
             lats = self.npz_file['all']['lat']
             feats = []

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -22,15 +22,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, edit
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (WaitCursorManager,
-                                  LayerEditingManager,
                                   log_msg,
                                   extract_npz,
                                   )
-from svir.utilities.shared import DEBUG
 
 
 class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
@@ -128,7 +126,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
 
     def add_field_to_layer(self, field_name):
         try:
-            # NOTE: add_numeric_attribute uses LayerEditingManager
+            # NOTE: add_numeric_attribute uses the native qgis editing manager
             added_field_name = add_numeric_attribute(field_name, self.layer)
         except TypeError as exc:
             log_msg(str(exc), level='C', message_bar=self.iface.messageBar())
@@ -136,7 +134,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         return added_field_name
 
     def read_npz_into_layer(self, field_names, **kwargs):
-        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+        with edit(self.layer):
             lons = self.npz_file['all']['lon']
             lats = self.npz_file['all']['lat']
             feats = []

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -24,16 +24,14 @@
 
 import numpy
 import collections
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, edit
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (WaitCursorManager,
-                                  LayerEditingManager,
                                   log_msg,
                                   extract_npz,
                                   get_loss_types,
                                   )
-from svir.utilities.shared import DEBUG
 
 
 class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
@@ -130,7 +128,7 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         return field_names
 
     def add_field_to_layer(self, field_name):
-        # NOTE: add_numeric_attribute uses LayerEditingManager
+        # NOTE: add_numeric_attribute uses the native qgis editing manager
         added_field_name = add_numeric_attribute(
             field_name, self.layer)
         return added_field_name
@@ -139,7 +137,7 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         rlz_or_stat = kwargs['rlz_or_stat']
         loss_type = kwargs['loss_type']
         taxonomy = kwargs['taxonomy']
-        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+        with edit(self.layer):
             feats = []
             grouped_by_site = self.group_by_site(
                 self.npz_file, rlz_or_stat, loss_type, taxonomy)

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -22,15 +22,14 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, edit
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
-from svir.utilities.utils import (LayerEditingManager,
+from svir.utilities.utils import (
                                   log_msg,
                                   WaitCursorManager,
                                   extract_npz,
                                   )
-from svir.utilities.shared import DEBUG
 
 
 class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
@@ -107,14 +106,14 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         return field_names
 
     def add_field_to_layer(self, field_name):
-        # NOTE: add_numeric_attribute uses LayerEditingManager
+        # NOTE: add_numeric_attribute uses the native qgis editing manager
         added_field_name = add_numeric_attribute(
             field_name, self.layer)
         return added_field_name
 
     def read_npz_into_layer(self, field_names, **kwargs):
         poe = kwargs['poe']
-        with LayerEditingManager(self.layer, 'Reading npz', DEBUG):
+        with edit(self.layer):
             lons = self.npz_file['all']['lon']
             lats = self.npz_file['all']['lat']
             feats = []

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -622,36 +622,10 @@ class TraceTimeManager(object):
             log_msg(self.message)
             self.t_start = time()
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         if self.debug:
             self.t_stop = time()
             log_msg("Completed in %f" % (self.t_stop - self.t_start))
-
-
-class LayerEditingManager(object):
-    """
-    Wrapper to be used to edit a layer,
-    that executes startEditing and commitChanges
-
-    :param layer: the layer that is being edited
-    :param message: description of the task that is being performed
-    :param debug: if False, nothing will be logged
-    """
-    def __init__(self, layer, message, debug=False):
-        self.layer = layer
-        self.message = message
-        self.debug = debug
-
-    def __enter__(self):
-        self.layer.startEditing()
-        if self.debug:
-            log_msg("BEGIN %s" % self.message)
-
-    def __exit__(self, type, value, traceback):
-        self.layer.commitChanges()
-        self.layer.updateExtents()
-        if self.debug:
-            log_msg("END %s" % self.message)
 
 
 class WaitCursorManager(object):
@@ -674,7 +648,7 @@ class WaitCursorManager(object):
             QApplication.processEvents()
         QApplication.setOverrideCursor(Qt.WaitCursor)
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):
         QApplication.restoreOverrideCursor()
         if self.has_message:
             self.message_bar.popWidget(self.message)


### PR DESCRIPTION
Since QGIS 2.12, a context manager to edit a layer was added: http://www.opengis.ch/2015/08/12/with-edit-layer/
I was using a very similar context manager (LayerEditingManager) that also optionally logged messages like "BEGIN doing something... END doing something" but that missed doing a roll-back in case of failure. With this PR I am removing my own context manager, replacing all occurrences with the QGIS native one.