### PR TITLE
Improvements to the integration tests

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -20,6 +20,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e DISPLAY=:99 \
  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
  -e BRANCH="$BRANCH" \
+ -e SELECTED_CALC_ID="$SELECTED_CALC_ID" \
  qgis/qgis:latest
 
 docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
@@ -28,4 +29,4 @@ docker exec -it qgis sh -c "git clone -q -b $BRANCH --depth=1 https://github.com
 
 docker exec -it qgis sh -c "qgis_setup.sh svir"
 
-docker exec -it qgis sh -c "cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+docker exec -it qgis sh -c "cd /tests_directory && SELECTED_CALC_ID=$SELECTED_CALC_ID qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -26,8 +26,11 @@ changelog=
     3.6.1
     * Calls to QgsVectorLayer.getFeatures() are optimized, reading only the necessary fields and ignoring geometries if unneeded
     * Multi-peril input files containing geometries as WKT can be loaded as layers
-    * Integration tests use an instance of Irmt instead of instantiating Irmt sub-dialogs
-    * When the mouse points to the name of a OQ-Engine output, a tooltip displays the output type code (e.g. Aggregate Asset Losses -> agg_losses-rlzs)
+    * Improvements to the integration tests: an instance of Irmt is used instead of instantiating Irmt sub-dialogs, and no mocked object is used anymore;
+      OQ-Engine outputs that are loaded as QGIS layers are checked to contain at least one feature; an additional integration test runs a OQ-Engine hazard calculation,
+      displays its progress log, then runs a risk calculation based on its outputs, showing again the progress, then deletes both calculations;
+      instead of running one single big integration test, a single test is run for each OQ-Engine output type that the IRMT is able to load.
+    * When the mouse points to the name of a OQ-Engine output, a tooltip displays the output type code and its approximate size (if available)
     * Fixed a useless downloading of unneeded files while loading OQ-Engine outputs using the "extract" API
     * Fixed the possibility to load data corresponding to specific taxonomies, for dmg_by_asset and losses_by_asset OQ-Engine output types
     3.6.0

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -280,7 +280,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self.time_consuming_outputs.append(output_dict)
             self.global_time_consuming_outputs.append(output_dict)
 
-    def load_calc_output(self, calc, selected_output_type):
+    def load_calc_output(self, calc, selected_output_type, taxonomy_idx=None):
         calc_id = calc['id']
         for output in self.output_list[calc_id]:
             if (output['type'] != selected_output_type and
@@ -298,14 +298,17 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             output_copy = copy.deepcopy(output)
             output_copy['type'] = selected_output_type
             try:
-                loading_resp = self.load_output(calc, output_copy)
+                loading_resp = self.load_output(
+                    calc, output_copy, taxonomy_idx=taxonomy_idx)
             except Exception:
                 self._on_loading_ko(output_dict)
             else:
                 if loading_resp != 'skipped':
                     self._on_loading_ok(start_time, output_dict)
 
-    def on_init_done(self, dlg):
+    def on_init_done(self, dlg, taxonomy_idx=None):
+        if taxonomy_idx is not None:
+            print("\t\tTaxonomy: %s" % dlg.taxonomy_cbx.itemText(taxonomy_idx))
         # set dialog options and accept
         if dlg.output_type == 'uhs':
             dlg.load_selected_only_ckb.setChecked(True)
@@ -314,32 +317,24 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 dlg.poe_cbx.count(), 0, 'No PoE was found')
             dlg.poe_cbx.setCurrentIndex(0)
         elif dlg.output_type == 'losses_by_asset':
-            # FIXME: testing only for the first taxonomy that is found
             dlg.load_selected_only_ckb.setChecked(True)
