### PR TITLE
Start/stop polling on error and display error in dialog when engine server is disconnected

### DIFF
--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -404,8 +404,10 @@ class Irmt(object):
         if self.drive_oq_engine_server_dlg.is_logged_in:
             self.drive_oq_engine_server_dlg.start_polling()
         else:
-            self.drive_oq_engine_server_dlg.reject()
-            self.drive_oq_engine_server_dlg = None
+            log_msg('Unable to connect to the OpenQuake Engine server. '
+                    'Please check that the server is running and the '
+                    'plugin connection settings are correct.', level='C',
+                    message_bar=self.drive_oq_engine_server_dlg.message_bar)
 
     def on_same_fs(self, checksum_file_path, local_checksum):
         # initialize drive_oq_engine_server_dlg dialog without displaying it


### PR DESCRIPTION
When the dialog to drive the OQ Engine is opened, it is displayed also if the connection with the server is down, and an error message is shown in the message bar on top of the dialog.
The "Reconnect" button is enabled when the connection is down, and it is disabled when the connection is already working.
Polling is disabled after 3 attempts of reconnection, and it is re-enabled when a connection is established correctly.