### PR TITLE
Loading single-layer hmaps, specify in labels what's chosen for styling

### DIFF
--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -69,17 +69,25 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             self.load_all_poes_chk.setChecked(True)
             self.load_all_poes_chk.setEnabled(False)
             self.poe_cbx.setEnabled(True)
+            self.poe_lbl.setText(
+                'Probability of Exceedance (used for styling)')
             self.load_all_imts_chk.setChecked(True)
             self.load_all_imts_chk.setEnabled(False)
             self.imt_cbx.setEnabled(True)
+            self.imt_lbl.setText(
+                'Intensity Measure Type (used for styling)')
         else:
             self.show_return_time_chk.setEnabled(True)
             self.load_all_poes_chk.setChecked(False)
             self.load_all_poes_chk.setEnabled(True)
             self.poe_cbx.setEnabled(True)
+            self.poe_lbl.setText(
+                'Probability of Exceedance')
             self.load_all_imts_chk.setChecked(False)
             self.load_all_imts_chk.setEnabled(True)
             self.imt_cbx.setEnabled(True)
+            self.imt_lbl.setText(
+                'Intensity Measure Type')
 
     def set_ok_button(self):
         self.ok_button.setEnabled(self.poe_cbx.currentIndex() != -1)


### PR DESCRIPTION
This is just a quick fix to clarify something in the GUI, that was a little confusing.
If you choose to download hazard maps using one multi-column layer per realization, IMT and POE can still be selected, and the chosen ones are used to style the layer automatically. In this case, I am adding "used for styling" to the labels on top of the corresponding drop-down menus. This way it becomes clearer that, whatever you choose, all the IMTs and all the POEs are loaded in the layer, but the default styling is done using the chosen ones.