### PR TITLE
Improve management of failed connection with the engine server

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -166,6 +166,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.download_tasks = {}
         self.open_output_dlgs = {}
 
+        self.is_gui_enabled = False
         self.attempt_login()
 
     def on_reconnect_btn_clicked(self):
@@ -178,6 +179,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         except HANDLED_EXCEPTIONS as exc:
             # in case of disconnection, try 3 times to reconnect, before
             # displaying an error
+            self.set_gui_enabled(False)
             if isinstance(exc, ConnectionError):
                 if self.num_login_attempts < 3:
                     # it attempts to login after the timeout is triggered
@@ -275,6 +277,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             else:
                 self._handle_exception(exc)
             return False
+        if not self.is_gui_enabled:
+            self.set_gui_enabled(True)
         self.calc_list = json.loads(resp.text)
         selected_keys = [
             'description', 'id', 'calculation_mode', 'owner', 'status']
@@ -991,6 +995,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.output_list_tbl.setEnabled(enabled)
         self.download_datastore_btn.setEnabled(enabled)
         self.show_calc_params_btn.setEnabled(enabled)
+        self.is_gui_enabled = enabled
 
     def reject(self):
         self.stop_polling()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Fixed removal of plugin menu while the plugin is unloaded/uninstalled/disabled
     * Buttons to load layers that have no geometries are renamed from "Load layer" to "Load table"
     * Upgraded compatibility to the OQ Platform 2019
+    * Better management of failing connection with the OQ Engine server
     3.4.0
     * Whenever an error message is shown to the user, a button in the QGIS message bar allows to display the traceback in a separate window
     * Fixed loader for Aggregate Loss Curves in event based risk OQ-Engine output

--- a/svir/ui/ui_drive_engine_server.ui
+++ b/svir/ui/ui_drive_engine_server.ui
@@ -40,6 +40,13 @@
        </property>
       </spacer>
      </item>
+     <item>
+      <widget class="QPushButton" name="reconnect_btn">
+       <property name="text">
+        <string>Reconnect</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/559

I removed the automatic redirection to the plugin settings.
While the connection is not working, the GUI is temporarily disabled and the plugin attempts to reconnect to the engine server for 3 times. If the server remains unreachable during those attempts, the GUI remains disabled, but there is an additional "Reconnect" button to actively attempt a new reconnection.