+            # Taxonomies should be at least 'All' and a single one
             assert_and_emit(
                 dlg.loading_exception, self.assertGreater,
-                dlg.taxonomy_cbx.count(), 0, 'No taxonomy was found')
-            dlg.taxonomy_cbx.setCurrentIndex(0)
+                dlg.taxonomy_cbx.count(), 1, 'No taxonomy was found')
+            # 'All' (inserted on top)
+            taxonomy_all_idx = dlg.taxonomy_cbx.findText('All')
+            assert_and_emit(
+                dlg.loading_exception, self.assertEqual,
+                taxonomy_all_idx, 0,
+                "Taxonomy All was not the first in selector")
+            dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
             assert_and_emit(
                 dlg.loading_exception, self.assertGreater,
                 dlg.loss_type_cbx.count(), 0, 'No loss type was found')
             dlg.loss_type_cbx.setCurrentIndex(0)
-
-            # # FIXME: we need to do dlg.accept() also for the case
-            #          loading all taxonomies, and performing the
-            #          aggregation by zone
-
-            # # test all taxonomies
-            # dlg.load_selected_only_ckb.setChecked(True)
-            # taxonomy_idx = dlg.taxonomy_cbx.findText('All')
-            # self.assertNotEqual(taxonomy_idx, -1,
-            #                     'Taxonomy All was not found')
-            # dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
-            # loss_type_idx = dlg.loss_type_cbx.findText('structural')
-            # self.assertNotEqual(loss_type_idx, -1,
-            #                     'Loss type structural was not found')
-            # dlg.loss_type_cbx.setCurrentIndex(loss_type_idx)
-            # dlg.accept()
+            # FIXME: we need to do dlg.accept() also for the case
+            #        performing the aggregation by zone
 
             # FIXME: copied/pasted from skipped unit test
             #        that was causing segfault
@@ -496,7 +491,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.skipped_attempts.append(skipped_attempt)
         self.global_skipped_attempts.append(skipped_attempt)
 
-    def load_output(self, calc, output):
+    def load_output(self, calc, output, taxonomy_idx=None):
         # NOTE: it is better to avoid resetting the project here, because some
         # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
@@ -560,7 +555,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             dlg.loading_completed.connect(self.on_loading_completed)
             dlg.loading_exception[Exception].connect(self.on_loading_exception)
             dlg.init_done.connect(
-                lambda: self.on_init_done(dlg))
+                lambda: self.on_init_done(dlg, taxonomy_idx=taxonomy_idx))
             timeout = 10
             start_time = time.time()
             while time.time() - start_time < timeout:
@@ -598,7 +593,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.skipped_attempts = []
         self.time_consuming_outputs = []
         for calc in self.calc_list:
-            self.load_calc_output(calc, selected_output_type)
+            if selected_output_type in ['losses_by_asset']:
+                # TODO: keep track of taxonomy in test summary
+                for taxonomy_idx in [0, 1]:
+                    self.load_calc_output(
+                        calc, selected_output_type, taxonomy_idx=taxonomy_idx)
+            else:
+                self.load_calc_output(calc, selected_output_type)
         if self.skipped_attempts:
             print('\nSkipped:')
             for skipped_attempt in self.skipped_attempts:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -279,6 +279,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             output_dict['loading_time'] = loading_time
             self.time_consuming_outputs.append(output_dict)
             self.global_time_consuming_outputs.append(output_dict)
+        if output_dict['output_type'] in OQ_EXTRACT_TO_LAYER_TYPES:
+            loaded_layer = self.irmt.iface.activeLayer()
+            self.assertNotNone(loaded_layer, 'No layer was loaded')
+            num_feats = loaded_layer.featureCount()
+            self.assertGreater(
+                num_feats, 0, 'The loaded layer does not contain any feature!')
 
     def load_calc_output(self, calc, selected_output_type, taxonomy_idx=None):
         calc_id = calc['id']
@@ -703,7 +709,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # depending on the amount of features selected
         num_feats = layer.featureCount()
         self.assertGreater(
-            num_feats, 0, 'The layer does not contain any feature!')
+            num_feats, 0, 'The loaded layer does not contain any feature!')
         # select first feature only
         layer.select(1)
         layer.removeSelection()

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -281,7 +281,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self.global_time_consuming_outputs.append(output_dict)
         if output_dict['output_type'] in OQ_EXTRACT_TO_LAYER_TYPES:
             loaded_layer = self.irmt.iface.activeLayer()
