### PR TITLE
Hovering on the name of an engine calc output, a tooltip displays the output type and its size

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -752,6 +752,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 item = QTableWidgetItem()
                 value = output_list[row][key]
                 item.setData(Qt.DisplayRole, value)
+                item.setData(Qt.ToolTipRole, output_list[row]['type'])
                 self.output_list_tbl.setItem(row, col, item)
             outtypes = output_list[row]['outtypes']
             for col, outtype in enumerate(outtypes, len(selected_keys)):

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -752,7 +752,13 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 item = QTableWidgetItem()
                 value = output_list[row][key]
                 item.setData(Qt.DisplayRole, value)
-                item.setData(Qt.ToolTipRole, output_list[row]['type'])
+                size_mb = output_list[row]['size_mb']
+                if size_mb is None:
+                    size_str = ' (size: n.a.)'
+                else:
+                    size_str = ' (size: ~%.2f MB)' % size_mb
+                tooltip = "%s" % output_list[row]['type'] + size_str
+                item.setData(Qt.ToolTipRole, tooltip)
                 self.output_list_tbl.setItem(row, col, item)
             outtypes = output_list[row]['outtypes']
             for col, outtype in enumerate(outtypes, len(selected_keys)):

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Calls to QgsVectorLayer.getFeatures() are optimized, reading only the necessary fields and ignoring geometries if unneeded
     * Multi-peril input files containing geometries as WKT can be loaded as layers
     * Integration tests use an instance of Irmt instead of instantiating Irmt sub-dialogs
+    * When the mouse points to the name of a OQ-Engine output, a tooltip displays the output type code (e.g. Aggregate Asset Losses -> agg_losses-rlzs)
     3.6.0
     * Changed the realizations output for OQ-Engine scenario calculations, displaying the GSIM names instead of the branch path
     * All possibly running timers are stopped before the plugin is unloaded


### PR DESCRIPTION
(e.g. Aggregate Asset Losses -> agg_losses-rlzs)

![tooltip](https://user-images.githubusercontent.com/350930/61035274-2967d200-a3c7-11e9-90ed-a0f2e7ba3806.gif)

In the past, we decided to avoid displaying such information in the table, keeping the visualized data simpler and cleaner. However, this is visualized in the WebUI, and it can be useful in some cases.
I decided to implement this hybrid approach, to allow users to easily obtain the information by pointing the mouse to the output name and visualizing the tooltip, so the table remains as simple and clean as before.