### PR TITLE
Major improvements in integration tests

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -2,14 +2,29 @@
 
 set -e
 
+if [ "$TRAVIS_PULL_REQUEST_BRANCH" != "" ]; then
+    BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
+elif [ "$TRAVIS_BRANCH" != "" ]; then
+    BRANCH=$TRAVIS_BRANCH
+else
+    BRANCH='master'
+fi
+if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${BRANCH})" == "" ]; then
+    BRANCH='master'
+fi
+export BRANCH
+
 docker rm -f qgis || true
 docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/tests_directory \
  -e DISPLAY=:99 \
  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+ -e BRANCH="$BRANCH" \
  qgis/qgis:latest
 
 docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
+
+docker exec -it qgis sh -c "git clone -q -b $BRANCH --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$BRANCH'"
 
 docker exec -it qgis sh -c "qgis_setup.sh svir"
 

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -607,6 +607,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 data = {}
             files = {'archive': open(zipped_file_name, 'rb')}
             try:
+                log_msg('POST: %s, with files: %s, with data: %s' % (
+                            run_calc_url, files, data),
+                        level='I', print_to_stderr=True)
                 resp = self.session.post(
                     run_calc_url, files=files, data=data, timeout=20,
                     stream=True)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -770,8 +770,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                                           OQ_EXTRACT_TO_VIEW_TYPES):
                         # FIXME: enable button for ebrisk as soon as the output
                         # will be loadable
-                        if (calculation_mode == 'ebrisk'
-                                and output['type'] not in OQ_RST_TYPES):
+                        if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
+                                calculation_mode == 'ebrisk'):
                             continue
                         action = 'Show'
                     elif output['type'] in OQ_ZIPPED_TYPES:

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -146,7 +146,7 @@ class ExtractThread(QThread):
 
         if not resp.ok:
             self.exception_sig.emit(ExtractFailed(
-                "%s (%s): %s" % (err_msg, resp.reason, resp.content)))
+                "%s (%s):\n%s" % (err_msg, resp.reason, resp.content)))
             return
 
         # FIXME: use stream=True

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -146,7 +146,8 @@ class ExtractThread(QThread):
 
         if not resp.ok:
             self.exception_sig.emit(ExtractFailed(
-                "%s (%s):\n%s" % (err_msg, resp.reason, resp.content)))
+                "%s (%s):\n%s" % (err_msg, resp.reason,
+                                  resp.content.decode('utf8'))))
             return
 
         # FIXME: use stream=True

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -33,7 +33,6 @@ import time
 import operator
 import requests
 from mock import Mock
-from qgis.core import QgsApplication
 from qgis.utils import iface
 from qgis.testing import unittest
 from svir.irmt import Irmt
@@ -50,8 +49,6 @@ from svir.dialogs.drive_oq_engine_server_dialog import OUTPUT_TYPE_LOADERS
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 from svir.dialogs.load_inputs_dialog import LoadInputsDialog
 
-
-QGIS_APP = QgsApplication([], True)
 
 LONG_LOADING_TIME = 10  # seconds
 
@@ -412,7 +409,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             timeout = 10
             start_time = time.time()
             while time.time() - start_time < timeout:
-                QGIS_APP.processEvents()
                 if self.loading_completed:
                     print('\t\tok')
                     return

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -575,9 +575,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         num_feats = layer.featureCount()
         self.assertGreater(
             num_feats, 0, 'The layer does not contain any feature!')
+        # select first feature only
         layer.select(1)
         layer.removeSelection()
-        if num_feats > 1:
-            layer.select(2)
-        layer.selectAll()
+        # select first and last features (just one if there is only one)
+        layer.select([1, num_feats])
         layer.removeSelection()
+        # NOTE: in the past, we were also selecting all features, but it was
+        # not necessary ant it made tests much slower in case of many features

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -457,9 +457,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         calc_id = calc['id']
         output_type = output['type']
         # TODO: when ebrisk becomes loadable, let's not skip this
-        if calc['calculation_mode'] == 'ebrisk':
+        if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
+                calc['calculation_mode'] == 'ebrisk'):
             self._store_skipped_attempt(
-                calc_id, calc['description'], output_type)
+                calc_id, calc['calculation_mode'],
+                calc['description'], output_type)
             print('\t\tSKIPPED')
             return 'skipped'
         # NOTE: loading zipped output only for multi_risk

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -33,6 +33,7 @@ import time
 import operator
 import requests
 from mock import Mock
+from qgis.core import QgsApplication
 from qgis.utils import iface
 from qgis.testing import unittest
 from svir.irmt import Irmt
@@ -49,6 +50,8 @@ from svir.dialogs.drive_oq_engine_server_dialog import OUTPUT_TYPE_LOADERS
 from svir.dialogs.show_full_report_dialog import ShowFullReportDialog
 from svir.dialogs.load_inputs_dialog import LoadInputsDialog
 
+
+QGIS_APP = QgsApplication([], True)
 
 LONG_LOADING_TIME = 10  # seconds
 
@@ -409,6 +412,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             timeout = 10
             start_time = time.time()
             while time.time() - start_time < timeout:
+                QGIS_APP.processEvents()
                 if self.loading_completed:
                     print('\t\tok')
                     return

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -74,7 +74,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         cls.global_skipped_attempts = []
         cls.global_time_consuming_outputs = []
         cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
-        time.sleep(1)
+        # NOTE: calc_list must be retrieved BEFORE starting any test
         cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
         cls.irmt.iface.newProject()
 

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -229,16 +229,15 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self.time_consuming_outputs.append(output_dict)
             self.global_time_consuming_outputs.append(output_dict)
 
-    def load_calc_outputs(self, calc, selected_output_type):
+    def load_calc_output(self, calc, selected_output_type):
         calc_id = calc['id']
         for output in self.output_list[calc_id]:
+            if output['type'] != selected_output_type:
+                continue
             output_dict = {'calc_id': calc_id,
                            'calc_description': calc['description'],
                            'output_type': output['type']}
             start_time = time.time()
-            if (selected_output_type is not None
-                    and output['type'] != selected_output_type):
-                continue
             print('\n\tCalculation %s: %s' % (calc['id'], calc['description']))
             try:
                 loading_resp = self.load_output(calc, output)
@@ -472,13 +471,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         if output_type in (OQ_CSV_TO_LAYER_TYPES |
                            OQ_RST_TYPES | OQ_ZIPPED_TYPES):
             if output_type in OQ_CSV_TO_LAYER_TYPES:
-                # TODO: we should test the actual downloader, asynchronously
-                filepath = self.download_output(output['id'], 'csv')
+                filetype = 'csv'
             elif output_type in OQ_RST_TYPES:
