### PR TITLE
Allow reading geometries from multi-peril input files

### DIFF
--- a/svir/dialogs/load_inputs_dialog.py
+++ b/svir/dialogs/load_inputs_dialog.py
@@ -105,9 +105,10 @@ class LoadInputsDialog(QDialog):
             log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
                     exception=exc)
             raise exc
-        LoadOutputAsLayerDialog.style_maps(
-            self.layer, 'intensity', self.iface, 'input',
-            render_higher_on_top=self.higher_on_top_chk.isChecked())
+        if 'intensity' in [field.name() for field in self.layer.fields()]:
+            LoadOutputAsLayerDialog.style_maps(
+                self.layer, 'intensity', self.iface, 'input',
+                render_higher_on_top=self.higher_on_top_chk.isChecked())
         log_msg('Layer %s was loaded successfully' % layer_name,
                 level='S', message_bar=self.iface.messageBar())
 

--- a/svir/dialogs/load_inputs_dialog.py
+++ b/svir/dialogs/load_inputs_dialog.py
@@ -83,15 +83,15 @@ class LoadInputsDialog(QDialog):
     def get_multi_peril_csv_dict(ini_str):
         config = configparser.ConfigParser(allow_no_value=True)
         config.read_string(ini_str)
-        multi_peril_file_str = None
+        multi_peril_csv_str = None
         for key in config:
-            if 'multi_peril_file' in config[key]:
-                multi_peril_file_str = config[key]['multi_peril_file']
+            if 'multi_peril_csv' in config[key]:
+                multi_peril_csv_str = config[key]['multi_peril_csv']
                 break
-        if multi_peril_file_str is None:
-            raise KeyError('multi_peril_file not found in .ini file')
+        if multi_peril_csv_str is None:
+            raise KeyError('multi_peril_csv not found in .ini file')
         multi_peril_csv_dict = json.loads(
-            multi_peril_file_str.replace('\'', '"'))
+            multi_peril_csv_str.replace('\'', '"'))
         return multi_peril_csv_dict
 
     def load_from_csv(self, csv_path):

--- a/svir/dialogs/load_inputs_dialog.py
+++ b/svir/dialogs/load_inputs_dialog.py
@@ -29,7 +29,8 @@ import configparser
 from qgis.PyQt.QtCore import pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QDialog, QVBoxLayout, QDialogButtonBox, QGroupBox, QCheckBox)
-from svir.utilities.utils import import_layer_from_csv, log_msg
+from svir.utilities.utils import import_layer_from_csv, log_msg, get_headers
+from svir.utilities.shared import GEOM_FIELDNAMES
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 
 
@@ -97,11 +98,12 @@ class LoadInputsDialog(QDialog):
     def load_from_csv(self, csv_path):
         # extract the name of the csv file and remove the extension
         layer_name, ext = os.path.splitext(os.path.basename(csv_path))
-        # FIXME: what if the format is not wkt?
-        if ext == 'wkt':
-            wkt_field = 'WKT'
-        else:
-            wkt_field = None
+        wkt_field = None
+        headers = get_headers(csv_path)
+        for header in headers:
+            if header.lower() in GEOM_FIELDNAMES:
+                wkt_field = header
+                break
         try:
             self.layer = import_layer_from_csv(
                 self, csv_path, layer_name, self.iface, wkt_field=wkt_field,

--- a/svir/dialogs/load_inputs_dialog.py
+++ b/svir/dialogs/load_inputs_dialog.py
@@ -96,11 +96,16 @@ class LoadInputsDialog(QDialog):
 
     def load_from_csv(self, csv_path):
         # extract the name of the csv file and remove the extension
-        layer_name = os.path.splitext(os.path.basename(csv_path))[0]
+        layer_name, ext = os.path.splitext(os.path.basename(csv_path))
+        # FIXME: what if the format is not wkt?
+        if ext == 'wkt':
+            wkt_field = 'WKT'
+        else:
+            wkt_field = None
         try:
             self.layer = import_layer_from_csv(
-                self, csv_path, layer_name, self.iface, add_to_legend=True,
-                add_on_top=True, zoom_to_layer=True)
+                self, csv_path, layer_name, self.iface, wkt_field=wkt_field,
+                add_to_legend=True, add_on_top=True, zoom_to_layer=True)
         except RuntimeError as exc:
             log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
                     exception=exc)

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -27,6 +27,7 @@ import tempfile
 from collections import OrderedDict
 from svir.utilities.utils import (import_layer_from_csv,
                                   get_params_from_comment_line,
+                                  count_heading_commented_lines,
                                   log_msg,
                                   )
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
@@ -99,11 +100,12 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
         # extract the name of the csv file and remove the extension
         layer_name = os.path.splitext(os.path.basename(csv_path))[0]
         layer_name += '_%sy' % investigation_time
