### PR TITLE
Force printing also to stderr while logging from ExtractNpzTask

### DIFF
--- a/svir/tasks/download_oq_output_task.py
+++ b/svir/tasks/download_oq_output_task.py
@@ -26,6 +26,7 @@ import os
 from time import sleep
 from qgis.core import QgsTask
 from qgis.PyQt.QtCore import QThread, pyqtSignal, pyqtSlot
+from svir.utilities.utils import log_msg
 
 
 class TaskCanceled(Exception):
@@ -58,16 +59,18 @@ class DownloadOqOutputTask(QgsTask):
         self.current_calc_id = current_calc_id
         self.exception = None
 
-    def run(self):
         if self.current_calc_id:
-            download_url = "%s/v1/calc/%s/datastore" % (
+            self.download_url = "%s/v1/calc/%s/datastore" % (
                 self.hostname, self.current_calc_id)
         else:
-            download_url = (
+            self.download_url = (
                 "%s/v1/calc/result/%s?export_type=%s&dload=true" % (
                     self.hostname, self.output_id, self.outtype))
+        log_msg('GET: %s' % self.download_url, level='I', print_to_stderr=True)
+
+    def run(self):
         try:
-            self.download_output(self.session, download_url)
+            self.download_output(self.session, self.download_url)
         except Exception as exc:
             self.exception = exc
             return False

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -23,7 +23,6 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 import io
-import sys
 import numpy
 import tempfile
 from time import sleep
@@ -58,11 +57,11 @@ class ExtractNpzTask(QgsTask):
         self.dest_folder = tempfile.gettempdir()
         self.extract_url = '%s/v1/calc/%s/extract/%s' % (
             self.hostname, self.calc_id, self.output_type)
-        print('Extracting', self.extract_url, file=sys.stderr)
         self.extract_params = params
         self.exception = None
-        log_msg('GET: %s, with parameters: %s'
-                % (self.extract_url, self.extract_params), level='I')
+        log_msg('GET: %s, with parameters: %s' % (
+                    self.extract_url, self.extract_params),
+                level='I', print_to_stderr=True)
 
     def run(self):
         try:

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -152,7 +152,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
                                     levels[level],
                                     duration)
         if print_to_stderr:
-            print(message, file=sys.stderr)
+            print('\t\t%s' % message, file=sys.stderr)
 
 
 def tr(message):
@@ -1087,17 +1087,18 @@ def get_checksum(file_path):
 def extract_npz(
         session, hostname, calc_id, output_type, message_bar, params=None):
     url = '%s/v1/calc/%s/extract/%s' % (hostname, calc_id, output_type)
-    log_msg('GET: %s, with parameters: %s' % (url, params), level='I')
+    log_msg('GET: %s, with parameters: %s' % (url, params), level='I',
+            print_to_stderr=True)
     resp = session.get(url, params=params)
     if not resp.ok:
         msg = "Unable to extract %s with parameters %s: %s" % (
             url, params, resp.reason)
-        log_msg(msg, level='C', message_bar=message_bar)
+        log_msg(msg, level='C', message_bar=message_bar, print_to_stderr=True)
         return
     resp_content = resp.content
     if not resp_content:
         msg = 'GET %s returned an empty content!' % url
-        log_msg(msg, level='C', message_bar=message_bar)
+        log_msg(msg, level='C', message_bar=message_bar, print_to_stderr=True)
         return
     return numpy.load(io.BytesIO(resp_content))
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -83,7 +83,8 @@ def get_irmt_version():
 
 
 def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
-            message_bar=None, duration=None, exception=None):
+            message_bar=None, duration=None, exception=None,
+            print_to_stderr=False):
     """
     Add a message to the QGIS message log. If a messageBar is provided,
     the same message will be displayed also in the messageBar. In the latter
@@ -150,6 +151,8 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
                                     tr(message),
                                     levels[level],
                                     duration)
+        if print_to_stderr:
+            print(message, file=sys.stderr)
 
 
 def tr(message):


### PR DESCRIPTION
This should leverage the `log_msg` function that was already called, also printing to stderr in this specific case, instead of just logging to the qgis log and to the qgis message bar.
Let's see how it behaves on Travis.