-                # TODO: we should test the actual downloader, asynchronously
-                filepath = self.download_output(output['id'], 'rst')
-            elif output_type in OQ_ZIPPED_TYPES:
-                filepath = self.download_output(output['id'], 'zip')
+                filetype = 'rst'
+            else:  # OQ_ZIPPED_TYPES
+                filetype = 'zip'
+            # TODO: we should test the actual downloader, asynchronously
+            filepath = self.download_output(output['id'], filetype)
             assert filepath is not None
             self.irmt.iface.newProject()
             if output_type == 'fullreport':
@@ -559,7 +558,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.skipped_attempts = []
         self.time_consuming_outputs = []
         for calc in self.calc_list:
-            self.load_calc_outputs(calc, selected_output_type)
+            self.load_calc_output(calc, selected_output_type)
         if self.skipped_attempts:
             print('\nSkipped:')
             for skipped_attempt in self.skipped_attempts:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -456,14 +456,14 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
         output_type = output['type']
-        # # TODO: when ebrisk becomes loadable, let's not skip this
-        # if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
-        #         calc['calculation_mode'] == 'ebrisk'):
-        #     self._store_skipped_attempt(
-        #         calc_id, calc['calculation_mode'],
-        #         calc['description'], output_type)
-        #     print('\t\tSKIPPED')
-        #     return 'skipped'
+        # TODO: when ebrisk becomes loadable, let's not skip this
+        if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
+                calc['calculation_mode'] == 'ebrisk'):
+            self._store_skipped_attempt(
+                calc_id, calc['calculation_mode'],
+                calc['description'], output_type)
+            print('\t\tSKIPPED')
+            return 'skipped'
         # NOTE: loading zipped output only for multi_risk
         if output_type == 'input' and calc['calculation_mode'] != 'multi_risk':
             self._store_skipped_attempt(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -115,27 +115,53 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         #   4) remove the calculation
         pass
 
-    def test_all_output_types_found_in_demos(self):
+    def test_all_loadable_output_types_found_in_demos(self):
+        loadable_output_types_found = set()
+        loadable_output_types_not_found = set()
         calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
-        for output_type in OQ_ALL_TYPES:
-            output_found = False
+        for loadable_output_type in OQ_ALL_TYPES:
+            loadable_output_type_found = False
             for calc in calc_list:
                 output_list = \
                     self.irmt.drive_oq_engine_server_dlg.get_output_list(
                         calc['id'])
                 for output in output_list:
-                    if output_type == output['type']:
-                        output_found = True
-                        print("\t%s found" % output_type)
+                    if loadable_output_type == output['type']:
+                        loadable_output_type_found = True
+                        loadable_output_types_found.add(loadable_output_type)
                         break
-                if output_found:
+                if loadable_output_type_found:
                     break
-            if not output_found:
-                if output_type.endswith('_aggr'):
-                    print("\t%s not found, tested in load_calc_outputs" %
-                          output_type)
                 else:
-                    raise RuntimeError("%s not found" % output_type)
+                    loadable_output_types_not_found.add(loadable_output_type)
+        if loadable_output_types_found:
+            print("Output_types found at least in one demo:\n%s" %
+                  ",".join(loadable_output_types_found))
+        else:
+            raise RuntimeError("No loadable output type was found in any demo")
+        if loadable_output_types_not_found:
+            print("Output_types not found in any demo:\n%s" %
+                  ",".join(loadable_output_types_not_found))
+            if all([output_type.endswith('_aggr')
+                    for output_type in loadable_output_types_not_found]):
+                print("The only missing output types are '_aggr', which are"
+                      " not actual outputs exposed by the engine, but"
+                      " derived outputs accessed through the extract API."
+                      " Therefore, is is ok.")
+            else:
+                print("Some missing output types are '_aggr', which are"
+                      " not actual outputs exposed by the engine, but"
+                      " derived outputs accessed through the extract API."
+                      " Therefore, is is ok: %s" % [
+                          output_type
+                          for output_type in loadable_output_types_not_found
+                          if output_type.endswith('_aggr')])
+                raise RuntimeError(
+                    "The following loadable output types were not found in"
+                    " any demo:\n%s" % [
+                        output_type
+                        for output_type in loadable_output_types_not_found
+                        if not output_type.endswith('_aggr')])
 
     def test_all_loaders_are_implemented(self):
         calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -76,6 +76,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
         # NOTE: calc_list must be retrieved BEFORE starting any test
         cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
+        cls.output_list = {}
         try:
             selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
         except (ValueError, TypeError):
@@ -92,6 +93,10 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         print("List of tested OQ-Engine demo calculations:")
         for calc in cls.calc_list:
             print('\tCalculation %s: %s' % (calc['id'], calc['description']))
+            cls.output_list[calc['id']] = \
+                cls.irmt.drive_oq_engine_server_dlg.get_output_list(calc['id'])
+            print('\t\tOutput types: %s' % ', '.join(
+                [output['type'] for output in cls.output_list]))
 
     @classmethod
     def tearDownClass(cls):
@@ -137,10 +142,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         for loadable_output_type in OQ_ALL_TYPES:
             loadable_output_type_found = False
             for calc in self.calc_list:
-                output_list = \
-                    self.irmt.drive_oq_engine_server_dlg.get_output_list(
-                        calc['id'])
-                for output in output_list:
+                for output in self.output_list[calc['id']]:
                     if loadable_output_type == output['type']:
                         loadable_output_type_found = True
                         loadable_output_types_found.add(loadable_output_type)
@@ -181,9 +183,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
     def test_all_loaders_are_implemented(self):
         not_implemented_loaders = set()
         for calc in self.calc_list:
-            output_list = self.irmt.drive_oq_engine_server_dlg.get_output_list(
-                calc['id'])
-            for output in output_list:
+            for output in self.output_list[calc['id']]:
                 if output['type'] not in OQ_ALL_TYPES:
                     not_implemented_loaders.add(output['type'])
         if not_implemented_loaders:
@@ -230,9 +230,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     def load_calc_outputs(self, calc, selected_output_type):
         calc_id = calc['id']
-        output_list = self.irmt.drive_oq_engine_server_dlg.get_output_list(
-            calc_id)
-        for output in output_list:
+        for output in self.output_list[calc_id]:
             output_dict = {'calc_id': calc_id,
                            'calc_description': calc['description'],
                            'output_type': output['type']}

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -76,6 +76,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
         # NOTE: calc_list must be retrieved BEFORE starting any test
         cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
+        print("List of OQ-Engine demo calculations:")
+        for calc in cls.calc_list:
+            print('\tCalculation %s: %s' % (calc['id'], calc['description']))
         cls.irmt.iface.newProject()
 
     @classmethod

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -72,6 +72,28 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.irmt.drive_oq_engine_server(show=False, hostname=self.hostname)
         self.irmt.iface.newProject()
 
+    def test_all_output_types_found_in_demos(self):
+        calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
+        for output_type in OQ_ALL_TYPES:
+            output_found = False
+            for calc in calc_list:
+                output_list = \
+                    self.irmt.drive_oq_engine_server_dlg.get_output_list(
+                        calc['id'])
+                for output in output_list:
+                    if output_type == output['type']:
+                        output_found = True
+                        print("%s found" % output_type)
+                        break
+                if output_found:
+                    break
+            if not output_found:
+                if output_type.endswith('_aggr'):
+                    print("%s not found, tested in test_load_outputs" %
+                          output_type)
+                else:
+                    raise RuntimeError("%s not found" % output_type)
+
     def download_output(self, output_id, outtype):
         dest_folder = tempfile.gettempdir()
         output_download_url = (

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -79,7 +79,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        print("\n\nGLOBAL SUMMARY:")
+        print("\n\nGLOBAL SUMMARY")
+        print("==============\n")
         if cls.global_skipped_attempts:
             print('\nSkipped:')
             for skipped_attempt in cls.global_skipped_attempts:
@@ -107,6 +108,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     @unittest.skip("TODO")
     def test_run_calculation(self):
+        # We should:
+        #   1) have input files available
+        #   2) start the calculation
+        #   3) in a loop, print the console log until finished
+        #   4) remove the calculation
         pass
 
     def test_all_output_types_found_in_demos(self):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -125,6 +125,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                       % (failed_attempt['calc_id'],
                          failed_attempt['calc_mode'],
                          failed_attempt['calc_description']))
+                print('\t\tOutput type: %s' % failed_attempt['output_type'])
         if cls.global_time_consuming_outputs:
             print('\n\nSome loaders took longer than %s seconds:' %
                   LONG_LOADING_TIME)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -548,6 +548,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         if selected_calc_id is not None:
             calc_list = [calc for calc in self.calc_list
                          if calc['id'] == selected_calc_id]
+        else:
+            calc_list = self.calc_list
         for calc in calc_list:
             self.load_calc_outputs(calc, selected_output_type)
         if self.skipped_attempts:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -570,7 +570,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 # NOTE: we avoid printing the error also at the end, because:
                 #       1) it would be a duplicate
                 #       2) it would not contain the traceback from the engine
-                failing_summary += '\n\tCalculation %s (%s): %s' % (
+                failing_summary += ('\n\tCalculation %s (%s): %s'
+                                    '\n\t\t(please check traceback ahead)') % (
                     failed_attempt['calc_id'],
                     failed_attempt['calc_mode'],
                     failed_attempt['calc_description'])

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -125,10 +125,25 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                     break
             if not output_found:
                 if output_type.endswith('_aggr'):
-                    print("\t%s not found, tested in test_load_output" %
+                    print("\t%s not found, tested in load_calc_outputs" %
                           output_type)
                 else:
                     raise RuntimeError("%s not found" % output_type)
+
+    def test_all_loaders_are_implemented(self):
+        not_implemented_loaders = []
+        for calc in self.calc_list:
+            output_list = self.irmt.drive_oq_engine_server_dlg.get_output_list(
+                calc['id'])
+            for output in output_list:
+                if output['type'] not in OQ_ALL_TYPES:
+                    not_implemented_loaders.append(output)
+        if not_implemented_loaders:
+            print("Some loaders are still not implemented:")
+            print(not_implemented_loaders)
+        else:
+            print("All outputs in the demos have a corresponding loader")
+        # NOTE: We want green tests even when loaders are still missing
 
     def download_output(self, output_id, outtype):
         dest_folder = tempfile.gettempdir()

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -131,16 +131,17 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                     raise RuntimeError("%s not found" % output_type)
 
     def test_all_loaders_are_implemented(self):
-        not_implemented_loaders = []
+        not_implemented_loaders = set()
         for calc in self.calc_list:
             output_list = self.irmt.drive_oq_engine_server_dlg.get_output_list(
                 calc['id'])
             for output in output_list:
                 if output['type'] not in OQ_ALL_TYPES:
-                    not_implemented_loaders.append(output)
+                    not_implemented_loaders.add(output)
         if not_implemented_loaders:
-            print("Some loaders are still not implemented:")
-            print(not_implemented_loaders)
+            print('\n\nLoaders for the following output types found in the'
+                  ' available calculations have not been implemented yet:')
+            print(", ".join(not_implemented_loaders))
         else:
             print("All outputs in the demos have a corresponding loader")
         # NOTE: We want green tests even when loaders are still missing
@@ -490,10 +491,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             os.close(tmpfile_handler)
             print('\t\tok')
             return
-        else:
-            self.not_implemented_loaders.add(output_type)
-            print('\tLoader for output type %s is not implemented'
-                  % output_type)
 
     def on_loading_completed(self):
         self.loading_completed = True
@@ -508,7 +505,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.failed_attempts = []
         self.skipped_attempts = []
         self.time_consuming_outputs = []
-        self.not_implemented_loaders = set()
         calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
         try:
             selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
@@ -550,13 +546,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                                  key=operator.itemgetter('loading_time'),
                                  reverse=True):
                 print('\t%s' % output)
-        if self.not_implemented_loaders:
-            # sanity check
-            for not_implemented_loader in self.not_implemented_loaders:
-                assert not_implemented_loader not in OQ_ALL_TYPES
-            print('\n\nLoaders for the following output types found in the'
-                  ' available calculations have not been implemented yet:')
-            print(", ".join(self.not_implemented_loaders))
 
     def load_hcurves(self):
         self._set_output_type('Hazard Curves')

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -232,34 +232,25 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
     def load_calc_output(self, calc, selected_output_type):
         calc_id = calc['id']
         for output in self.output_list[calc_id]:
-            if output['type'] != selected_output_type:
+            if (output['type'] != selected_output_type and
+                    "%s_aggr" % output['type'] != selected_output_type):
                 continue
             output_dict = {'calc_id': calc_id,
                            'calc_description': calc['description'],
-                           'output_type': output['type']}
+                           'output_type': selected_output_type}
             start_time = time.time()
             print('\n\tCalculation %s: %s' % (calc['id'], calc['description']))
+            # NOTE: aggregated outputs use an existing OQ-Engine output and
+            #       virtually transforms it postfixing its type with '_aggr'
+            output_copy = copy.deepcopy(output)
+            output_copy['type'] = selected_output_type
             try:
-                loading_resp = self.load_output(calc, output)
+                loading_resp = self.load_output(calc, output_copy)
             except Exception:
                 self._on_loading_ko(output_dict)
             else:
                 if loading_resp != 'skipped':
                     self._on_loading_ok(start_time, output_dict)
-            output_type_aggr = "%s_aggr" % output['type']
-            if output_type_aggr in OQ_EXTRACT_TO_VIEW_TYPES:
-                aggr_output = copy.deepcopy(output)
-                aggr_output['type'] = output_type_aggr
-                aggr_output_dict = copy.deepcopy(output_dict)
-                aggr_output_dict['output_type'] = aggr_output['type']
-                start_time = time.time()
-                try:
-                    loading_resp = self.load_output(calc, aggr_output)
-                except Exception:
-                    self._on_loading_ko(aggr_output_dict)
-                else:
-                    if loading_resp != 'skipped':
-                        self._on_loading_ok(start_time, aggr_output_dict)
 
     def on_init_done(self, dlg):
         # set dialog options and accept

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -74,6 +74,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         cls.global_skipped_attempts = []
         cls.global_time_consuming_outputs = []
         cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
+        time.sleep(1)
         cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
         cls.irmt.iface.newProject()
 
@@ -118,10 +119,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
     def test_all_loadable_output_types_found_in_demos(self):
         loadable_output_types_found = set()
         loadable_output_types_not_found = set()
-        calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
         for loadable_output_type in OQ_ALL_TYPES:
             loadable_output_type_found = False
-            for calc in calc_list:
+            for calc in self.calc_list:
                 output_list = \
                     self.irmt.drive_oq_engine_server_dlg.get_output_list(
                         calc['id'])
@@ -164,9 +164,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                         if not output_type.endswith('_aggr')]))
 
     def test_all_loaders_are_implemented(self):
