### PR TITLE
Collapse taxonomies_gbx and tag_gbx when unchecked and adapt dialog size

### DIFF
--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -65,8 +65,8 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         self.populate_out_dep_widgets()
 
         self.adjustSize()
-        self.on_taxonomies_gbx_toggled()
-        self.on_tag_gbx_toggled()
+        self.on_taxonomies_gbx_toggled(False)
+        self.on_tag_gbx_toggled(False)
         self.set_ok_button()
         self.show()
         self.init_done.emit()
@@ -103,7 +103,8 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
             sorted([taxonomy for taxonomy in self.exposure_metadata['taxonomy']
                     if taxonomy != '?']))
         self.taxonomies_gbx_v_layout.addWidget(self.taxonomies_multisel)
-        self.taxonomies_gbx.toggled.connect(self.on_taxonomies_gbx_toggled)
+        self.taxonomies_gbx.toggled[bool].connect(
+            self.on_taxonomies_gbx_toggled)
         self.vlayout.addWidget(self.taxonomies_gbx)
         self.tag_gbx = QGroupBox()
         self.tag_gbx.setTitle('Filter by tag')
@@ -119,7 +120,7 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         self.tag_cbx.addItems([
             tag_name for tag_name in self.tag_names if tag_name != 'taxonomy'])
         self.tag_gbx_v_layout.addWidget(self.tag_values_multisel)
-        self.tag_gbx.toggled.connect(self.on_tag_gbx_toggled)
+        self.tag_gbx.toggled[bool].connect(self.on_tag_gbx_toggled)
         self.vlayout.addWidget(self.tag_gbx)
         self.higher_on_top_chk = QCheckBox('Render higher values on top')
         self.higher_on_top_chk.setChecked(True)
@@ -132,21 +133,13 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
             self.pre_populate_zonal_layer_cbx()
         self.exposure_rbn.setChecked(True)
 
-    def on_taxonomies_gbx_toggled(self):
-        if self.taxonomies_gbx.isChecked():
-            for widget in self.taxonomies_gbx.findChildren(QWidget):
-                widget.setVisible(True)
-        else:
-            for widget in self.taxonomies_gbx.findChildren(QWidget):
-                widget.setVisible(False)
+    def on_taxonomies_gbx_toggled(self, is_checked):
+        for widget in self.taxonomies_gbx.findChildren(QWidget):
+            widget.setVisible(is_checked)
 
-    def on_tag_gbx_toggled(self):
-        if self.tag_gbx.isChecked():
-            for widget in self.tag_gbx.findChildren(QWidget):
-                widget.setVisible(True)
-        else:
-            for widget in self.tag_gbx.findChildren(QWidget):
-                widget.setVisible(False)
+    def on_tag_gbx_toggled(self, is_checked):
+        for widget in self.tag_gbx.findChildren(QWidget):
+            widget.setVisible(is_checked)
 
     def on_visualize_changed(self):
         self.peril_cbx.setEnabled(self.risk_rbn.isChecked())

--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -23,7 +23,7 @@
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
 from qgis.PyQt.QtWidgets import (
-    QGroupBox, QVBoxLayout, QHBoxLayout, QRadioButton, QCheckBox)
+    QGroupBox, QVBoxLayout, QHBoxLayout, QRadioButton, QCheckBox, QWidget,)
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication,)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
@@ -65,6 +65,8 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         self.populate_out_dep_widgets()
 
         self.adjustSize()
+        self.on_taxonomies_gbx_toggled()
+        self.on_tag_gbx_toggled()
         self.set_ok_button()
         self.show()
         self.init_done.emit()
@@ -101,6 +103,7 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
             sorted([taxonomy for taxonomy in self.exposure_metadata['taxonomy']
                     if taxonomy != '?']))
         self.taxonomies_gbx_v_layout.addWidget(self.taxonomies_multisel)
+        self.taxonomies_gbx.toggled.connect(self.on_taxonomies_gbx_toggled)
         self.vlayout.addWidget(self.taxonomies_gbx)
         self.tag_gbx = QGroupBox()
         self.tag_gbx.setTitle('Filter by tag')
@@ -116,6 +119,7 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         self.tag_cbx.addItems([
             tag_name for tag_name in self.tag_names if tag_name != 'taxonomy'])
         self.tag_gbx_v_layout.addWidget(self.tag_values_multisel)
+        self.tag_gbx.toggled.connect(self.on_tag_gbx_toggled)
         self.vlayout.addWidget(self.tag_gbx)
         self.higher_on_top_chk = QCheckBox('Render higher values on top')
         self.higher_on_top_chk.setChecked(True)
@@ -127,6 +131,22 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         else:
             self.pre_populate_zonal_layer_cbx()
         self.exposure_rbn.setChecked(True)
+
+    def on_taxonomies_gbx_toggled(self):
+        if self.taxonomies_gbx.isChecked():
+            for widget in self.taxonomies_gbx.findChildren(QWidget):
+                widget.setVisible(True)
+        else:
+            for widget in self.taxonomies_gbx.findChildren(QWidget):
+                widget.setVisible(False)
+
+    def on_tag_gbx_toggled(self):
+        if self.tag_gbx.isChecked():
+            for widget in self.tag_gbx.findChildren(QWidget):
+                widget.setVisible(True)
+        else:
+            for widget in self.tag_gbx.findChildren(QWidget):
+                widget.setVisible(False)
 
     def on_visualize_changed(self):
         self.peril_cbx.setEnabled(self.risk_rbn.isChecked())

--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -65,8 +65,8 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         self.populate_out_dep_widgets()
 
         self.adjustSize()
-        self.on_taxonomies_gbx_toggled(False)
-        self.on_tag_gbx_toggled(False)
+        self.taxonomies_gbx.toggled.emit(False)
+        self.tag_gbx.toggled.emit(False)
         self.set_ok_button()
         self.show()
         self.init_done.emit()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -356,8 +356,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.zonal_layer = QgsProject.instance().mapLayer(zonal_layer_id)
         self.set_ok_button()
 
-    def on_zonal_layer_gbx_toggled(self, on):
-        if on and not self.zonal_layer_cbx.currentText():
+    def on_zonal_layer_gbx_toggled(self, is_checked):
+        if is_checked and not self.zonal_layer_cbx.currentText():
             self.ok_button.setEnabled(False)
         else:
             self.set_ok_button()

--- a/svir/ui/ui_load_output_as_layer.ui
+++ b/svir/ui/ui_load_output_as_layer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>474</width>
-    <height>250</height>
+    <width>208</width>
+    <height>121</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,8 +28,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>454</width>
-        <height>197</height>
+        <width>188</width>
+        <height>68</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/578

I thought about doing the same also for the "Aggregate by zone" groupbox, but it is a little more tricky, so I decided to keep it as it is, at least for the moment.