### PR TITLE
Fix call to the extract api and log as info both url and params

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -25,6 +25,8 @@ email=staff.it@globalquakemodel.org
 changelog=
     3.3.0
     * Fixed loader for aggregated Average Asset Losses Statistics OQ-Engine output
+    * All calls to the OQ-Engine "extract" API are logged
+    * Fixed a bug that caused the log verbosity to be always set to "warning", instead of reading it correctly from user settings 
     3.2.12
     * More stable connection with the OQ-Engine server, preventing issues while reading the console log of a calculation
     3.2.11

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -82,8 +82,8 @@ def get_irmt_version():
     return _IRMT_VERSION
 
 
-def log_msg(message, tag='GEM OpenQuake plugin', level='I', message_bar=None,
-            duration=None, exception=None):
+def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
+            message_bar=None, duration=None, exception=None):
     """
     Add a message to the QGIS message log. If a messageBar is provided,
     the same message will be displayed also in the messageBar. In the latter
@@ -123,14 +123,17 @@ def log_msg(message, tag='GEM OpenQuake plugin', level='I', message_bar=None,
     if 'nose' in sys.modules and level == 'C':
         raise RuntimeError(message)
     else:
-        log_verbosity = QSettings().value('oq_utils/log_verbosity', 'W')
+        log_verbosity = QSettings().value('irmt/log_level', 'W')
         if (level == 'C'
                 or level == 'W' and log_verbosity in ('S', 'I', 'W')
                 or level in ('I', 'S') and log_verbosity in ('I', 'S')):
             QgsMessageLog.logMessage(
                 tr(message) + tb_text, tr(tag), levels[level])
         if message_bar is not None:
-            if level == 'I':
+            if level == 'S':
+                title = 'Success'
+                duration = duration if duration is not None else 8
+            elif level == 'I':
                 title = 'Info'
                 duration = duration if duration is not None else 8
             elif level == 'W':
@@ -139,9 +142,6 @@ def log_msg(message, tag='GEM OpenQuake plugin', level='I', message_bar=None,
             elif level == 'C':
                 title = 'Error'
                 duration = duration if duration is not None else 0
-            elif level == 'S':
-                title = 'Success'
-                duration = duration if duration is not None else 8
             max_msg_len = 200
             if len(message) > max_msg_len:
                 message = ("%s[...] (Please open the Log Messages Panel to"
@@ -1084,6 +1084,7 @@ def get_checksum(file_path):
 def extract_npz(
         session, hostname, calc_id, output_type, message_bar, params=None):
     url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
+    log_msg('GET: %s, with parameters: %s' % (url, params), level='I')
     resp = session.get(url, params=params)
     if not resp.ok:
         msg = "Unable to extract %s with parameters %s: %s" % (


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/525

While fixing that issue, I noticed a couple of bugs, that I've fixed too:

1. the log verbosity was not getting the information from the right variable, therefore it was always set to WARNING, regardless from what the user selected

2. the task that calls the extract api was ignoring parameters, so the outputs were wrong. I can't understand why I did not spot it before.