-        calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
         not_implemented_loaders = set()
-        for calc in calc_list:
+        for calc in self.calc_list:
             output_list = self.irmt.drive_oq_engine_server_dlg.get_output_list(
                 calc['id'])
             for output in output_list:
@@ -536,7 +535,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.failed_attempts = []
         self.skipped_attempts = []
         self.time_consuming_outputs = []
-        calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
         try:
             selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
         except (ValueError, TypeError):
@@ -548,7 +546,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                   ' Running tests only for calculation #%s'
                   % selected_calc_id)
         if selected_calc_id is not None:
-            calc_list = [calc for calc in calc_list
+            calc_list = [calc for calc in self.calc_list
                          if calc['id'] == selected_calc_id]
         for calc in calc_list:
             self.load_calc_outputs(calc, selected_output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -92,7 +92,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         print("List of tested OQ-Engine demo calculations:")
         for calc in cls.calc_list:
             print('\tCalculation %s: %s' % (calc['id'], calc['description']))
-        cls.irmt.iface.newProject()
 
     @classmethod
     def tearDownClass(cls):
@@ -455,7 +454,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.global_skipped_attempts.append(skipped_attempt)
 
     def load_output(self, calc, output):
-        self.irmt.iface.newProject()
+        # NOTE: it is better to avoid resetting the project here, because some
+        # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
         output_type = output['type']
         # TODO: when ebrisk becomes loadable, let's not skip this
@@ -481,6 +481,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             elif output_type in OQ_ZIPPED_TYPES:
                 filepath = self.download_output(output['id'], 'zip')
             assert filepath is not None
+            self.irmt.iface.newProject()
             if output_type == 'fullreport':
                 dlg = ShowFullReportDialog(filepath)
                 dlg.accept()
@@ -511,6 +512,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                     calc_id, calc['description'], output_type)
                 print('\t\tSKIPPED')
                 return 'skipped'
+            self.irmt.iface.newProject()
             dlg = OUTPUT_TYPE_LOADERS[output_type](
                 self.irmt.iface, self.irmt.viewer_dock,
                 self.irmt.drive_oq_engine_server_dlg.session,
@@ -536,6 +538,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 'Loading time exceeded %s seconds' % timeout)
             return 'ko'
         elif output_type in OQ_EXTRACT_TO_VIEW_TYPES:
+            self.irmt.iface.newProject()
             self.irmt.viewer_dock.load_no_map_output(
                 calc_id, self.irmt.drive_oq_engine_server_dlg.session,
                 self.hostname, output_type,

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -143,7 +143,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 calc['id'])
             for output in output_list:
                 if output['type'] not in OQ_ALL_TYPES:
-                    not_implemented_loaders.add(output)
+                    not_implemented_loaders.add(output['type'])
         if not_implemented_loaders:
             print('\n\nLoaders for the following output types found in the'
                   ' available calculations have not been implemented yet:')

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -79,11 +79,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         try:
             selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
         except (ValueError, TypeError):
-            print('\n\n\tSELECTED_CALC_ID was not set or is not an integer'
+            print('SELECTED_CALC_ID was not set or is not an integer'
                   ' value. Running tests for all the available calculations')
             selected_calc_id = None
         else:
-            print('\n\n\tSELECTED_CALC_ID is set.'
+            print('SELECTED_CALC_ID is set.'
                   ' Running tests only for calculation #%s'
                   % selected_calc_id)
         if selected_calc_id is not None:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -319,6 +319,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self._test_export()
         dlg.loading_completed.emit()
 
+    def _store_skipped_attempt(self, id, description, type):
+        skipped_attempt = {
+            'calc_id': id,
+            'calc_description': description,
+            'output_type': type}
+        self.skipped_attempts.append(skipped_attempt)
+
     def load_output(self, calc, output):
         self.irmt.iface.newProject()
         calc_id = calc['id']
@@ -326,21 +333,15 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # TODO: when ebrisk becomes loadable, let's not skip this
         if calc['calculation_mode'] == 'ebrisk':
             print('\tLoading output type %s...' % output_type)
-            skipped_attempt = {
-                'calc_id': calc_id,
-                'calc_description': calc['description'],
-                'output_type': output_type}
-            self.skipped_attempts.append(skipped_attempt)
+            self._store_skipped_attempt(
+                calc_id, calc['description'], output_type)
             print('\t\tSKIPPED')
             return
         # NOTE: loading zipped output only for multi_risk
         if output_type == 'input' and calc['calculation_mode'] != 'multi_risk':
             print('\tLoading output type %s...' % output_type)
-            skipped_attempt = {
-                'calc_id': calc_id,
-                'calc_description': calc['description'],
-                'output_type': output_type}
-            self.skipped_attempts.append(skipped_attempt)
+            self._store_skipped_attempt(
+                calc_id, calc['description'], output_type)
             print('\t\tSKIPPED')
             return
         if output_type in (OQ_CSV_TO_LAYER_TYPES |
@@ -380,11 +381,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             #       let's not skip this
             if (output_type == 'gmf_data'
                     and calc['calculation_mode'] == 'event_based'):
-                skipped_attempt = {
-                    'calc_id': calc_id,
-                    'calc_description': calc['description'],
-                    'output_type': output_type}
-                self.skipped_attempts.append(skipped_attempt)
+                self._store_skipped_attempt(
+                    calc_id, calc['description'], output_type)
                 print('\t\tSKIPPED')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -504,9 +504,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
     def on_loading_exception(self, exception):
         self.loading_exception = exception
 
-    def test_load_realizations(self):
-        self.load_output_type('realizations')
-
     def load_output_type(self, selected_output_type):
         self.failed_attempts = []
         self.skipped_attempts = []

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -382,12 +382,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             if output_type == 'fullreport':
                 dlg = ShowFullReportDialog(filepath)
                 dlg.accept()
-                print('\t\tok')
+                print('\t\tok\n')
                 return
             if output_type in OQ_ZIPPED_TYPES:
                 dlg = LoadInputsDialog(filepath, self.irmt.iface)
                 dlg.accept()
-                print('\t\tok')
+                print('\t\tok\n')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](
                 self.irmt.iface, self.irmt.viewer_dock,
@@ -395,7 +395,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 self.hostname, calc_id, output_type, filepath)
             if dlg.ok_button.isEnabled():
                 dlg.accept()
-                print('\t\tok')
+                print('\t\tok\n')
                 return
             else:
                 raise RuntimeError('The ok button is disabled')
@@ -423,7 +423,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             while time.time() - start_time < timeout:
                 QGIS_APP.processEvents()
                 if self.loading_completed:
-                    print('\t\tok')
+                    print('\t\tok\n')
                     return
                 if self.loading_exception:
                     raise self.loading_exception
@@ -438,7 +438,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.irmt.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)
-            print('\t\tok')
+            print('\t\tok\n')
             return
         else:
             self.not_implemented_loaders.add(output_type)
@@ -483,10 +483,10 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                          skipped_attempt['calc_description']))
                 print('\t\tOutput type: %s' % skipped_attempt['output_type'])
         if not self.failed_attempts:
