### PR TITLE
Better handling of the connection to the oq-engine server

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -934,4 +934,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
 
     def reject(self):
         self.stop_polling()
-        super(DriveOqEngineServerDialog, self).reject()
+        if self.params_dlg is not None:
+            self.params_dlg.reject()
+        if self.console_dlg is not None:
+            self.console_dlg.reject()
+        if self.full_report_dlg is not None:
+            self.full_report_dlg.reject()
+        for dlg in self.open_output_dlgs:
+            dlg.reject()
+        super().reject()

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -156,12 +156,14 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.layout().insertWidget(0, self.message_bar)
 
         self.engine_version = None
+        self.num_login_attempts = 0
         self.attempt_login()
 
         self.download_tasks = {}
         self.open_output_dlgs = {}
 
     def attempt_login(self):
+        self.num_login_attempts += 1
         try:
             self.login()
         except HANDLED_EXCEPTIONS as exc:
@@ -173,6 +175,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.setWindowTitle(
                     'Drive the OpenQuake Engine v%s (%s)' % (
                         self.engine_version, self.hostname))
+                self.num_login_attempts = 0
 
     def check_engine_compatibility(self):
         engine_version = self.get_engine_version()
@@ -883,6 +886,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.run_calc()
 
     def _handle_exception(self, exc):
+        # in case of disconnection, try 3 times to reconnect, before displaying
+        # an error
+        if isinstance(exc, ConnectionError):
+            if self.num_login_attempts < 3:
+                self.attempt_login()
+                return
         if isinstance(exc, SSLError):
             err_msg = '; '.join(exc.message.message.strerror.message[0])
             err_msg += ' (you could try prepending http:// or https://)'

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -426,7 +426,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                        ' Server.') % self.output_type
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
             else:
-                return investigation_time
+                # We must cast to 'str' to keep numerical padding
+                # after saving the project
+                return str(investigation_time)
         else:
             # some outputs do not need the investigation time
             return None

--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -421,7 +421,7 @@ class SettingsDialog(QDialog, FORM_CLASS):
         """
         self.save_state()
         if self.irmt_main is not None:
-            self.irmt_main.reset_engine_login()
+            self.irmt_main.reset_drive_oq_engine_server_dlg()
         current_engine_hostname = QSettings().value('irmt/engine_hostname')
         # in case the engine hostname was modified, the embedded web apps that
         # were using the old hostname must be refreshed using the new one

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -367,7 +367,7 @@ class Irmt(object):
         return self.drive_oq_engine_server_dlg.on_same_fs(
             checksum_file_path, local_checksum)
 
-    def reset_engine_login(self):
+    def reset_drive_oq_engine_server_dlg(self):
         if self.drive_oq_engine_server_dlg is not None:
             was_dlg_visible = self.drive_oq_engine_server_dlg.isVisible()
             self.drive_oq_engine_server_dlg.reject()

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -369,10 +369,12 @@ class Irmt(object):
 
     def reset_engine_login(self):
         if self.drive_oq_engine_server_dlg is not None:
-            self.drive_oq_engine_server_dlg.current_calc_id = None
-            self.drive_oq_engine_server_dlg.pointed_calc_id = None
-            self.drive_oq_engine_server_dlg.is_logged_in = False
-            self.drive_oq_engine_server_dlg.clear_output_list()
+            was_dlg_visible = self.drive_oq_engine_server_dlg.isVisible()
+            self.drive_oq_engine_server_dlg.reject()
+            self.drive_oq_engine_server_dlg = DriveOqEngineServerDialog(
+                self.iface, self.viewer_dock)
+            if was_dlg_visible:
+                self.drive_oq_engine_server_dlg.show()
 
     def show_manual(self):
         base_url = os.path.abspath(os.path.join(

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.2.8
+version=3.2.9
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,9 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.2.9
+    * When saving plugin settings, any dialog driving the oq-engine is reset
+    * When the connection with the oq-engine server is lost, the plugin attempts to reconnect 3 times before displaying an error
     3.2.8
     * Ported to qgis3 the conversion of layer style to the format accepted by Geoserver
     * Fixed a bug loading hazard maps loading one layer per realization or statistic


### PR DESCRIPTION
1. When saving plugin settings, any dialog driving the oq-engine is reset, thus avoiding issues with old dialogs pointing to resources that are on a server that is no longer available (fixes https://github.com/gem/oq-irmt-qgis/issues/510)

2. When the connection with the oq-engine server is lost, the plugin attempts to reconnect 3 times before displaying an error and loading the settings dialog (fixes https://github.com/gem/oq-irmt-qgis/issues/503)

