### PR TITLE
Add dmg_by_event and losses_by_event to outputs loaded from basic csv

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -106,6 +106,8 @@ OUTPUT_TYPE_LOADERS = {
     'ruptures': LoadRupturesAsLayerDialog,
     'realizations': LoadBasicCsvAsLayerDialog,
     'sourcegroups': LoadBasicCsvAsLayerDialog,
+    'dmg_by_event': LoadBasicCsvAsLayerDialog,
+    'losses_by_event': LoadBasicCsvAsLayerDialog,
     'dmg_by_asset': LoadDmgByAssetAsLayerDialog,
     'gmf_data': LoadGmfDataAsLayerDialog,
     'hmaps': LoadHazardMapsAsLayerDialog,

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,7 @@ email=staff.it@globalquakemodel.org
 changelog=
     3.1.1
     * When loading Ground Motion Fields for scenario calculations, the names of the GMPEs are displayed instead of the realization names
+    * Added loaders for dmg_by_event and losses_by_event, from csv
     3.1.0
     * Ruptures imported from the OQ-Engine can be styled automatically by tectonic region type or by magnitude
     * Improved visualization of aggregate outputs in the Data Viewer

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -215,7 +215,8 @@ RECOVERY_DEFAULTS['n_recovery_based_dmg_states'] = len(
 # occurs given loss-based damage state i
 
 
-OQ_BASIC_CSV_TO_LAYER_TYPES = set(['realizations', 'sourcegroups'])
+OQ_BASIC_CSV_TO_LAYER_TYPES = set([
+    'realizations', 'sourcegroups', 'dmg_by_event', 'losses_by_event'])
 OQ_COMPLEX_CSV_TO_LAYER_TYPES = set(['ruptures'])
 OQ_CSV_TO_LAYER_TYPES = (
     OQ_BASIC_CSV_TO_LAYER_TYPES | OQ_COMPLEX_CSV_TO_LAYER_TYPES)


### PR DESCRIPTION
Companion of https://github.com/gem/oq-engine/pull/3632

This is good as long as tables are small enough. Otherwise, we need to use a more efficient approach, leveraging the OQ-Engine 'extract' api, perhaps also checking the size of the output before attempting to load it into a QGIS layer.

NOTE: It does not work in case there are multiple realizations ==> multiple csv files zipped together