-            print('\n\n%s successfully loaded for all calculations' %
+            print('\n%s successfully loaded for all calculations' %
                   selected_output_type)
         else:
-            print('\n\nFailed attempts:')
+            print('\nFailed attempts:')
             for failed_attempt in self.failed_attempts:
                 print('\tCalculation %s: %s'
                       % (failed_attempt['calc_id'],

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -456,6 +456,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
         output_type = output['type']
+        # TODO: when ebrisk becomes loadable, let's not skip this
+        if calc['calculation_mode'] == 'ebrisk':
+            self._store_skipped_attempt(
+                calc_id, calc['description'], output_type)
+            print('\t\tSKIPPED')
+            return 'skipped'
         # NOTE: loading zipped output only for multi_risk
         if output_type == 'input' and calc['calculation_mode'] != 'multi_risk':
             self._store_skipped_attempt(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -382,12 +382,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             if output_type == 'fullreport':
                 dlg = ShowFullReportDialog(filepath)
                 dlg.accept()
-                print('\t\tok\n')
+                print('\t\tok')
                 return
             if output_type in OQ_ZIPPED_TYPES:
                 dlg = LoadInputsDialog(filepath, self.irmt.iface)
                 dlg.accept()
-                print('\t\tok\n')
+                print('\t\tok')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](
                 self.irmt.iface, self.irmt.viewer_dock,
@@ -395,7 +395,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 self.hostname, calc_id, output_type, filepath)
             if dlg.ok_button.isEnabled():
                 dlg.accept()
-                print('\t\tok\n')
+                print('\t\tok')
                 return
             else:
                 raise RuntimeError('The ok button is disabled')
@@ -423,7 +423,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             while time.time() - start_time < timeout:
                 QGIS_APP.processEvents()
                 if self.loading_completed:
-                    print('\t\tok\n')
+                    print('\t\tok')
                     return
                 if self.loading_exception:
                     raise self.loading_exception
@@ -438,7 +438,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             tmpfile_handler, tmpfile_name = tempfile.mkstemp()
             self.irmt.viewer_dock.write_export_file(tmpfile_name)
             os.close(tmpfile_handler)
-            print('\t\tok\n')
+            print('\t\tok')
             return
         else:
             self.not_implemented_loaders.add(output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -70,9 +70,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.hostname = os.environ.get('OQ_ENGINE_HOST',
                                        'http://localhost:8800')
         self.irmt.drive_oq_engine_server(show=False, hostname=self.hostname)
-        self.reset_gui()
-
-    def reset_gui(self):
         self.irmt.iface.newProject()
 
     def download_output(self, output_id, outtype):
@@ -327,12 +324,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         dlg.loading_completed.emit()
 
     def load_output(self, calc, output):
-        # NOTE: resetting the Data Viewer before loading each output, prevents
-        #       a segfault. For some reason, while running the actual
-        #       application, the GUI is properly re-designed while opening a
-        #       new output, but not in the testing environment (so widgets
-        #       corresponding to previous outputs are not removed from the GUI)
-        self.reset_gui()
+        self.irmt.iface.newProject()
         calc_id = calc['id']
         output_type = output['type']
         # TODO: when ebrisk becomes loadable, let's not skip this

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -567,11 +567,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         else:
             failing_summary = ''
             for failed_attempt in self.failed_attempts:
+                # NOTE: we avoid printing the error also at the end, because:
+                #       1) it would be a duplicate
+                #       2) it would not contain the traceback from the engine
                 failing_summary += '\n\tCalculation %s (%s): %s\n%s' % (
                     failed_attempt['calc_id'],
                     failed_attempt['calc_mode'],
-                    failed_attempt['calc_description'],
-                    ''.join(traceback.format_tb(failed_attempt['traceback'])))
+                    failed_attempt['calc_description'])
             raise FailedAttempts(failing_summary)
         if self.time_consuming_outputs:
             print('\n\nSome loaders took longer than %s seconds:' %

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -32,7 +32,6 @@ import csv
 import time
 import operator
 import requests
-from mock import Mock
 from qgis.core import QgsApplication
 from qgis.utils import iface
 from qgis.testing import unittest
@@ -379,8 +378,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print('\t\tok')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](
-                self.irmt.iface, Mock(), requests, self.hostname, calc_id,
-                output_type, filepath)
+                self.irmt.iface, self.irmt.viewer_dock(), requests,
+                self.hostname, calc_id, output_type, filepath)
             if dlg.ok_button.isEnabled():
                 dlg.accept()
                 print('\t\tok')
@@ -401,8 +400,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print('\t\tSKIPPED')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](
-                self.irmt.iface, Mock(), requests, self.hostname, calc_id,
-                output_type)
+                self.irmt.iface, self.irmt.viewer_dock(), requests,
+                self.hostname, calc_id, output_type)
             self.loading_completed = False
             self.loading_exception = None
             dlg.loading_completed.connect(self.on_loading_completed)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -64,14 +64,15 @@ def run_all():
 
 class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
