### PR TITLE
Add (WebUI) wherever explaining things about the OQ-Engine server

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -1011,7 +1011,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 err_msg += ' (you could try prepending http:// or https://)'
             elif isinstance(exc, ConnectionError):
                 err_msg += (
-                    ' (please make sure the OpenQuake Engine WebUI'
+                    ' (please make sure the OpenQuake Engine server (WebUI)'
                     ' is running)')
             elif isinstance(exc, (SvNetworkError, ServerError)):
                 err_msg += (

--- a/svir/help/source/04_irmt_settings.rst
+++ b/svir/help/source/04_irmt_settings.rst
@@ -42,11 +42,11 @@ a remote workstation or cluster. The `OQ Engine Server
 <https://github.com/gem/oq-engine/blob/master/doc/running/server.md>`_ provides
 an HTTP RESTful API. The OpenQuake IRMT plugin leverages this API to enable the user to
 drive the OQ-Engine directly from within QGIS. In order to interface the plugin
-with a running OQ Engine Server, it is necessary to insert in this dialog the
+with a running OQ Engine Server (WebUI), it is necessary to insert in this dialog the
 user credentials (if they are required by the server) and the web URL where the
 service is hosted (see :numref:`fig-connection-profile`). By default, the host
 is set to `http://localhost:8800`, meaning that the plugin will attempt to
-connect to a OQ Engine Server running locally, on port `8800`.
+connect to a OQ Engine Server (WebUI) running locally, on port `8800`.
 
 It is possible to create multiple connection profiles, and to edit or
 remove existing ones. For instance, you might want to use alternatively an OpenQuake

--- a/svir/help/source/14_driving_the_oqengine.rst
+++ b/svir/help/source/14_driving_the_oqengine.rst
@@ -18,7 +18,7 @@ submitting new jobs, watching calculation
 progress, retrieving and visualizing results, seamlessly within the QGIS
 interface. This is made possible by leveraging the OpenQuake Engine
 Server `HTTP RESTful API <https://github.com/gem/oq-engine/blob/master/doc/web-api.md>`_.
-The connection with a running OQ-Engine Server has to be properly set up as described
+The connection with a running OQ-Engine Server (WebUI) has to be properly set up as described
 in :ref:`chap-irmt-settings`. The server can run locally in the same computer where
 QGIS is running, or remotely. For instance, it is possible to connect to a remote
 cluster, to perform jobs that are highly demanding in terms of computational resources.

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -405,7 +405,7 @@ class Irmt(object):
             self.drive_oq_engine_server_dlg.start_polling()
         else:
             log_msg('Unable to connect to the OpenQuake Engine server. '
-                    'Please check that the server is running and the '
+                    'Please check that the server (WebUI) is running and the '
                     'plugin connection settings are correct.', level='C',
                     message_bar=self.drive_oq_engine_server_dlg.message_bar)
 


### PR DESCRIPTION
This minor change should make it more intuitive for users to understand that the engine server starts when you "run the webui". 