### PR TITLE
Add instructions working around a bug in matplotlib 3.0.0 for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ On macOS:
 ```bash
 $ sudo pip3.6 install matplotlib scipy
 ```
-NOTE: matplotlib v3.0.0 on macOS has a known bug importing pyplot.
+
+NOTE: matplotlib v3.0.0 on macOS and on Microsoft Windows has a known bug importing pyplot.
 In order to fix that issue, an earlier version of matplotlib can be installed:
 ```bash
 $ sudo pip3.6 install matplotlib==2.2.3

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ On macOS:
 ```bash
 $ sudo pip3.6 install matplotlib scipy
 ```
+NOTE: matplotlib v3.0.0 on macOS has a known bug importing pyplot.
+In order to fix that issue, an earlier version of matplotlib can be installed:
+```bash
+$ sudo pip3.6 install matplotlib==2.2.3
+```
 
 On Ubuntu (Debian and similar):
 

--- a/svir/help/source/00_installation.rst
+++ b/svir/help/source/00_installation.rst
@@ -20,7 +20,7 @@ On macOS:
     $ sudo pip3.6 install matplotlib scipy
 
 .. warning::
-    matplotlib v3.0.0 on macOS has a known bug importing pyplot.
+    matplotlib v3.0.0 on macOS and on Microsoft Windows has a known bug importing pyplot.
     In order to fix that issue, an earlier version of matplotlib can be installed:
     $ sudo pip3.6 install matplotlib==2.2.3
 

--- a/svir/help/source/00_installation.rst
+++ b/svir/help/source/00_installation.rst
@@ -19,6 +19,11 @@ On macOS:
 
     $ sudo pip3.6 install matplotlib scipy
 
+.. warning::
+    matplotlib v3.0.0 on macOS has a known bug importing pyplot.
+    In order to fix that issue, an earlier version of matplotlib can be installed:
+    $ sudo pip3.6 install matplotlib==2.2.3
+
 On Ubuntu (Debian and similar):
 
 .. code-block:: bash

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.2.10
+version=3.2.11
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.2.11
+    * Added instructions about how to workaround a bug that occurs on macOS while importing matplotlib.pyplot on matplotlib v3.0.0
     3.2.10
     * Added the possibility to 'Abort' an OQ-Engine calculation
     3.2.9


### PR DESCRIPTION
Actually, with @raoanirudh, we tested the workaround on matplotlib v2.2.2, but I believe also v2.2.3 would work fine as well. We should double-check it though.