### PR TITLE
Newline

### DIFF
--- a/svir/dialogs/download_layer_dialog.py
+++ b/svir/dialogs/download_layer_dialog.py
@@ -269,7 +269,7 @@ class DownloadLayerDialog(QDialog, FORM_CLASS):
                 raise SvNetworkError(get_style_resp.reason)
             fd, sld_file = tempfile.mkstemp(suffix=".sld")
             os.close(fd)
-            with open(sld_file, 'w') as f:
+            with open(sld_file, 'w', newline='') as f:
                 f.write(get_style_resp.text)
             layer.loadSldStyle(sld_file)
         except Exception as e:

--- a/svir/dialogs/ipt_dialog.py
+++ b/svir/dialogs/ipt_dialog.py
@@ -165,7 +165,7 @@ class IptPythonApi(GemApi):
         ipt_dir = self.parent().ipt_dir
         try:
             basename = os.path.basename(file_name)
-            with open(os.path.join(ipt_dir, basename), "w") as f:
+            with open(os.path.join(ipt_dir, basename), "w", newline='') as f:
                 f.write(content)
         except Exception as exc:
             return {'ret': 1, 'reason': str(exc)}
@@ -303,7 +303,7 @@ class IptPythonApi(GemApi):
         file_name = str(content_disposition.split('"')[1])
         file_content = str(reply.readAll())
         ipt_dir = self.parent().ipt_dir
-        with open(os.path.join(ipt_dir, file_name), "w") as f:
+        with open(os.path.join(ipt_dir, file_name), "w", newline='') as f:
             f.write(file_content)
         self.call_js_cb(js_cb_func, js_cb_object_id, file_name, 0)
 

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -81,7 +81,7 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
             dest_shp = None  # the destination file will be selected via GUI
         csv_path = self.path_le.text()
         # extract the investigation_time from the heading commented line
-        with open(csv_path, 'r') as f:
+        with open(csv_path, 'r', newline='') as f:
             comment_line = f.readline()
             try:
                 params_dict = get_params_from_comment_line(comment_line)

--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -187,7 +187,7 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
         # Incorporate Napa Data to community recovery model
         summary_filename = os.path.join(
             self.output_data_dir, 'summary.csv')
-        summary = open(summary_filename, 'w')
+        summary = open(summary_filename, 'w', newline='')
         writer = csv.writer(summary)
         header = ['zone_id', 'days_to_recover_95_perc', 'event_time',
                   'after_6_months', 'after_12_months', 'after_18_months']

--- a/svir/dialogs/show_full_report_dialog.py
+++ b/svir/dialogs/show_full_report_dialog.py
@@ -38,6 +38,6 @@ class ShowFullReportDialog(QDialog, FORM_CLASS):
         QDialog.__init__(self)
         # Set up the user interface from Designer.
         self.setupUi(self)
-        with open(filepath, 'r') as rst_file:
+        with open(filepath, 'r', newline='') as rst_file:
             text = rst_file.read()
         self.text_browser.setText(text)

--- a/svir/dialogs/upload_dialog.py
+++ b/svir/dialogs/upload_dialog.py
@@ -137,7 +137,7 @@ class UploadDialog(QDialog, FORM_CLASS):
             import tempfile
             fd, fname = tempfile.mkstemp(suffix=".sld")
             os.close(fd)
-            with open(fname, 'w') as f:
+            with open(fname, 'w', newline='') as f:
                 f.write(sld)
             os.system('tidy -xml -i %s' % fname)
         headers = {'content-type': 'application/vnd.ogc.sld+xml'}

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1465,7 +1465,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         csv_headline += (
             "OpenQuake Integrated Risk Modelling Toolkit v%s\r\n"
             % irmt_version)
-        with open(filename, 'w') as csv_file:
+        with open(filename, 'w', newline='') as csv_file:
             csv_file.write(csv_headline)
             writer = csv.writer(csv_file)
             if self.output_type == 'recovery_curves':

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -1413,6 +1413,6 @@ class Irmt(object):
     def get_ipt_checksum(self):
         unique_filename = ".%s" % uuid.uuid4().hex
         checksum_file_path = os.path.join(self.ipt_dir, unique_filename)
-        with open(checksum_file_path, "w") as f:
+        with open(checksum_file_path, "w", newline='') as f:
             f.write(os.urandom(32))
         return checksum_file_path, get_checksum(checksum_file_path)

--- a/svir/metadata/iso_19115_template.py
+++ b/svir/metadata/iso_19115_template.py
@@ -24,7 +24,7 @@ import os
 from string import Template  # pylint: disable=W0402
 
 _xml_file = os.path.join(os.path.dirname(__file__), 'iso_19115_template.xml')
-with open(_xml_file, 'r') as f:
+with open(_xml_file, 'r', newline='') as f:
     _template = f.read()
 
 # This template uses python strings.Template module to allow replacing values

