### PR TITLE
Mock messageBar in tests, to avoid warning about a missing svg file

### DIFF
--- a/svir/test/qgis_interface.py
+++ b/svir/test/qgis_interface.py
@@ -4,6 +4,7 @@
 """Fake QGIS Interface."""
 
 import logging
+from unittest import mock
 
 from qgis.PyQt.QtCore import QObject, pyqtSlot, pyqtSignal
 from qgis.core import QgsMapLayer, QgsProject
@@ -285,4 +286,10 @@ class QgisInterface(QObject):
         :returns: A QGIS message bar instance
         :rtype: QgsMessageBar
         """
-        return self.message_bar
+        # NOTE: if we show an actual message bar instead of using a mock, it
+        #       spams the log with:
+        #           "qt.svg: Cannot open file
+        #           ':/images/themes/default/mIconTimerPause.svg',
+        #           because: No such file or directory"
+        # return self.message_bar
+        return mock.Mock()


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/527

While running tests, showing an actual message bar is useless, so we can use a mock as a workaround to avoid that annoying warning. I couldn't find any proper way to fix the fact that qgis is not finding that svg.
Even using a mock instead of the actual message bar, a single warning still appears on top of the log, but it's unobtrusive (the other dozens of obtrusive occurrences disappeared).