### PR TITLE
Add possibility to load hmaps in one layer per realization (or per statistic)

### DIFF
--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -24,6 +24,7 @@
 
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
+from qgis.PyQt.QtCore import Qt
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import WaitCursorManager, log_msg
@@ -46,16 +47,24 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         self.setWindowTitle(
             'Load hazard maps as layer')
         self.create_num_sites_indicator()
+        self.create_load_multicol_ckb()
         self.create_rlz_or_stat_selector(all_ckb=True)
         self.create_imt_selector(all_ckb=True)
         self.create_poe_selector(all_ckb=True)
         self.create_show_return_time_ckb()
+
+        self.load_multicol_ckb.stateChanged[int].connect(
+            self.on_load_multicol_ckb_stateChanged)
 
         self.extract_npz_task = ExtractNpzTask(
             'Extract hazard maps', QgsTask.CanCancel, self.session,
             self.hostname, self.calc_id, self.output_type, self.finalize_init,
             self.on_extract_error)
         QgsApplication.taskManager().addTask(self.extract_npz_task)
+
+    def on_load_multicol_ckb_stateChanged(self, state):
+        if state == Qt.Checked:
+            self.show_return_time_chk.setChecked(False)
 
     def set_ok_button(self):
         self.ok_button.setEnabled(self.poe_cbx.currentIndex() != -1)
@@ -105,11 +114,18 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         self.set_ok_button()
 
     def build_layer_name(self, rlz_or_stat=None, **kwargs):
-        imt = kwargs['imt']
-        poe = kwargs['poe']
+        if self.load_multicol_ckb.isChecked():
+            imt = self.imt_cbx.currentText()
+            poe = self.poe_cbx.currentText()
+        else:
+            imt = kwargs['imt']
+            poe = kwargs['poe']
         self.default_field_name = '%s-%s' % (imt, poe)
         investigation_time = self.get_investigation_time()
-        if self.show_return_time_chk.isChecked():
+        if self.load_multicol_ckb.isChecked():
+            layer_name = "hazard_map_%s_%sy" % (
+                rlz_or_stat, investigation_time)
+        elif self.show_return_time_chk.isChecked():
             return_time = int(float(investigation_time) / float(poe))
             layer_name = "hmap_%s_%s_%syr" % (
                 rlz_or_stat, imt, return_time)
@@ -119,9 +135,12 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         return layer_name
 
     def get_field_names(self, **kwargs):
-        imt = kwargs['imt']
-        poe = kwargs['poe']
-        field_names = ['%s-%s' % (imt, poe)]
+        if self.load_multicol_ckb.isChecked():
+            field_names = self.dataset.dtype.names
+        else:
+            imt = kwargs['imt']
+            poe = kwargs['poe']
+            field_names = ['%s-%s' % (imt, poe)]
         return field_names
 
     def add_field_to_layer(self, field_name):
@@ -160,18 +179,26 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             if (not self.load_all_rlzs_or_stats_chk.isChecked()
                     and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):
                 continue
-            for imt in self.imts:
-                if (not self.load_all_imts_chk.isChecked()
-                        and imt != self.imt_cbx.currentText()):
-                    continue
-                for poe in self.imts[imt]:
-                    if (not self.load_all_poes_chk.isChecked()
-                            and poe != self.poe_cbx.currentText()):
+            if self.load_multicol_ckb.isChecked():
+                with WaitCursorManager(
+                        'Creating layer for "%s"...' % rlz_or_stat,
+                        self.iface.messageBar()):
+                    self.build_layer(rlz_or_stat)
+                    self.style_maps()
+            else:
+                for imt in self.imts:
+                    if (not self.load_all_imts_chk.isChecked()
+                            and imt != self.imt_cbx.currentText()):
                         continue
-                    with WaitCursorManager(
-                        'Creating layer for "%s, %s, %s"...' % (
-                            rlz_or_stat, imt, poe), self.iface.messageBar()):
-                        self.build_layer(rlz_or_stat, imt=imt, poe=poe)
-                        self.style_maps()
+                    for poe in self.imts[imt]:
+                        if (not self.load_all_poes_chk.isChecked()
+                                and poe != self.poe_cbx.currentText()):
+                            continue
+                        with WaitCursorManager(
+                                'Creating layer for "%s, %s, %s"...' % (
+                                    rlz_or_stat, imt, poe),
+                                self.iface.messageBar()):
+                            self.build_layer(rlz_or_stat, imt=imt, poe=poe)
+                            self.style_maps()
         if self.npz_file is not None:
             self.npz_file.close()

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -65,6 +65,21 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
     def on_load_multicol_ckb_stateChanged(self, state):
         if state == Qt.Checked:
             self.show_return_time_chk.setChecked(False)
+            self.show_return_time_chk.setEnabled(False)
+            self.load_all_poes_chk.setChecked(True)
+            self.load_all_poes_chk.setEnabled(False)
+            self.poe_cbx.setEnabled(True)
+            self.load_all_imts_chk.setChecked(True)
+            self.load_all_imts_chk.setEnabled(False)
+            self.imt_cbx.setEnabled(True)
+        else:
+            self.show_return_time_chk.setEnabled(True)
+            self.load_all_poes_chk.setChecked(False)
+            self.load_all_poes_chk.setEnabled(True)
+            self.poe_cbx.setEnabled(True)
+            self.load_all_imts_chk.setChecked(False)
+            self.load_all_imts_chk.setEnabled(True)
+            self.imt_cbx.setEnabled(True)
 
     def set_ok_button(self):
         self.ok_button.setEnabled(self.poe_cbx.currentIndex() != -1)

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -152,6 +152,11 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.file_size_lbl = QLabel(self.file_size_msg % '')
         self.vlayout.addWidget(self.file_size_lbl)
 
+    def create_load_multicol_ckb(self):
+        self.load_multicol_ckb = QCheckBox(
+            'Load one layer per realization or statistic')
+        self.vlayout.addWidget(self.load_multicol_ckb)
+
     def create_rlz_or_stat_selector(self, all_ckb=False, label='Realization'):
         self.rlz_or_stat_lbl = QLabel(label)
         self.rlz_or_stat_cbx = QComboBox()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.2.4
+version=3.2.5
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.2.5
+    * Hazard maps can be loaded as one layer per realization/statistic or as multiple layers, per each combination of realization/statistic-imt-poe
     3.2.4
     * Added loaders for dmg_by_event and losses_by_event, from csv (disabled for event-based calculations)
     * Outputs of a selected oq-engine calculation are sorted by name in alphabetical order


### PR DESCRIPTION
After https://github.com/gem/oq-irmt-qgis/pull/488 and https://github.com/gem/oq-irmt-qgis/pull/489, the user became unable to load hmaps altogether in a single layer (one layer per realization or statistic).
In this PR I am adding another checkbox, to follow the original workflow. Therefore, the user will be able to choose the preferred approach.