### PR TITLE
Disable whatever calls extract/agg_curves

### DIFF
--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -245,7 +245,8 @@ OQ_TO_LAYER_TYPES = (OQ_CSV_TO_LAYER_TYPES |
                      OQ_ZIPPED_TYPES)
 OQ_RST_TYPES = set([
     'fullreport'])
-# FIXME: extract/agg_curves was removed engine-side
+# FIXME: agg_curves-stats calls extract/agg_curves/loss_type, that was removed
+#        engine side
 OQ_EXTRACT_TO_VIEW_TYPES = set([
      'agg_curves-rlzs',
      # 'agg_curves-stats',

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -220,22 +220,38 @@ RECOVERY_DEFAULTS['n_recovery_based_dmg_states'] = len(
 
 
 OQ_BASIC_CSV_TO_LAYER_TYPES = set([
-    'realizations', 'sourcegroups', 'dmg_by_event', 'losses_by_event',
+    'realizations',
+    'sourcegroups',
+    'dmg_by_event',
+    'losses_by_event',
     'agg_risk'])
-OQ_COMPLEX_CSV_TO_LAYER_TYPES = set(['ruptures'])
+OQ_COMPLEX_CSV_TO_LAYER_TYPES = set([
+    'ruptures'])
 OQ_CSV_TO_LAYER_TYPES = (
     OQ_BASIC_CSV_TO_LAYER_TYPES | OQ_COMPLEX_CSV_TO_LAYER_TYPES)
 OQ_EXTRACT_TO_LAYER_TYPES = set([
-    'hmaps', 'hcurves', 'uhs', 'losses_by_asset', 'gmf_data',
-    'dmg_by_asset', 'avg_losses-stats', 'asset_risk'])
-OQ_ZIPPED_TYPES = set(['input'])
+    'hmaps',
+    'hcurves',
+    'uhs',
+    'losses_by_asset',
+    'gmf_data',
+    'dmg_by_asset',
+    'avg_losses-stats',
+    'asset_risk'])
+OQ_ZIPPED_TYPES = set([
+    'input'])
 OQ_TO_LAYER_TYPES = (OQ_CSV_TO_LAYER_TYPES |
                      OQ_EXTRACT_TO_LAYER_TYPES |
                      OQ_ZIPPED_TYPES)
-OQ_RST_TYPES = set(['fullreport'])
-OQ_EXTRACT_TO_VIEW_TYPES = set(
-    ['agg_curves-rlzs', 'agg_curves-stats', 'dmg_by_asset_aggr',
-     'losses_by_asset_aggr', 'avg_losses-stats_aggr'])
+OQ_RST_TYPES = set([
+    'fullreport'])
+# FIXME: extract/agg_curves was removed engine-side
+OQ_EXTRACT_TO_VIEW_TYPES = set([
+     'agg_curves-rlzs',
+     # 'agg_curves-stats',
+     'dmg_by_asset_aggr',
+     'losses_by_asset_aggr',
+     'avg_losses-stats_aggr'])
 OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES)
 
 LOG_LEVELS = {'I': 'Info (high verbosity)',


### PR DESCRIPTION
Companion of https://github.com/gem/oq-engine/pull/4882

Besides some code re-alignment, the only actual change is commenting out the loader for `agg_curves-stats`, that is the only one that uses `extract/agg_curves/loss_type`