-    def setUp(self):
-        self.irmt = Irmt(iface)
-        self.irmt.initGui()
-        self.hostname = os.environ.get('OQ_ENGINE_HOST',
-                                       'http://localhost:8800')
-        self.irmt.drive_oq_engine_server(show=False, hostname=self.hostname)
-        self.calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
-        self.irmt.iface.newProject()
+    @classmethod
+    def setUpClass(cls):
+        cls.irmt = Irmt(iface)
+        cls.irmt.initGui()
+        cls.hostname = os.environ.get('OQ_ENGINE_HOST',
+                                      'http://localhost:8800')
+        cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
+        cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
+        cls.irmt.iface.newProject()
 
     @unittest.skip("TODO")
     def test_run_calculation(self):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -116,9 +116,10 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         pass
 
     def test_all_output_types_found_in_demos(self):
+        calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
         for output_type in OQ_ALL_TYPES:
             output_found = False
-            for calc in self.calc_list:
+            for calc in calc_list:
                 output_list = \
                     self.irmt.drive_oq_engine_server_dlg.get_output_list(
                         calc['id'])
@@ -137,8 +138,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                     raise RuntimeError("%s not found" % output_type)
 
     def test_all_loaders_are_implemented(self):
+        calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list
         not_implemented_loaders = set()
