### PR TITLE
Show traceback

### DIFF
--- a/svir/calculations/calculate_utils.py
+++ b/svir/calculations/calculate_utils.py
@@ -143,7 +143,8 @@ def calculate_composite_variable(iface, layer, node):
         node_attr_id, node_attr_name, field_was_added = \
             get_node_attr_id_and_name(edited_node, layer)
     except InvalidNode as e:
-        log_msg(str(e), level='C', message_bar=iface.messageBar())
+        log_msg(str(e), level='C', message_bar=iface.messageBar(),
+                exception=e)
         if added_attrs_ids:
             ProcessLayer(layer).delete_attributes(added_attrs_ids)
         return set(), set(), node, False
@@ -156,14 +157,16 @@ def calculate_composite_variable(iface, layer, node):
                                               layer,
                                               discarded_feats)
     except (InvalidOperator, InvalidChild, InvalidFormula) as e:
-        log_msg(str(e), level='C', message_bar=iface.messageBar())
+        log_msg(str(e), level='C', message_bar=iface.messageBar(),
+                exception=e)
         if added_attrs_ids:
             ProcessLayer(layer).delete_attributes(added_attrs_ids)
         return set(), set(), node, False
     except TypeError as e:
         msg = ('Could not calculate the composite variable due'
                ' to data problems: %s' % e)
-        log_msg(msg, level='C', message_bar=iface.messageBar())
+        log_msg(msg, level='C', message_bar=iface.messageBar(),
+                exception=e)
         if added_attrs_ids:
             ProcessLayer(layer).delete_attributes(
                 added_attrs_ids)

--- a/svir/dialogs/download_layer_dialog.py
+++ b/svir/dialogs/download_layer_dialog.py
@@ -274,7 +274,8 @@ class DownloadLayerDialog(QDialog, FORM_CLASS):
         except Exception as e:
             error_msg = ('Unable to download and apply the'
                          ' style layer descriptor: %s' % e)
-            log_msg(error_msg, level='C', message_bar=self.iface.messageBar())
+            log_msg(error_msg, level='C', message_bar=self.iface.messageBar(),
+                    exception=e)
         self.iface.setActiveLayer(layer)
         project_definitions = supplemental_information['project_definitions']
         # ensure backwards compatibility with projects with a single

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -597,7 +597,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         try:
             result = json.loads(resp.text)['success']
         except Exception as exc:
-            log_msg(str(exc), level='C', message_bar=self.iface.messageBar())
+            log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
+                    exception=exc)
             return False
         else:
             return result

--- a/svir/dialogs/load_basic_csv_as_layer_dialog.py
+++ b/svir/dialogs/load_basic_csv_as_layer_dialog.py
@@ -73,7 +73,8 @@ class LoadBasicCsvAsLayerDialog(LoadOutputAsLayerDialog):
                 save_as_shp=False, dest_shp=dest_shp,
                 zoom_to_layer=False, has_geom=False)
         except RuntimeError as exc:
-            log_msg(str(exc), level='C', message_bar=self.iface.messageBar())
+            log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
+                    exception=exc)
             return
         log_msg('Layer %s was loaded successfully' % layer_name,
                 level='S', message_bar=self.iface.messageBar())

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -169,7 +169,8 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             # NOTE: add_numeric_attribute uses the native qgis editing manager
             added_field_name = add_numeric_attribute(field_name, self.layer)
         except TypeError as exc:
-            log_msg(str(exc), level='C', message_bar=self.iface.messageBar())
+            log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
+                    exception=exc)
             return
         return added_field_name
 

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -419,12 +419,13 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         if self.output_type in ('hcurves', 'uhs', 'hmaps'):
             try:
                 investigation_time = self.npz_file['investigation_time']
-            except KeyError:
+            except KeyError as exc:
                 msg = ('investigation_time not found. It is mandatory for %s.'
                        ' Please check if the ouptut was produced by an'
                        ' obsolete version of the OpenQuake Engine'
                        ' Server.') % self.output_type
-                log_msg(msg, level='C', message_bar=self.iface.messageBar())
+                log_msg(msg, level='C', message_bar=self.iface.messageBar(),
+                        exception=exc)
             else:
                 # We must cast to 'str' to keep numerical padding
                 # after saving the project
