### PR TITLE
Avoid downloading asset_risk unused csv output

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -856,7 +856,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             else:
                 raise NotImplementedError("%s %s" % (action, outtype))
         elif action in ['Load layer', 'Load table']:
-            if outtype == 'npz':
+            if outtype == 'npz' or output_type == 'asset_risk':
                 self.open_output(output_id, output_type)
             elif outtype == 'csv':
                 dest_folder = tempfile.gettempdir()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.5.1
+version=3.5.2
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.5.2
+    * Fixed a bug in the loader for asset_risk outputs, that was downloading a not used csv output
     3.5.1
     * Higher map values can optionally be rendered on top of lower values
     * The utility to import_layer_from_csv accepts two additional parameters: 'add_to_legend' and 'add_on_top'
@@ -127,7 +129,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=True
+experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False


### PR DESCRIPTION
@CatalinaYepes had problems downloading the asset_risk output as csv, but I was surprised that the plugin attempted to download it instead of just using the extract api. In fact, there were two bugs: one in the engine (that could not export the csv) and one in the plugin (that was uselessly downloading the csv before loading the actual data through the export api).

In this part of the code that I fixed the logic is a bit tricky, so I should probably refactor it a bit in another PR. For now, this solves the issue.

PS: considering that the asset_risk csv file is sometimes quite big, avoiding to download it should make the plugin noticeably faster while displaying the dialog to load that output.