### PR TITLE
Fix unloading plugin menu

### DIFF
--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -516,8 +516,7 @@ class Irmt(object):
             self.iface.removeToolBarIcon(action)
         clear_progress_message_bar(self.iface.messageBar())
 
-        # remove menu
-        self.menu.deleteLater()
+        self.menu.clear()
 
         # remove the dock
         self.viewer_dock.remove_connects()

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -170,8 +170,8 @@ class Irmt(object):
         if get_menu is not None:
             self.menu = get_menu
 
-        menu_bar.insertMenu(self.iface.firstRightStandardMenu().menuAction(),
-                            self.menu)
+        self.menu_action = menu_bar.insertMenu(
+            self.iface.firstRightStandardMenu().menuAction(), self.menu)
 
         # Action to activate the modal dialog to import socioeconomic
         # data from the platform
@@ -517,6 +517,7 @@ class Irmt(object):
         clear_progress_message_bar(self.iface.messageBar())
 
         self.menu.clear()
+        self.iface.mainWindow().menuBar().removeAction(self.menu_action)
 
         # remove the dock
         self.viewer_dock.remove_connects()


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/464

Now it should be possible to reload the plugin using the plugin reloader tool, without raising exceptions.
The change is just a couple of lines of code, but it makes a big difference, because I can avoid to keep closing/opening qgis whenever I change code in the plugin.