### PR TITLE
Set incremental symbol levels

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -684,11 +684,11 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         renderer.setUsingSymbolLevels(True)
         symbol_items = [item for item in renderer.legendSymbolItems()]
         for i in range(len(symbol_items)):
-            sym = symbol_items[i].symbol()
+            sym = symbol_items[i].symbol().clone()
             key = symbol_items[i].ruleKey()
             for lay in range(sym.symbolLayerCount()):
                 sym.symbolLayer(lay).setRenderingPass(i)
-            renderer.setLegendSymbolItem(key, sym.clone())
+            renderer.setLegendSymbolItem(key, sym)
         layer.setRenderer(renderer)
         layer.setOpacity(0.7)
         layer.triggerRepaint()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -685,8 +685,10 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         symbol_items = [item for item in renderer.legendSymbolItems()]
         for i in range(len(symbol_items)):
             sym = symbol_items[i].symbol()
+            key = symbol_items[i].ruleKey()
             for lay in range(sym.symbolLayerCount()):
                 sym.symbolLayer(lay).setRenderingPass(i)
+            renderer.setLegendSymbolItem(key, sym.clone())
         layer.setRenderer(renderer)
         layer.setOpacity(0.7)
         layer.triggerRepaint()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -681,6 +681,12 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 rule.setLabel(simplified)
             root_rule.removeChildAt(0)
             renderer = rule_renderer
+        renderer.setUsingSymbolLevels(True)
+        symbol_items = [item for item in renderer.legendSymbolItems()]
+        for i in range(len(symbol_items)):
+            sym = symbol_items[i].symbol()
+            for lay in range(sym.symbolLayerCount()):
+                sym.symbolLayer(lay).setRenderingPass(i)
         layer.setRenderer(renderer)
         layer.setOpacity(0.7)
         layer.triggerRepaint()


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/557

Via pdb I checked that it sets reasonable levels, but it looks like it is working on a copy of the legend symbol items, so the original renderer remains unchanged.
I tried to do something like `renderer.setLegendSymbolItem`, but I did not understand how to pass a proper key parameter to that function.