-            self.assertNotNone(loaded_layer, 'No layer was loaded')
+            self.assertIsNotNone(loaded_layer, 'No layer was loaded')
             num_feats = loaded_layer.featureCount()
             self.assertGreater(
                 num_feats, 0, 'The loaded layer does not contain any feature!')

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -341,47 +341,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             dlg.loss_type_cbx.setCurrentIndex(0)
             # FIXME: we need to do dlg.accept() also for the case
             #        performing the aggregation by zone
-
-            # FIXME: copied/pasted from skipped unit test
-            #        that was causing segfault
-            # loss_layer_path = os.path.join(
-            #     self.data_dir_name, 'risk',
-            #     'output-399-losses_by_asset_123.npz')
-            # zonal_layer_path = os.path.join(
-            #     self.data_dir_name, 'risk', 'zonal_layer.shp')
-            # dlg = LoadLossesByAssetAsLayerDialog(
-            #     self.irmt.iface, self.irmt.viewer_dock,
-            #     Mock(), Mock(), Mock(),
-            #     'losses_by_asset', loss_layer_path,
-            #     zonal_layer_path=zonal_layer_path)
-            # dlg.load_selected_only_ckb.setChecked(True)
-            # dlg.zonal_layer_gbx.setChecked(True)
-            # taxonomy_idx = dlg.taxonomy_cbx.findText('All')
-            # self.assertNotEqual(taxonomy_idx, -1,
-            #                    'Taxonomy All was not found')
-            # dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
-            # loss_type_idx = dlg.loss_type_cbx.findText('structural')
-            # self.assertNotEqual(loss_type_idx, -1,
-            #                     'Loss type structural was not found')
-            # dlg.loss_type_cbx.setCurrentIndex(loss_type_idx)
-            # self.assertTrue(dlg.zonal_layer_cbx.currentText(),
-            #                 'The zonal layer was not loaded')
-            # dlg.accept()
-            # zonal_layer_plus_stats = [
-            #     layer for layer in self.irmt.iface.layers()
-            #     if layer.name() == 'Zonal data (copy)'][0]
-            # zonal_layer_plus_stats_first_feat = \
-            #     zonal_layer_plus_stats.getFeatures().next()
-            # expected_zonal_layer_path = os.path.join(
-            #     self.data_dir_name, 'risk',
-            #     'zonal_layer_plus_losses_by_asset_stats.shp')
-            # expected_zonal_layer = QgsVectorLayer(
-            #     expected_zonal_layer_path, 'Zonal data', 'ogr')
-            # expected_zonal_layer_first_feat = \
-            #     expected_zonal_layer.getFeatures().next()
-            # assert_almost_equal(
-            #     zonal_layer_plus_stats_first_feat.attributes(),
-            #     expected_zonal_layer_first_feat.attributes())
         elif dlg.output_type == 'dmg_by_asset':
             # FIXME: testing only for selected taxonomy
             dlg.load_selected_only_ckb.setChecked(True)
@@ -389,6 +348,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 dlg.loading_exception, self.assertGreater,
                 dlg.taxonomy_cbx.count(), 0, 'No taxonomy was found')
             dlg.taxonomy_cbx.setCurrentIndex(0)
+            taxonomy_all_idx = dlg.taxonomy_cbx.findText('All')
+            assert_and_emit(
+                dlg.loading_exception, self.assertEqual,
+                taxonomy_all_idx, 0,
+                "Taxonomy All was not the first in selector")
+            dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
             assert_and_emit(
                 dlg.loading_exception, self.assertGreater,
                 dlg.loss_type_cbx.count(), 0, 'No loss_type was found')
@@ -397,65 +362,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 dlg.loading_exception, self.assertGreater,
                 dlg.dmg_state_cbx.count(), 0, 'No damage state was found')
             dlg.dmg_state_cbx.setCurrentIndex(0)