@@ -738,7 +739,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                         zonal_layer_plus_sum_name)
                 except Exception as exc:
                     log_msg(str(exc), level='C',
-                            message_bar=self.iface.messageBar())
+                            message_bar=self.iface.messageBar(),
+                            exception=exc)
                     super().accept()
                     return
             else:

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -87,13 +87,14 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
                 params_dict = get_params_from_comment_line(comment_line)
             except LookupError as exc:
                 log_msg(exc.message, level='C',
-                        message_bar=self.iface.messageBar())
+                        message_bar=self.iface.messageBar(),
+                        exception=exc)
                 return
             try:
                 investigation_time = params_dict['investigation_time']
-            except KeyError:
+            except KeyError as exc:
                 log_msg('Investigation time not found', level='C',
-                        message_bar=self.iface.messageBar())
+                        message_bar=self.iface.messageBar(), exception=exc)
                 return
         # extract the name of the csv file and remove the extension
         layer_name = os.path.splitext(os.path.basename(csv_path))[0]
@@ -106,7 +107,8 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
                 save_as_shp=self.save_as_shp_ckb.isChecked(),
                 dest_shp=dest_shp)
         except RuntimeError as exc:
-            log_msg(str(exc), level='C', message_bar=self.iface.messageBar())
+            log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
+                    exception=exc)
             return
         self.layer.setCustomProperty('investigation_time', investigation_time)
         style_by = self.style_by_cbx.itemData(self.style_by_cbx.currentIndex())

--- a/svir/dialogs/projects_manager_dialog.py
+++ b/svir/dialogs/projects_manager_dialog.py
@@ -185,5 +185,6 @@ class ProjectsManagerDialog(QDialog, FORM_CLASS):
             exc_msg = exc.args[0]
             if isinstance(exc_msg, bytes):
                 exc_msg = exc_msg.decode('utf-8')   # make it a unicode object
-            log_msg(exc_msg, level='C', message_bar=self.iface.messageBar())
+            log_msg(exc_msg, level='C', message_bar=self.iface.messageBar(),
+                    exception=exc)
             self.ok_button.setEnabled(False)

--- a/svir/dialogs/recovery_settings_dialog.py
+++ b/svir/dialogs/recovery_settings_dialog.py
@@ -204,7 +204,7 @@ class RecoverySettingsDialog(QDialog, FORM_CLASS):
         except ValueError as exc:
             log_msg(exc.message, level='C',
                     message_bar=self.iface.messageBar(),
-                    duration=5)
+                    duration=5, exception=exc)
         else:
             super(RecoverySettingsDialog, self).accept()
 

--- a/svir/dialogs/settings_dialog.py
+++ b/svir/dialogs/settings_dialog.py
@@ -348,8 +348,7 @@ class SettingsDialog(QDialog, FORM_CLASS):
             try:
                 is_lockdown = check_is_lockdown(hostname, session)
             except Exception as exc:
-                err_msg = ("Unable to connect"
-                           " (see Log Message Panel for details)")
+                err_msg = ("Unable to connect")
                 log_msg(err_msg, level='C', message_bar=self.message_bar,
                         exception=exc)
                 return

--- a/svir/dialogs/transformation_dialog.py
+++ b/svir/dialogs/transformation_dialog.py
@@ -182,7 +182,8 @@ class TransformationDialog(QDialog, FORM_CLASS):
                             inverse, simulate=True)
                 except TypeError as exc:
                     log_msg(str(exc), level='C',
-                            message_bar=self.iface.messageBar())
+                            message_bar=self.iface.messageBar(),
+                            exception=exc)
                     return
             self.new_field_name_txt.setText(new_attr_name)
             self.attr_name_user_def = False

--- a/svir/dialogs/upload_dialog.py
+++ b/svir/dialogs/upload_dialog.py
@@ -129,10 +129,8 @@ class UploadDialog(QDialog, FORM_CLASS):
         except Exception as e:
             error_msg = (
                 'Unable to export the styled layer descriptor: ' + str(e))
-            log_msg(traceback.format_exc(), level='C')
-            self.message_bar.pushMessage(
-                'Style error', error_msg, duration=0,
-                level=Qgis.Critical)
+            log_msg(error_msg, level='C', message_bar=self.message_bar,
+                    exception=e)
             return
 
         if DEBUG:

