### PR TITLE
Fix visualization of multiple realizations for GMFs

### DIFF
--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -146,7 +146,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         added_field_name = add_numeric_attribute(field_name, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_npz_into_layer(self, field_names, rlz_or_stat, **kwargs):
         with edit(self.layer):
             feats = []
             fields = self.layer.fields()
@@ -154,7 +154,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             dataset_field_names = self.get_field_names()
             d2l_field_names = dict(
                 list(zip(dataset_field_names[2:], layer_field_names)))
-            for row in self.dataset:
+            for row in self.npz_file[rlz_or_stat]:
                 # add a feature
                 feat = QgsFeature(fields)
                 for field_name in dataset_field_names:

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -46,7 +46,6 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
 
         self.setWindowTitle(
             'Load ground motion fields as layer')
-        self.create_load_selected_only_ckb()
         self.create_num_sites_indicator()
         # NOTE: gmpe and gsim are synonyms
         self.create_rlz_or_stat_selector('Ground Motion Prediction Equation')
@@ -114,7 +113,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
 
     def load_from_npz(self):
         for rlz, gsim in zip(self.rlzs_or_stats, self.gsims):
-            if (self.load_selected_only_ckb.isChecked()
+            if (not self.load_all_rlzs_or_stats_chk.isChecked()
                     and gsim != self.rlz_or_stat_cbx.currentText()):
                 continue
             with WaitCursorManager('Creating layer for "%s"...'

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -26,6 +26,7 @@ changelog=
     3.6.0
     * Changed the realizations output for OQ-Engine scenario calculations, displaying the GSIM names instead of the branch path
     * All possibly running timers are stopped before the plugin is unloaded
+    * Fixed a bug occurring while loading ground motion fields, that caused only one realization to be visualized
     3.5.3
     * The GUI elements for loading OQ-Engine outputs are in a scrollable area, usable also on low resolution screens
     * Some GUI sections can be expanded/collapsed


### PR DESCRIPTION
This PR fixes two problems:

1. there was a redundant checkbox to load only selected items, which functionality overlapped with that provided by the checkbox used to select one or all realizations. In this context we don't need to avoid selecting all IMTs, so it's pointless to keep another checkbox to force selecting only one IMT.
2. when choosing to load one layer per GMPE, multiple layers were created, but all containing data corresponding to the GMPE that was currently selected in the dropdown menu.

We still don't have a way to display an average GMF, because this is not provided by the OQ-Engine. The hazard scientists are discussing about it, but for now we will just display the separate GMFs corresponding to the available GMPEs.