### PR TITLE
Fix aggregate avg_losses-stats

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -685,11 +685,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 npz = extract_npz(session, hostname, calc_id, to_extract,
                                   message_bar=self.iface.messageBar())
             # stats might be unavailable in case of a single realization
-            if npz['stats'] == numpy.array(None):
+            if len(npz['stats']) == 0:
                 # NOTE: writing 'mean' instead of 'rlz-0' would be equivalent
                 self.stats = ['rlz-0']
             else:
-                self.stats = str(npz['stats'], 'utf8').split()
+                self.stats = [str(stat, 'utf8') for stat in npz['stats']]
 
         self.tag_names_multiselect.set_unselected_items(list(self.tags.keys()))
         self.tag_names_multiselect.set_selected_items([])

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.2.12
+version=3.3.0
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.3.0
+    * Fixed loader for aggregated Average Asset Losses Statistics OQ-Engine output
     3.2.12
     * More stable connection with the OQ-Engine server, preventing issues while reading the console log of a calculation
     3.2.11
@@ -136,7 +138,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=False
+experimental=True
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False


### PR DESCRIPTION
It looks like the format of the extracted data changed engine-side. With these little changes, it seems to work properly.