--- a/svir/metadata/metadata_utilities.py
+++ b/svir/metadata/metadata_utilities.py
@@ -162,7 +162,7 @@ def write_iso_metadata_file(xml_filename, supplemental_information=None):
     :return:
     """
     xml = generate_iso_metadata(supplemental_information)
-    with open(xml_filename, 'w') as f:
+    with open(xml_filename, 'w', newline='') as f:
         f.write(xml)
     return xml
 

--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -325,7 +325,7 @@ class RecoveryModeling(object):
                 output_filename = os.path.join(
                     output_by_building_dir,
                     "zone_%s_bldg_%s.txt" % (zone_id, asset_ref))
-                with open(output_filename, 'w') as f:
+                with open(output_filename, 'w', newline='') as f:
                     f.write(str(building_level_recovery_function))
             # The following lines plot building level curves
             # fig = plt.figure()

--- a/svir/test/functional/test_recovery_modeling.py
+++ b/svir/test/functional/test_recovery_modeling.py
@@ -63,9 +63,9 @@ def calculate_and_check_recovery_curve(
         zone_id, zonal_dmg_by_asset_probs, zonal_asset_refs, seed=seed,
         n_simulations=n_simulations, usage='testing')
     if regenerate_expected_values:
-        with open(expected_curve_path, 'w') as f:
+        with open(expected_curve_path, 'w', newline='') as f:
             f.write(json.dumps(recovery_curve))
-    with open(expected_curve_path, 'r') as f:
+    with open(expected_curve_path, 'r', newline='') as f:
         expected_recovery_curve = json.loads(f.read())
     testcase.assertEqual(len(recovery_curve), len(expected_recovery_curve))
     for actual, expected in zip(recovery_curve, expected_recovery_curve):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -555,7 +555,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # shapely/libgeos/numpy/etc the numbers could be slightly different.
         # The parameters of the demos could change in the future and the
         # numbers (even the number of rows and columns) could change.
-        with open(exported_file_path, 'r') as got:
+        with open(exported_file_path, 'r', newline='') as got:
             got_reader = csv.reader(got)
             n_rows = 0
             for got_line in got_reader:

--- a/svir/thread_worker/download_platform_data_worker.py
+++ b/svir/thread_worker/download_platform_data_worker.py
@@ -93,9 +93,9 @@ class DownloadPlatformDataWorker(AbstractWorker):
             types_string = '"String","String"' + ',"Real"' * sv_variables_count
             if self.load_geometries:
                 types_string += ',"String"'
-            with open(fname_types, 'w') as csvt:
+            with open(fname_types, 'w', newline='') as csvt:
                 csvt.write(types_string)
-            with open(fname, 'w') as csv_file:
+            with open(fname, 'w', newline='') as csv_file:
                 n_countries_to_download = len(self.country_iso_codes)
                 n_downloaded_countries = 0
                 for line in result.iter_lines():

--- a/svir/ui/gem_qwebview.py
+++ b/svir/ui/gem_qwebview.py
@@ -171,7 +171,7 @@ class GemQWebView(QWebView):
                 if not os.path.exists(file_fullpath):
                     break
                 i += 1
-        with open(file_fullpath, "w") as f:
+        with open(file_fullpath, "w", newline='') as f:
             f.write(file_content)
         self.gem_api.common.info('File downloaded as: %s' % file_fullpath)
 

--- a/svir/utilities/import_sv_data.py
+++ b/svir/utilities/import_sv_data.py
@@ -228,9 +228,9 @@ class SvDownloader(object):
             types_string = '"String","String"' + ',"Real"' * sv_variables_count
             if load_geometries:
                 types_string += ',"String"'
-            with open(fname_types, 'w') as csvt:
+            with open(fname_types, 'w', newline='') as csvt:
                 csvt.write(types_string)
-            with open(fname, 'w') as csv_file:
+            with open(fname, 'w', newline='') as csv_file:
                 n_countries_to_download = len(country_iso_codes)
                 n_downloaded_countries = 0
                 msg_bar_item, progress = create_progress_message_bar(

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -36,7 +36,7 @@ metadata_file_path = os.path.join(
     os.path.dirname(os.path.realpath(__file__)),
     os.pardir,
     'metadata.txt')
-with open(metadata_file_path, 'r') as f:
+with open(metadata_file_path, 'r', newline='') as f:
     cp.read_file(f)
 IRMT_PLUGIN_VERSION = cp.get('general', 'version')
 PLATFORM_REGISTRATION_URL = 'https://platform.openquake.org/account/signup/'

--- a/svir/utilities/sldadapter.py
+++ b/svir/utilities/sldadapter.py
@@ -333,7 +333,7 @@ def getStyleAsSld(layer, styleName):
                 sldfile = os.path.join(sldpath, "grayscale.sld")
             else:
                 sldfile = os.path.join(sldpath, "rgb.sld")
-            with open(sldfile, 'r') as f:
+            with open(sldfile, 'r', newline='') as f:
                 sld = f.read()
             return sld
     else:

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -80,7 +80,7 @@ def get_irmt_version():
     if _IRMT_VERSION is None:
         metadata_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)), '..', 'metadata.txt')
-        with open(metadata_path, 'r') as f:
+        with open(metadata_path, 'r', newline='') as f:
             for line in f:
                 if line.startswith('version='):
                     _IRMT_VERSION = line.split('=')[1].strip()
@@ -241,7 +241,7 @@ def count_heading_commented_lines(fname):
     """
     count top lines in the file starting with '#'
     """
-    with open(fname) as f:
+    with open(fname, 'r', newline='') as f:
         lines_to_skip_count = 0
         for line in f:
             li = line.strip()


### PR DESCRIPTION
From the manual of python builtin `open` function:
 
>* On input, if newline is None, universal newlines mode is
>    enabled. Lines in the input can end in '\n', '\r', or '\r\n', and
>    these are translated into '\n' before being returned to the
>    caller. If it is '', universal newline mode is enabled, but line
>    endings are returned to the caller untranslated. If it has any of
>    the other legal values, input lines are only terminated by the given
>    string, and the line ending is returned to the caller untranslated.
    
>* On output, if newline is None, any '\n' characters written are
>    translated to the system default line separator, os.linesep. If
>    newline is '' or '\n', no translation takes place. If newline is any
>    of the other legal values, any '\n' characters written are translated
>    to the given string.

If the default is to translate all newlines to `os.linesep`, and if I understand correctly the consequences of it, it looks like we should explicitly use `newline=''`. in order to prevent from the automatic translation.