-        for calc in self.calc_list:
+        for calc in calc_list:
             output_list = self.irmt.drive_oq_engine_server_dlg.get_output_list(
                 calc['id'])
             for output in output_list:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -135,33 +135,33 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 else:
                     loadable_output_types_not_found.add(loadable_output_type)
         if loadable_output_types_found:
-            print("Output_types found at least in one demo:\n%s" %
-                  ",".join(loadable_output_types_found))
+            print("\nOutput_types found at least in one demo:\n\t%s" %
+                  "\n\t".join(loadable_output_types_found))
         else:
             raise RuntimeError("No loadable output type was found in any demo")
         if loadable_output_types_not_found:
-            print("Output_types not found in any demo:\n%s" %
-                  ",".join(loadable_output_types_not_found))
+            print("\nOutput_types not found in any demo:\n\t%s" %
+                  "\n\t".join(loadable_output_types_not_found))
             if all([output_type.endswith('_aggr')
                     for output_type in loadable_output_types_not_found]):
-                print("The only missing output types are '_aggr', which are"
+                print("\nThe only missing output types are '_aggr', which are"
                       " not actual outputs exposed by the engine, but"
                       " derived outputs accessed through the extract API."
                       " Therefore, is is ok.")
             else:
-                print("Some missing output types are '_aggr', which are"
+                print("\nSome missing output types are '_aggr', which are"
                       " not actual outputs exposed by the engine, but"
                       " derived outputs accessed through the extract API."
-                      " Therefore, is is ok: %s" % [
+                      " Therefore, is is ok:\n\t%s" % "\n\t".join([
                           output_type
                           for output_type in loadable_output_types_not_found
-                          if output_type.endswith('_aggr')])
+                          if output_type.endswith('_aggr')]))
                 raise RuntimeError(
-                    "The following loadable output types were not found in"
-                    " any demo:\n%s" % [
+                    "\nThe following loadable output types were not found in"
+                    " any demo:\n%s" % "\n\t".join([
                         output_type
                         for output_type in loadable_output_types_not_found
-                        if not output_type.endswith('_aggr')])
+                        if not output_type.endswith('_aggr')]))
 
     def test_all_loaders_are_implemented(self):
         calc_list = self.irmt.drive_oq_engine_server_dlg.calc_list

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -378,7 +378,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print('\t\tok')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](
-                self.irmt.iface, self.irmt.viewer_dock(), requests,
+                self.irmt.iface, self.irmt.viewer_dock, requests,
                 self.hostname, calc_id, output_type, filepath)
             if dlg.ok_button.isEnabled():
                 dlg.accept()
@@ -400,7 +400,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print('\t\tSKIPPED')
                 return
             dlg = OUTPUT_TYPE_LOADERS[output_type](
-                self.irmt.iface, self.irmt.viewer_dock(), requests,
+                self.irmt.iface, self.irmt.viewer_dock, requests,
                 self.hostname, calc_id, output_type)
             self.loading_completed = False
             self.loading_exception = None

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -93,10 +93,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         print("List of tested OQ-Engine demo calculations:")
         for calc in cls.calc_list:
             print('\tCalculation %s: %s' % (calc['id'], calc['description']))
-            cls.output_list[calc['id']] = \
+            calc_output_list = \
                 cls.irmt.drive_oq_engine_server_dlg.get_output_list(calc['id'])
+            cls.output_list[calc['id']] = calc_output_list
             print('\t\tOutput types: %s' % ', '.join(
-                [output['type'] for output in cls.output_list]))
+                [output['type'] for output in calc_output_list]))
 
     @classmethod
     def tearDownClass(cls):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -496,14 +496,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 raise RuntimeError('The ok button is disabled')
                 return 'ko'
         elif output_type in OQ_EXTRACT_TO_LAYER_TYPES:
