### PR TITLE
Disable 'Show' buttons if calculation_mode == 'ebrisk'

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -737,6 +737,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                                       OQ_EXTRACT_TO_VIEW_TYPES):
                     if output['type'] in (OQ_RST_TYPES |
                                           OQ_EXTRACT_TO_VIEW_TYPES):
+                        # FIXME: enable button for ebrisk as soon as the output
+                        # will be loadable
+                        if calculation_mode == 'ebrisk':
+                            continue
                         action = 'Show'
                     else:
                         action = 'Load as layer'

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -739,7 +739,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                                           OQ_EXTRACT_TO_VIEW_TYPES):
                         # FIXME: enable button for ebrisk as soon as the output
                         # will be loadable
-                        if calculation_mode == 'ebrisk':
+                        if (calculation_mode == 'ebrisk'
+                                and output['type'] not in OQ_RST_TYPES):
                             continue
                         action = 'Show'
                     else:


### PR DESCRIPTION
This way, for the latest demo, it's possible to load (successfully) all outputs except the "Show" ones, that were broken.