--- a/svir/dialogs/upload_settings_dialog.py
+++ b/svir/dialogs/upload_settings_dialog.py
@@ -218,7 +218,8 @@ class UploadSettingsDialog(QDialog, FORM_CLASS):
                     error_msg = (
                         'Unable to login to the platform: ' + e.message)
                     log_msg(error_msg, level='C',
-                            message_bar=self.iface.messageBar())
+                            message_bar=self.iface.messageBar(),
+                            exception=e)
                     return
                 if 'platform_layer_id' not in self.suppl_info:
                     error_msg = ('Unable to retrieve the id of'

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1125,9 +1125,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     for period in periods:
                         if period not in unique_periods:
                             unique_periods.append(period)
-                except ValueError:
+                except ValueError as exc:
                     log_msg(err_msg, level='C',
-                            message_bar=self.iface.messageBar())
+                            message_bar=self.iface.messageBar(),
+                            exception=exc)
                     self.output_type_cbx.setCurrentIndex(-1)
                     return
                 self.current_abscissa = unique_periods

--- a/svir/dialogs/weight_data_dialog.py
+++ b/svir/dialogs/weight_data_dialog.py
@@ -238,9 +238,10 @@ class WeightDataDialog(QDialog, FORM_CLASS):
         self.printer.setOutputFileName(dest_full_path_name)
         try:
             self.web_view.print_(self.printer)
-        except Exception:
+        except Exception as exc:
             msg = 'It was impossible to create the pdf'
-            log_msg(msg, level='C', message_bar=self.iface.messageBar())
+            log_msg(msg, level='C', message_bar=self.iface.messageBar(),
+                    exception=exc)
         else:
             msg = ('Project definition printed as pdf and saved to: %s'
                    % dest_full_path_name)

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -157,6 +157,7 @@ class Irmt(object):
         QgsProject.instance().layersAdded.connect(self.layers_added)
         QgsProject.instance().layersRemoved.connect(
             self.layers_removed)
+        # FIXME: connect a button in the messageBar instead 
         QgsApplication.messageLog().messageReceived.connect(
             self.on_message_log_received)
 
@@ -305,6 +306,7 @@ class Irmt(object):
                 return action.menu()
         return None
 
+    # FIXME: connect from a button in the messageBar instead
     def on_message_log_received(self, message, tag, level):
         if level == Qgis.Critical:
             dock = self.iface.mainWindow().findChild(QDockWidget, 'MessageLog')
@@ -547,6 +549,7 @@ class Irmt(object):
             self.layers_added)
         QgsProject.instance().layersRemoved.disconnect(
             self.layers_removed)
