### PR TITLE
Avoid useless downloading of npz (extracted anyway afterwards)

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -333,7 +333,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     def get_row_by_calc_id(self, calc_id):
         # find QTableItem corresponding to that calc_id
         calc_id_col_idx = 1
-        for row in xrange(self.calc_list_tbl.rowCount()):
+        for row in range(self.calc_list_tbl.rowCount()):
             item_calc_id = self.calc_list_tbl.item(row, calc_id_col_idx)
             if int(item_calc_id.text()) == calc_id:
                 return row
@@ -757,14 +757,16 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))
         elif action == 'Load as layer':
-            dest_folder = tempfile.gettempdir()
-            if outtype in ('npz', 'csv'):
+            filepath = None
+            if output_type not in OUTPUT_TYPE_LOADERS:
+                raise NotImplementedError(output_type)
+            if outtype == 'csv':
+                dest_folder = tempfile.gettempdir()
                 filepath = self.download_output(
                     output_id, outtype, dest_folder)
                 if not filepath:
                     return
-                if output_type not in OUTPUT_TYPE_LOADERS:
-                    raise NotImplementedError(output_type)
+            if outtype in ('npz', 'csv'):
                 dlg = OUTPUT_TYPE_LOADERS[output_type](
                     self.iface, self.viewer_dock,
                     self.session, self.hostname, self.current_calc_id,

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -26,6 +26,8 @@ changelog=
     3.1.2
     * When loading OQ-Engine outputs that can be aggregated by zone, if the option to run the aggregation is checked, the ok button is
       disabled until a valid zonal layer is loaded
+    * Fixed a bug in the workflow loading outputs from the OQ-Engine (npz files were unnecessarily downloaded, before extracting the
+      same data through the "extract API")
     3.1.1
     * When loading Ground Motion Fields for scenario calculations, the names of the GMPEs are displayed instead of the realization names
     * When loading a OQ-Engine output as layer, the engine version is saved as a custom property of the layer


### PR DESCRIPTION
This should reduce the loading time by about one half. This can be crucial, especially for big outputs loaded from a cluster. I should make a new release with this fix, as soon as possible.
This does NOT reduce the duration of integration tests, because in the tests I was already calling the loaders (that perform the extract) without downloading the npz in advance.