-            # TODO: when gmf_data for event_based becomes loadable,
-            #       let's not skip this
-            if (output_type == 'gmf_data'
-                    and calc['calculation_mode'] == 'event_based'):
-                self._store_skipped_attempt(
-                    calc_id, calc['description'], output_type)
-                print('\t\tSKIPPED')
-                return 'skipped'
             self.irmt.iface.newProject()
             dlg = OUTPUT_TYPE_LOADERS[output_type](
                 self.irmt.iface, self.irmt.viewer_dock,

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -135,8 +135,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                         break
                 if loadable_output_type_found:
                     break
-                else:
-                    loadable_output_types_not_found.add(loadable_output_type)
+            if not loadable_output_type_found:
+                loadable_output_types_not_found.add(loadable_output_type)
         if loadable_output_types_found:
             print("\nOutput_types found at least in one demo:\n\t%s" %
                   "\n\t".join(loadable_output_types_found))

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -87,13 +87,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 for output in output_list:
                     if output_type == output['type']:
                         output_found = True
-                        print("%s found" % output_type)
+                        print("\t%s found" % output_type)
                         break
                 if output_found:
                     break
             if not output_found:
                 if output_type.endswith('_aggr'):
-                    print("%s not found, tested in test_load_output" %
+                    print("\t%s not found, tested in test_load_output" %
                           output_type)
                 else:
                     raise RuntimeError("%s not found" % output_type)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -241,7 +241,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             if (selected_output_type is not None
                     and output['type'] != selected_output_type):
                 continue
-            print('\n\tCalculation %s: %s' % (calc['id'], calc['description']))
+            print('\tCalculation %s: %s' % (calc['id'], calc['description']))
             try:
                 loading_resp = self.load_output(calc, output)
             except Exception:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -456,12 +456,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
         output_type = output['type']
-        # TODO: when ebrisk becomes loadable, let's not skip this
-        if calc['calculation_mode'] == 'ebrisk':
-            self._store_skipped_attempt(
-                calc_id, calc['description'], output_type)
-            print('\t\tSKIPPED')
-            return 'skipped'
         # NOTE: loading zipped output only for multi_risk
         if output_type == 'input' and calc['calculation_mode'] != 'multi_risk':
             self._store_skipped_attempt(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -456,14 +456,14 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
         output_type = output['type']
-        # TODO: when ebrisk becomes loadable, let's not skip this
-        if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
-                calc['calculation_mode'] == 'ebrisk'):
-            self._store_skipped_attempt(
-                calc_id, calc['calculation_mode'],
-                calc['description'], output_type)
-            print('\t\tSKIPPED')
-            return 'skipped'
+        # # TODO: when ebrisk becomes loadable, let's not skip this
+        # if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
+        #         calc['calculation_mode'] == 'ebrisk'):
+        #     self._store_skipped_attempt(
+        #         calc_id, calc['calculation_mode'],
+        #         calc['description'], output_type)
+        #     print('\t\tSKIPPED')
+        #     return 'skipped'
         # NOTE: loading zipped output only for multi_risk
         if output_type == 'input' and calc['calculation_mode'] != 'multi_risk':
             self._store_skipped_attempt(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -241,7 +241,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             if (selected_output_type is not None
                     and output['type'] != selected_output_type):
                 continue
-            print('\tCalculation %s: %s' % (calc['id'], calc['description']))
+            print('\n\tCalculation %s: %s' % (calc['id'], calc['description']))
             try:
                 loading_resp = self.load_output(calc, output)
             except Exception:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -570,7 +570,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 # NOTE: we avoid printing the error also at the end, because:
                 #       1) it would be a duplicate
                 #       2) it would not contain the traceback from the engine
-                failing_summary += '\n\tCalculation %s (%s): %s\n%s' % (
+                failing_summary += '\n\tCalculation %s (%s): %s' % (
                     failed_attempt['calc_id'],
                     failed_attempt['calc_mode'],
                     failed_attempt['calc_description'])

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -97,7 +97,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         traceback.print_tb(failed_attempt['traceback'])
         print(ex)
 
-    def _on_loading_ok(self, start_time, output_dict, output_type):
+    def _on_loading_ok(self, start_time, output_dict):
         loading_time = time.time() - start_time
         print('\t\t(loading time: %.4f sec)' % loading_time)
         if loading_time > LONG_LOADING_TIME:
@@ -120,9 +120,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             try:
                 self.load_output(calc, output)
             except Exception:
-                self._on_loading_ok(output_dict)
+                self._on_loading_ko(output_dict)
             else:
-                self._on_loading_ko(start_time, output_dict)
+                self._on_loading_ok(start_time, output_dict)
             output_type_aggr = "%s_aggr" % output['type']
             if output_type_aggr in OQ_EXTRACT_TO_VIEW_TYPES:
                 aggr_output = copy.deepcopy(output)
@@ -133,9 +133,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 try:
                     self.load_output(calc, aggr_output)
                 except Exception:
-                    self._on_loading_ok(aggr_output_dict)
+                    self._on_loading_ko(aggr_output_dict)
                 else:
-                    self._on_loading_ko(start_time, aggr_output_dict)
+                    self._on_loading_ok(start_time, aggr_output_dict)
 
     def on_init_done(self, dlg):
         # set dialog options and accept

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -248,7 +248,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 self._on_loading_ko(output_dict)
             else:
                 if loading_resp != 'skipped':
-                    self._on_loading_ok(start_time, output_dict, loading_resp)
+                    self._on_loading_ok(start_time, output_dict)
             output_type_aggr = "%s_aggr" % output['type']
             if output_type_aggr in OQ_EXTRACT_TO_VIEW_TYPES:
                 aggr_output = copy.deepcopy(output)
@@ -262,8 +262,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                     self._on_loading_ko(aggr_output_dict)
                 else:
                     if loading_resp != 'skipped':
-                        self._on_loading_ok(
-                            start_time, aggr_output_dict, loading_resp)
+                        self._on_loading_ok(start_time, aggr_output_dict)
 
     def on_init_done(self, dlg):
         # set dialog options and accept

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -76,7 +76,20 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
         # NOTE: calc_list must be retrieved BEFORE starting any test
         cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
-        print("List of OQ-Engine demo calculations:")
+        try:
+            selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
+        except (ValueError, TypeError):
+            print('\n\n\tSELECTED_CALC_ID was not set or is not an integer'
+                  ' value. Running tests for all the available calculations')
+            selected_calc_id = None
+        else:
+            print('\n\n\tSELECTED_CALC_ID is set.'
+                  ' Running tests only for calculation #%s'
+                  % selected_calc_id)
+        if selected_calc_id is not None:
+            cls.calc_list = [calc for calc in cls.calc_list
+                             if calc['id'] == selected_calc_id]
+        print("List of tested OQ-Engine demo calculations:")
         for calc in cls.calc_list:
             print('\tCalculation %s: %s' % (calc['id'], calc['description']))
         cls.irmt.iface.newProject()
@@ -538,22 +551,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.failed_attempts = []
         self.skipped_attempts = []
         self.time_consuming_outputs = []
-        try:
-            selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
-        except (ValueError, TypeError):
-            print('\n\n\tSELECTED_CALC_ID was not set or is not an integer'
-                  ' value. Running tests for all the available calculations')
-            selected_calc_id = None
-        else:
-            print('\n\n\tSELECTED_CALC_ID is set.'
-                  ' Running tests only for calculation #%s'
-                  % selected_calc_id)
-        if selected_calc_id is not None:
-            calc_list = [calc for calc in self.calc_list
-                         if calc['id'] == selected_calc_id]
-        else:
-            calc_list = self.calc_list
-        for calc in calc_list:
+        for calc in self.calc_list:
             self.load_calc_outputs(calc, selected_output_type)
         if self.skipped_attempts:
             print('\nSkipped:')

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -223,12 +223,12 @@ OQ_BASIC_CSV_TO_LAYER_TYPES = set([
     'realizations', 'sourcegroups', 'dmg_by_event', 'losses_by_event',
     'agg_risk'])
 OQ_COMPLEX_CSV_TO_LAYER_TYPES = set(['ruptures'])
-OQ_ZIPPED_TYPES = set(['input'])
 OQ_CSV_TO_LAYER_TYPES = (
     OQ_BASIC_CSV_TO_LAYER_TYPES | OQ_COMPLEX_CSV_TO_LAYER_TYPES)
 OQ_EXTRACT_TO_LAYER_TYPES = set([
     'hmaps', 'hcurves', 'uhs', 'losses_by_asset', 'gmf_data',
     'dmg_by_asset', 'avg_losses-stats', 'asset_risk'])
+OQ_ZIPPED_TYPES = set(['input'])
 OQ_TO_LAYER_TYPES = (OQ_CSV_TO_LAYER_TYPES |
                      OQ_EXTRACT_TO_LAYER_TYPES |
                      OQ_ZIPPED_TYPES)
@@ -236,8 +236,7 @@ OQ_RST_TYPES = set(['fullreport'])
 OQ_EXTRACT_TO_VIEW_TYPES = set(
     ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_aggr',
      'losses_by_asset_aggr', 'avg_losses-stats_aggr'])
-OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES |
-                OQ_ZIPPED_TYPES)
+OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES)
 
 LOG_LEVELS = {'I': 'Info (high verbosity)',
               'W': 'Warning (medium verbosity)',

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -220,22 +220,39 @@ RECOVERY_DEFAULTS['n_recovery_based_dmg_states'] = len(
 
 
 OQ_BASIC_CSV_TO_LAYER_TYPES = set([
-    'realizations', 'sourcegroups', 'dmg_by_event', 'losses_by_event',
+    'realizations',
+    'sourcegroups',
+    'dmg_by_event',
+    'losses_by_event',
     'agg_risk'])
-OQ_COMPLEX_CSV_TO_LAYER_TYPES = set(['ruptures'])
+OQ_COMPLEX_CSV_TO_LAYER_TYPES = set([
+    'ruptures'])
 OQ_CSV_TO_LAYER_TYPES = (
     OQ_BASIC_CSV_TO_LAYER_TYPES | OQ_COMPLEX_CSV_TO_LAYER_TYPES)
 OQ_EXTRACT_TO_LAYER_TYPES = set([
-    'hmaps', 'hcurves', 'uhs', 'losses_by_asset', 'gmf_data',
-    'dmg_by_asset', 'avg_losses-stats', 'asset_risk'])
-OQ_ZIPPED_TYPES = set(['input'])
+    'hmaps',
+    'hcurves',
+    'uhs',
+    'losses_by_asset',
+    'gmf_data',
+    'dmg_by_asset',
+    'avg_losses-stats',
+    'asset_risk'])
+OQ_ZIPPED_TYPES = set([
+    'input'])
 OQ_TO_LAYER_TYPES = (OQ_CSV_TO_LAYER_TYPES |
                      OQ_EXTRACT_TO_LAYER_TYPES |
                      OQ_ZIPPED_TYPES)
-OQ_RST_TYPES = set(['fullreport'])
-OQ_EXTRACT_TO_VIEW_TYPES = set(
-    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_aggr',
-     'losses_by_asset_aggr', 'avg_losses-stats_aggr'])
+OQ_RST_TYPES = set([
+    'fullreport'])
+# FIXME: agg_curves-stats calls extract/agg_curves/loss_type, that was removed
+#        engine side
+OQ_EXTRACT_TO_VIEW_TYPES = set([
+     'agg_curves-rlzs',
+     # 'agg_curves-stats',
+     'dmg_by_asset_aggr',
+     'losses_by_asset_aggr',
+     'avg_losses-stats_aggr'])
 OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES)
 
 LOG_LEVELS = {'I': 'Info (high verbosity)',

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1135,8 +1135,8 @@ def extract_npz(
             print_to_stderr=True)
     resp = session.get(url, params=params)
     if not resp.ok:
-        msg = "Unable to extract %s with parameters %s: %s" % (
-            url, params, resp.reason)
+        msg = "Unable to extract %s with parameters %s (%s):\n%s" % (
+            url, params, resp.reason, resp.content)
         log_msg(msg, level='C', message_bar=message_bar, print_to_stderr=True)
         return
     resp_content = resp.content

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1136,7 +1136,7 @@ def extract_npz(
     resp = session.get(url, params=params)
     if not resp.ok:
         msg = "Unable to extract %s with parameters %s (%s):\n%s" % (
-            url, params, resp.reason, resp.content)
+            url, params, resp.reason, resp.content.decode('utf8'))
         log_msg(msg, level='C', message_bar=message_bar, print_to_stderr=True)
         return
     resp_content = resp.content


### PR DESCRIPTION
Thanks to the QGIS docker, we can now remove every mocked objects from integration tests.
I've also noticed that in many tests I was selecting all the features and drawing all the corresponding curves, whereas it is sufficient to draw just a couple. This change made the tests for many output loaders much faster. In fact, it reduced the execution of integration tests from 658.462s to 236.349s, and we don't have any warnings about loaders taking more than 10 seconds to run.
I changed the way loaders are tested. Instead of running a single test with a big loop, trying to load all the outputs of all the available calculations, I have now one test for each loader, looping on all the available calculations and loading a specific output type for all of them. Each test produces its own summary, and there is a general summary once all tests are finished.
I also added new tests that became necessary after this change. One checks that all loadable output types appear at least once in the OQ-Engine demos (besides those with the _aggr suffix, that are treated differently). The other one lists all the output types for which we have implemented a loader, and those for which a loader is still missing (the test will always be green anyway, but it provides useful information).
I've also added a test running demo calculations (a hazard one, then a risk one on top of the former) and finally deleting the added calculations: https://github.com/gem/oq-irmt-qgis/pull/596