### PR TITLE
When an OQ-Engine output can't be extracted, log the reason

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Fixed loader for Aggregate Loss Curves in event based risk OQ-Engine output
     * Tests have been split into: unit tests (using the qgis.testing module); functional tests (running on the official QGIS docker
       without external services); integration tests (running on the official QGIS docker and interacting with a running OQ-Engine
+    * When a call to the OQ-Engine extract API fails, the error is handled and the full response message is logged
     3.3.0
     * Fixed loader for aggregated Average Asset Losses Statistics OQ-Engine output
     * All calls to the OQ-Engine "extract" API are logged

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,7 +27,7 @@ changelog=
     * Fixed loader for Aggregate Loss Curves in event based risk OQ-Engine output
     * Tests have been split into: unit tests (using the qgis.testing module); functional tests (running on the official QGIS docker
       without external services); integration tests (running on the official QGIS docker and interacting with a running OQ-Engine
-    * When a call to the OQ-Engine extract API fails, the error is handled and the full response message is logged
+    * When an OQ-Engine output can't be extracted, the error is handled and the full response message is logged
     3.3.0
     * Fixed loader for aggregated Average Asset Losses Statistics OQ-Engine output
     * All calls to the OQ-Engine "extract" API are logged


### PR DESCRIPTION
It works for the case described by Daniele, with a permission error. I haven't tried other cases, but I am fairly confident it should work in most cases.

Fixes https://github.com/gem/oq-irmt-qgis/issues/535