### PR TITLE
Cast IMLs to float if possible (fix plotting of IMT=PGV)

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1088,6 +1088,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         if (field_name.split('_')[0]
                             == selected_rlzs_or_stats[0])
                         and field_name.split('_')[1] == imt]
+                try:
+                    imls = [float(iml) for iml in imls]
+                except ValueError:
+                    log_msg('Intensity measure levels are not numeric',
+                            level='W', message_bar=self.iface.messageBar())
                 self.current_abscissa = imls
             elif self.output_type == 'uhs':
                 err_msg = ("The selected layer does not contain uniform"

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,7 @@ email=staff.it@globalquakemodel.org
 changelog=
     3.2.5
     * Hazard maps can be loaded as one layer per realization/statistic or as multiple layers, per each combination of realization/statistic-imt-poe
+    * Intensity measure levels are casted to float when possible, fixing a plotting issue in hazard curves with IMT=PGV
     3.2.4
     * Added loaders for dmg_by_event and losses_by_event, from csv (disabled for event-based calculations)
     * Outputs of a selected oq-engine calculation are sorted by name in alphabetical order


### PR DESCRIPTION
Without casting to float, plots looked fine for almost every IMTs (luckily), except PGV (see figure).
![screenshot from 2018-08-20 14-34-42](https://user-images.githubusercontent.com/350930/44344032-e4297180-a48f-11e8-9ef1-5660af560987.png). This fixes plots for every IMTs.

In the rare case of Modified Mercalli Intensity Scale, in which IMLs are not numeric, the original values will be kept. The OQ-Engine demos do not include any example using that scale.