-
-            # # FIXME: we need to do dlg.accept() also for the case
-            #          loading all taxonomies, and performing the
-            #          aggregation by zone
-            # dlg.load_selected_only_ckb.setChecked(True)
-            # taxonomy_idx = dlg.taxonomy_cbx.findText('All')
-            # self.assertNotEqual(
-            #     taxonomy_idx, -1, 'Taxonomy All was not found')
-            # dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
-            # loss_type_idx = dlg.loss_type_cbx.findText('structural')
-            # self.assertNotEqual(loss_type_idx, -1,
-            #                     'Loss type structural was not found')
-            # dlg.loss_type_cbx.setCurrentIndex(loss_type_idx)
-            # dmg_state_idx = dlg.dmg_state_cbx.findText('moderate')
-            # self.assertNotEqual(
-            #     dmg_state_idx, -1,
-            #     'Damage state moderate was not found')
-            # dlg.dmg_state_cbx.setCurrentIndex(dmg_state_idx)
-
-            # FIXME: copied/pasted from skipped unit test
-            #        that was causing segfault
-            #        (test_load_dmg_by_asset_aggregate_by_zone)
-            # dmg_layer_path = os.path.join(
-            #     self.data_dir_name, 'risk',
-            #     'output-1614-dmg_by_asset_356.npz')
-            # zonal_layer_path = os.path.join(
-            #     self.data_dir_name, 'risk',
-            #     'zonal_layer.shp')
-            # dlg.load_selected_only_ckb.setChecked(True)
-            # dlg.zonal_layer_gbx.setChecked(True)
-            # taxonomy_idx = dlg.taxonomy_cbx.findText('All')
-            # self.assertNotEqual(
-            #     taxonomy_idx, -1, 'Taxonomy All was not found')
-            # dlg.taxonomy_cbx.setCurrentIndex(taxonomy_idx)
-            # loss_type_idx = dlg.loss_type_cbx.findText('structural')
-            # self.assertNotEqual(loss_type_idx, -1,
-            #                     'Loss type structural was not found')
-            # dlg.loss_type_cbx.setCurrentIndex(loss_type_idx)
-            # dmg_state_idx = dlg.dmg_state_cbx.findText('moderate')
-            # self.assertNotEqual(
-            #     dmg_state_idx, -1,
-            #     'Damage state moderate was not found')
-            # dlg.dmg_state_cbx.setCurrentIndex(dmg_state_idx)
-            # dlg.accept()
-            # zonal_layer_plus_stats = [
-            #     layer for layer in self.irmt.iface.layers()
-            #     if layer.name() == 'Zonal data (copy)'][0]
-            # zonal_layer_plus_stats_first_feat = \
-            #     zonal_layer_plus_stats.getFeatures().next()
-            # expected_zonal_layer_path = os.path.join(
-            #     self.data_dir_name, 'risk',
-            #     'zonal_layer_plus_dmg_by_asset_stats.shp')
-            # expected_zonal_layer = QgsVectorLayer(
-            #     expected_zonal_layer_path, 'Zonal data', 'ogr')
-            # expected_zonal_layer_first_feat = \
-            #     expected_zonal_layer.getFeatures().next()
-            # assert_almost_equal(
-            #     zonal_layer_plus_stats_first_feat.attributes(),
-            #     expected_zonal_layer_first_feat.attributes())
+            # FIXME: we need to do dlg.accept() also for the case
+            #        performing the aggregation by zone
         elif dlg.output_type == 'asset_risk':
             num_selected_taxonomies = len(
                 list(dlg.taxonomies_multisel.get_selected_items()))
@@ -599,7 +507,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.skipped_attempts = []
         self.time_consuming_outputs = []
         for calc in self.calc_list:
-            if selected_output_type in ['losses_by_asset']:
+            if selected_output_type in ['losses_by_asset', 'dmg_by_asset']:
                 # TODO: keep track of taxonomy in test summary
                 for taxonomy_idx in [0, 1]:
                     self.load_calc_output(


### PR DESCRIPTION
I've added the possibility to use an env variable to run tests only for a specific calculation id.

For losses_by_asset, I am testing loading alternatively: 'All' taxonomies, or the first other taxonomy that is found (displaying the name of the taxonomy in the output of the test).

TODO:

- [x] Test different selections also for other outputs, the same way I did for losses_by_asset
- [x] Check that the output layers are not empty