+        n_lines_to_skip = count_heading_commented_lines(csv_path)
         try:
             self.layer = import_layer_from_csv(
                 self, csv_path, layer_name, self.iface,
                 wkt_field='boundary', delimiter='\\t',
-                lines_to_skip_count=1,
+                lines_to_skip_count=n_lines_to_skip,
                 save_as_shp=self.save_as_shp_ckb.isChecked(),
                 dest_shp=dest_shp)
         except RuntimeError as exc:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Changed the realizations output for OQ-Engine scenario calculations, displaying the GSIM names instead of the branch path
     * All possibly running timers are stopped before the plugin is unloaded
     * Fixed a bug occurring while loading ground motion fields, that caused only one realization to be visualized
+    * Multi-peril input files containing geometries as WKT can be loaded as layers
     3.5.3
     * The GUI elements for loading OQ-Engine outputs are in a scrollable area, usable also on low resolution screens
     * Some GUI sections can be expanded/collapsed

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -360,12 +360,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             return
         if output_type in (OQ_CSV_TO_LAYER_TYPES |
                            OQ_RST_TYPES | OQ_ZIPPED_TYPES):
+            print('\tLoading output type %s...' % output_type)
             if output_type in OQ_CSV_TO_LAYER_TYPES:
-                print('\tLoading output type %s...' % output_type)
                 # TODO: we should test the actual downloader, asynchronously
                 filepath = self.download_output(output['id'], 'csv')
             elif output_type in OQ_RST_TYPES:
-                print('\tLoading output type %s...' % output_type)
                 # TODO: we should test the actual downloader, asynchronously
                 filepath = self.download_output(output['id'], 'rst')
             elif output_type in OQ_ZIPPED_TYPES:

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -292,3 +292,5 @@ RAMP_EXTREME_COLORS = {
         {'top': '#d7191c',
          'bottom': '#2b83ba'}
 }
+
+GEOM_FIELDNAMES = ('geom', 'the_geom', 'geometry', 'wkt')

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -270,6 +270,16 @@ def count_heading_commented_lines(fname):
     return lines_to_skip_count
 
 
+def get_headers(fname, sep=','):
+    n_lines_to_skip = count_heading_commented_lines(fname)
+    with open(fname) as f:
+        for i in range(n_lines_to_skip):
+            next(f)
+        line = next(f)
+    headers = [header.strip() for header in line.split(sep)]
+    return headers
+
+
 def set_operator(sub_tree, operator):
     """
     if the root of the sub_tree has children, set the operator to be used to


### PR DESCRIPTION
The GUI will create a checkbox for each of the files specified in the multi_peril_csv section of the .ini file. They will be checked by default, therefore all files will be loaded as layers if the user just presses ok. Otherwise, users can unselect as many files as they prefer.
All csv files that contain an 'intensity' column will be styled with respect to it.
All files that contain a 'wkt' column will be read using that column to retrieve the geometry. In order to be more flexible, I am also accepting columns like 'geom', 'the_geom' or 'geometry' (case insensitive).