### PR TITLE
Let integration tests reuse more code from the plugin instead of reimplementing parts of it

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -128,7 +128,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     it is possible to run calculations, delete them, list them, visualize
     their outputs and loading them as vector layers.
     """
-    def __init__(self, iface, viewer_dock):
+    def __init__(self, iface, viewer_dock, hostname=None):
         self.iface = iface
         self.viewer_dock = viewer_dock  # needed to change the output_type
         QDialog.__init__(self)
@@ -140,7 +140,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         # keep track of the log lines acquired for each calculation
         self.calc_log_line = {}
         self.session = None
-        self.hostname = None
+        self.hostname = hostname
+        if hostname is not None:
+            self.forced_hostname = True
+        else:
+            self.forced_hostname = False
         self.calc_list = None
         self.current_calc_id = None  # list of outputs refers to this calc_id
         self.pointed_calc_id = None  # we will scroll to it
@@ -198,7 +202,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
 
     def login(self):
         self.session = Session()
-        self.hostname, username, password = get_credentials('engine')
+        if not self.forced_hostname:
+            self.hostname, username, password = get_credentials('engine')
         # try without authentication (if authentication is disabled server
         # side)
         # NOTE: check_is_lockdown() can raise exceptions,

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -326,9 +326,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                            OQ_RST_TYPES):
             if output_type in OQ_CSV_TO_LAYER_TYPES:
                 print('\tLoading output type %s...' % output_type)
+                # TODO: we should test the actual downloader, asynchronously
                 filepath = self.download_output(output['id'], 'csv')
             elif output_type in OQ_RST_TYPES:
                 print('\tLoading output type %s...' % output_type)
+                # TODO: we should test the actual downloader, asynchronously
                 filepath = self.download_output(output['id'], 'rst')
             assert filepath is not None
             if output_type == 'fullreport':

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -84,6 +84,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             "%s/v1/calc/result/%s?export_type=%s&dload=true" % (self.hostname,
                                                                 output_id,
                                                                 outtype))
+        print('\t\tGET: %s' % output_download_url, file=sys.stderr)
         # FIXME: enable the user to set verify=True
         resp = requests.get(output_download_url, verify=False)
         if not resp.ok:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -405,7 +405,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.time_consuming_outputs = []
         self.not_implemented_loaders = set()
         self.untested_otypes = copy.copy(OQ_ALL_TYPES)  # it's a set
-        calc_list = self.get_calc_list()
+        calc_list = self.drive_oq_engine_server_dlg.calc_list
         try:
             selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
         except (ValueError, TypeError):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -382,7 +382,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             print('\tLoading output type %s...' % output_type)
             self.viewer_dock.load_no_map_output(
                 calc_id, requests, self.hostname, output_type,
-                self.engine_version)
+                self.drive_oq_engine_server_dlg.engine_version)
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -27,7 +27,6 @@ import os
 import sys
 import traceback
 import tempfile
-import json
 import copy
 import csv
 import time
@@ -46,7 +45,8 @@ from svir.utilities.shared import (
                                    OQ_ALL_TYPES,
                                    )
 from svir.test.utilities import assert_and_emit
-from svir.dialogs.drive_oq_engine_server_dialog import OUTPUT_TYPE_LOADERS
+from svir.dialogs.drive_oq_engine_server_dialog import (
+    OUTPUT_TYPE_LOADERS, DriveOqEngineServerDialog)
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 from svir.dialogs.viewer_dock import ViewerDock
 
@@ -69,44 +69,14 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
     def setUp(self):
         self.hostname = os.environ.get('OQ_ENGINE_HOST',
                                        'http://localhost:8800')
-        self.engine_version = self.get_engine_version().split('-')[0]
         self.reset_gui()
 
     def reset_gui(self):
         mock_action = QAction(IFACE.mainWindow())
         self.viewer_dock = ViewerDock(IFACE, mock_action)
         IFACE.newProject()
-
-    def get_engine_version(self):
-        engine_version_url = "%s/v1/engine_version" % self.hostname
-        # FIXME: enable the user to set verify=True
-        resp = requests.get(
-            engine_version_url, timeout=10, verify=False,
-            allow_redirects=False)
-        if resp.status_code == 302:
-            raise RuntimeError(
-                "Error %s loading %s: please check the url" % (
-                    resp.status_code, resp.url))
-        if not resp.ok:
-            raise RuntimeError(
-                "Error %s loading %s: %s" % (
-                    resp.status_code, resp.url, resp.reason))
-        return resp.text
-
-    def get_calc_list(self):
-        calc_list_url = "%s/v1/calc/list?relevant=true" % self.hostname
-        resp = requests.get(
-            calc_list_url, timeout=10, verify=False)
-        calc_list = json.loads(resp.text)
-        return calc_list
-
-    def get_output_list(self, calc_id):
-        output_list_url = "%s/v1/calc/%s/results" % (self.hostname, calc_id)
-        resp = requests.get(output_list_url, timeout=10, verify=False)
-        if not resp.ok:
-            raise Exception(resp.text)
-        output_list = json.loads(resp.text)
-        return output_list
+        self.drive_oq_engine_server_dlg = DriveOqEngineServerDialog(
+            IFACE, self.viewer_dock)
 
     def download_output(self, output_id, outtype):
         dest_folder = tempfile.gettempdir()
@@ -127,7 +97,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     def load_calc_outputs(self, calc):
         calc_id = calc['id']
-        output_list = self.get_output_list(calc_id)
+        output_list = self.drive_oq_engine_server_dlg.get_output_list(calc_id)
         for output in output_list:
             output_dict = {'calc_id': calc_id,
                            'calc_description': calc['description'],

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -76,7 +76,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.viewer_dock = ViewerDock(IFACE, mock_action)
         IFACE.newProject()
         self.drive_oq_engine_server_dlg = DriveOqEngineServerDialog(
-            IFACE, self.viewer_dock)
+            IFACE, self.viewer_dock, hostname=self.hostname)
 
     def download_output(self, output_id, outtype):
         dest_folder = tempfile.gettempdir()


### PR DESCRIPTION
Some functionalities of the dialog that drives the Oq-Engine were re-implemented in the integration tests instead of leveraging the dialog itself.

I still need to fix the cases in which an output is downloaded from the Oq-Engine, for which we should test the actual downloader task. It was tricky and I couldn't fix that quickly, so I will postpone it to a separate PR.