### PR TITLE
At the end of integration tests, list outputs that took long to load

### DIFF
--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -32,6 +32,7 @@ import json
 import copy
 import csv
 import time
+import operator
 from mock import Mock
 
 from qgis.PyQt.QtWidgets import QAction
@@ -470,7 +471,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         if self.time_consuming_outputs:
             print('\n\nSome loaders took longer than %s seconds:' %
                   LONG_LOADING_TIME)
-            for output in self.time_consuming_outputs:
+            for output in sorted(self.time_consuming_outputs,
+                                 key=operator.itemgetter('loading_time'),
+                                 reverse=True):
                 print('\t%s' % output)
         if self.not_implemented_loaders:
             # sanity check


### PR DESCRIPTION
Setting a threshold of 10 seconds (listing outputs that took more than 10 seconds to load), the outcome is the following:
```python
Some loaders took longer than 10 seconds:
        {'calc_id': 14, 'calc_description': 'Classical PSHA with Characteristic Fault Source defined by Complex Fault Geometry.', 'output_type': 'hcurves', 'loading_time': 103.69501376152039}
        {'calc_id': 13, 'calc_description': 'Example Classical PSHA using Characteristic Fault Source with Simple Fault Geometry', 'output_type': 'hcurves', 'loading_time': 97.49299550056458}
        {'calc_id': 14, 'calc_description': 'Classical PSHA with Characteristic Fault Source defined by Complex Fault Geometry.', 'output_type': 'uhs', 'loading_time': 71.41788148880005}
        {'calc_id': 13, 'calc_description': 'Example Classical PSHA using Characteristic Fault Source with Simple Fault Geometry', 'output_type': 'uhs', 'loading_time': 70.58794021606445}
        {'calc_id': 7, 'calc_description': 'Stochastic Event-Based Hazard Demo (Nepal)', 'output_type': 'hcurves', 'loading_time': 35.883588790893555}
        {'calc_id': 12, 'calc_description': 'Classical PSHA with Characteristic Fault Source defined as sequence of planar fault segments', 'output_type': 'hcurves', 'loading_time': 19.564118146896362}
        {'calc_id': 3, 'calc_description': 'Classical PSHA Demo (Nepal)', 'output_type': 'hcurves', 'loading_time': 12.6327383518219}
        {'calc_id': 15, 'calc_description': 'Classical PSHA with Complex Fault Source', 'output_type': 'hcurves', 'loading_time': 12.465590000152588}
        {'calc_id': 24, 'calc_description': 'Classical PSHA with Simple Fault Source', 'output_type': 'hcurves', 'loading_time': 12.104838132858276}
        {'calc_id': 5, 'calc_description': 'Classical PSHA Demo (Nepal)', 'output_type': 'hcurves', 'loading_time': 10.937503337860107}
        {'calc_id': 1, 'calc_description': 'Classical BCR Demo - Hazard (Nepal)', 'output_type': 'hcurves', 'loading_time': 10.53511095046997}
```

NB: we should reduce the size at least of demos 14, 13, 12 and 7