+        # FIXME: disconnect from a button in the messageBar instead
         QgsApplication.messageLog().messageReceived.disconnect(
             self.on_message_log_received)
 

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -42,7 +42,6 @@ from qgis.core import (
                        QgsProject,
                        QgsExpression,
                        Qgis,
-                       QgsApplication,
                        )
 
 from qgis.PyQt.QtCore import (
@@ -54,8 +53,7 @@ from qgis.PyQt.QtCore import (
                               Qt,
                               QUrlQuery,
                               )
-from qgis.PyQt.QtWidgets import (
-    QAction, QFileDialog, QApplication, QMenu, QDockWidget, QTabWidget)
+from qgis.PyQt.QtWidgets import QAction, QFileDialog, QApplication, QMenu
 from qgis.PyQt.QtGui import QIcon, QDesktopServices
 
 from svir.dialogs.viewer_dock import ViewerDock
@@ -157,9 +155,6 @@ class Irmt(object):
         QgsProject.instance().layersAdded.connect(self.layers_added)
         QgsProject.instance().layersRemoved.connect(
             self.layers_removed)
-        # FIXME: connect a button in the messageBar instead 
-        QgsApplication.messageLog().messageReceived.connect(
-            self.on_message_log_received)
 
         # get or create directory to store input files for the OQ-Engine
         self.ipt_dir = self.get_ipt_dir()
@@ -305,19 +300,6 @@ class Irmt(object):
             if action.text() == title:
                 return action.menu()
         return None
-
-    # FIXME: connect from a button in the messageBar instead
-    def on_message_log_received(self, message, tag, level):
-        if level == Qgis.Critical:
-            dock = self.iface.mainWindow().findChild(QDockWidget, 'MessageLog')
-            dock.show()
-            tabs = dock.findChild(QTabWidget, 'tabWidget')
-            for tab in range(tabs.count()):
-                text = tabs.tabText(tab)
-                if text == tag:
-                    tabs.setCurrentIndex(tab)
-                    break
-            self.iface.mainWindow().findChild(QDockWidget, 'MessageLog').show()
 
     def experimental_enabled(self):
         experimental_enabled = QSettings().value(
@@ -549,9 +531,6 @@ class Irmt(object):
             self.layers_added)
         QgsProject.instance().layersRemoved.disconnect(
             self.layers_removed)
-        # FIXME: disconnect from a button in the messageBar instead
-        QgsApplication.messageLog().messageReceived.disconnect(
-            self.on_message_log_received)
 
     def import_sv_variables(self):
         """

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -617,7 +617,9 @@ class Irmt(object):
                     start_worker(worker, self.iface.messageBar(),
                                  'Downloading data from platform')
         except SvNetworkError as e:
-            log_msg(str(e), level='C', message_bar=self.iface.messageBar())
+            log_msg('An error occurred. See the traceback for details.',
+                    level='C', message_bar=self.iface.messageBar(),
+                    exception=e)
 
     def _data_download_successful(
             self, result, load_geometries, dest_filename, project_definition,
@@ -1257,7 +1259,8 @@ class Irmt(object):
                             message_bar=self.iface.messageBar())
                 except (ValueError, NotImplementedError, TypeError) as e:
                     log_msg(e.message, level='C',
-                            message_bar=self.iface.messageBar())
+                            message_bar=self.iface.messageBar(),
+                            exception=e)
                 else:  # only if the transformation was performed successfully
                     active_layer_id = self.iface.activeLayer().id()
                     read_layer_suppl_info_from_qgs(

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.4.0
+    * Whenever an error message is shown to the user, a button in the QGIS message bar allows to display the traceback in a separate window
     * Fixed loader for Aggregate Loss Curves in event based risk OQ-Engine output
     * Tests have been split into: unit tests (using the qgis.testing module); functional tests (running on the official QGIS docker
       without external services); integration tests (running on the official QGIS docker and interacting with a running OQ-Engine

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -31,6 +31,9 @@ import traceback
 import locale
 import zlib
 import io
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
 from copy import deepcopy
 from time import time
 from pprint import pformat
@@ -110,6 +113,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
         extracted and written in the log. When the exception is provided,
         an additional button in the `QgsMessageBar` allows to visualize the
         traceback in a separate window.
+    :print_to_stderr: if True, the error message will be printed also to stderr
     """
     levels = {
               'I': Qgis.Info,
@@ -173,7 +177,8 @@ def _on_tb_btn_clicked(message):
     dlg = QDialog()
     dlg.setWindowTitle('Traceback')
     text_browser = QTextBrowser()
-    text_browser.setText(message)
+    formatted_msg = highlight(message, PythonLexer(), HtmlFormatter(full=True))
+    text_browser.setHtml(formatted_msg)
     vbox.addWidget(text_browser)
     dlg.setLayout(vbox)
     dlg.setMinimumSize(700, 500)

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -31,7 +31,6 @@ import traceback
 import locale
 import zlib
 import io
-import sip
 from copy import deepcopy
 from time import time
 from pprint import pformat
@@ -137,9 +136,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
             if exception is not None:
                 tb_btn = QToolButton(message_bar)
                 tb_btn.setText('Show Traceback')
-                print('Created: %s' % tb_btn)
                 tb_btn.clicked.connect(lambda: on_tb_btn_clicked(tb_text))
-                tb_btn.destroyed.connect(on_tb_btn_destroyed)
         if message_bar is not None:
             if level == 'S':
                 title = 'Success'
@@ -179,10 +176,6 @@ def on_tb_btn_clicked(message):
     dlg.setLayout(vbox)
     dlg.setMinimumSize(700, 500)
     dlg.exec_()
-
-
-def on_tb_btn_destroyed(tb_btn):
-    print('Destroyed: %s' % sip.cast(tb_btn, QToolButton))
 
 
 def tr(message):

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -53,7 +53,7 @@ from qgis.PyQt.QtWidgets import (
                                  QMessageBox,
                                  QDialog,
                                  QTextBrowser,
-                                 QHBoxLayout,
+                                 QVBoxLayout,
                                  )
 from qgis.PyQt.QtGui import QColor
 
@@ -164,13 +164,14 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
 
 
 def on_tb_btn_clicked(message):
-    hbox = QHBoxLayout()
+    vbox = QVBoxLayout()
     dlg = QDialog()
     dlg.setWindowTitle('Traceback')
     text_browser = QTextBrowser()
     text_browser.setText(message)
-    hbox.addWidget(text_browser)
-    dlg.setLayout(hbox)
+    vbox.addWidget(text_browser)
+    dlg.setLayout(vbox)
+    dlg.setMinimumSize(700, 500)
     dlg.exec_()
 
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -51,6 +51,9 @@ from qgis.PyQt.QtWidgets import (
                                  QToolButton,
                                  QFileDialog,
                                  QMessageBox,
+                                 QDialog,
+                                 QLabel,
+                                 QVBoxLayout,
                                  )
 from qgis.PyQt.QtGui import QColor
 
@@ -129,6 +132,11 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
                 or level in ('I', 'S') and log_verbosity in ('I', 'S')):
             QgsMessageLog.logMessage(
                 tr(message) + tb_text, tr(tag), levels[level])
+            if exception is not None:
+                button = QToolButton(message_bar)
+                button.setText('Show Traceback')
+                button.clicked.connect(lambda: on_tb_btn_clicked(tb_text))
+                message_bar.layout().addWidget(button)
         if message_bar is not None:
             if level == 'S':
                 title = 'Success'
@@ -150,6 +158,16 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
                                     tr(message),
                                     levels[level],
                                     duration)
