### PR TITLE
Encode taxonomy in utf8, to avoid loading empty losses_by_asset or dmg_by_asset layers

### DIFF
--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -180,7 +180,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         F32 = numpy.float32
         dmg_by_site = collections.defaultdict(float)  # lon, lat -> dmg
         for rec in npz[rlz_or_stat]:
-            if taxonomy == 'All' or taxonomy == rec['taxonomy']:
+            if taxonomy == 'All' or taxonomy.encode('utf8') == rec['taxonomy']:
                 value = rec[loss_type]['%s_mean' % dmg_state]
                 dmg_by_site[rec['lon'], rec['lat']] += value
         data = numpy.zeros(

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -198,7 +198,7 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         F32 = numpy.float32
         loss_by_site = collections.defaultdict(float)  # lon, lat -> loss
         for rec in npz[rlz_or_stat]:
-            if taxonomy == 'All' or taxonomy == rec['taxonomy']:
+            if taxonomy == 'All' or taxonomy.encode('utf8') == rec['taxonomy']:
                 loss_by_site[rec['lon'], rec['lat']] += rec[loss_type]
         data = numpy.zeros(len(loss_by_site),
                            [('lon', F32), ('lat', F32), (loss_type, F32)])

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -27,6 +27,7 @@ changelog=
     * Calls to QgsVectorLayer.getFeatures() are optimized, reading only the necessary fields and ignoring geometries if unneeded
     * Multi-peril input files containing geometries as WKT can be loaded as layers
     * Integration tests use an instance of Irmt instead of instantiating Irmt sub-dialogs
+    * Fixed the possibility to load data corresponding to specific taxonomies, for dmg_by_asset and losses_by_asset OQ-Engine output types
     3.6.0
     * Changed the realizations output for OQ-Engine scenario calculations, displaying the GSIM names instead of the branch path
     * All possibly running timers are stopped before the plugin is unloaded


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/599

Taxonomies are returned by extract/losses_by_asset as bytes instead of strings. I was already decoding them as utf8 to be able to populate the corresponding dropdown menu. The problem was that I was not re-encoding the user-selected one as utf8 before comparing it with the data for filtering in `group_by_site`, therefore the filter always returned no records and the output layer was completely empty.

If we can assume that all bytes coming from the engine can be decoded as utf8, this fix is fine. Otherwise, perhaps it would be safer to store taxonomies as strings in the engine datastore.