+
+
+def on_tb_btn_clicked(message):
+    vbox = QVBoxLayout()
+    dlg = QDialog()
+    dlg.setWindowTitle('Traceback')
+    label = QLabel(message)
+    vbox.addWidget(label)
+    dlg.setLayout(vbox)
+    dlg.exec_()
 
 
 def tr(message):

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -52,8 +52,8 @@ from qgis.PyQt.QtWidgets import (
                                  QFileDialog,
                                  QMessageBox,
                                  QDialog,
-                                 QLabel,
-                                 QVBoxLayout,
+                                 QTextBrowser,
+                                 QHBoxLayout,
                                  )
 from qgis.PyQt.QtGui import QColor
 
@@ -161,12 +161,13 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
 
 
 def on_tb_btn_clicked(message):
-    vbox = QVBoxLayout()
+    hbox = QHBoxLayout()
     dlg = QDialog()
     dlg.setWindowTitle('Traceback')
-    label = QLabel(message)
-    vbox.addWidget(label)
-    dlg.setLayout(vbox)
+    text_browser = QTextBrowser()
+    text_browser.setText(message)
+    hbox.addWidget(text_browser)
+    dlg.setLayout(hbox)
     dlg.exec_()
 
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -107,7 +107,9 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
         to keep the message visible indefinitely, or None to use
         the default duration of the chosen level
     :param exception: an optional exception, from which the traceback will be
-        extracted and written only in the log
+        extracted and written in the log. When the exception is provided,
+        an additional button in the `QgsMessageBar` allows to visualize the
+        traceback in a separate window.
     """
     levels = {
               'I': Qgis.Info,
@@ -136,7 +138,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
             if exception is not None:
                 tb_btn = QToolButton(message_bar)
                 tb_btn.setText('Show Traceback')
-                tb_btn.clicked.connect(lambda: on_tb_btn_clicked(tb_text))
+                tb_btn.clicked.connect(lambda: _on_tb_btn_clicked(tb_text))
         if message_bar is not None:
             if level == 'S':
                 title = 'Success'
@@ -166,7 +168,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
             print('\t\t%s' % message, file=sys.stderr)
 
 
-def on_tb_btn_clicked(message):
+def _on_tb_btn_clicked(message):
     vbox = QVBoxLayout()
     dlg = QDialog()
     dlg.setWindowTitle('Traceback')


### PR DESCRIPTION
This is an improvement to the utility we use in the plugin to communicate with the user.
In case `log_msg` is called passing also an exception as parameter, the user will be able to visualize the traceback by clicking on a button that will appear in the messageBar. Therefore the messageBar will display the short version of the error message, but it will be easy to visualize the full error. 

To see how it works, you can attempt to drive the engine while the engine server is not running.