### PR TITLE
Minor improvements to the Data Viewer dock window

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1657,10 +1657,3 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.output_types_names[output_type])
         if index != -1:
             self.output_type_cbx.setCurrentIndex(index)
-        layer = self.iface.activeLayer()
-        if layer:
-            layer_type = layer.customProperty('output_type')
-            if layer_type:
-                self.output_type_cbx.setDisabled(True)
-                return
-        self.output_type_cbx.setEnabled(True)

--- a/svir/ui/ui_viewer_dock.ui
+++ b/svir/ui/ui_viewer_dock.ui
@@ -36,7 +36,7 @@
          <x>0</x>
          <y>0</y>
          <width>402</width>
-         <height>612</height>
+         <height>618</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -71,7 +71,11 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QComboBox" name="output_type_cbx"/>
+             <widget class="QComboBox" name="output_type_cbx">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>

--- a/svir/ui/ui_viewer_dock.ui
+++ b/svir/ui/ui_viewer_dock.ui
@@ -46,13 +46,6 @@
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <item>
-           <widget class="QCheckBox" name="bw_chk">
-            <property name="text">
-             <string>Optimize line style for black and white printing</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <layout class="QFormLayout" name="formLayout">
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
@@ -134,6 +127,13 @@
            </widget>
           </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="bw_chk">
+          <property name="text">
+           <string>Optimize line style for black and white printing</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
I made a couple of changes:

1. The dropdown menu to select the output type in the Data Viewer dock will remain always disabled. Now custom properties are added to the layers, specifying the layer output type. When you select a layer, it causes the automatic selection of the correct output type in the data viewer. Changing that selection manually is in general wrong, and in most cases it causes some exception to occur, so I decided to prevent it from happening accidentally.
(fixes https://github.com/gem/oq-irmt-qgis/issues/605)

2. The checkbox to style the plot in black&white was on top of the widget, but it makes more sense to keep it on the bottom, close to the plotting area, so I moved it there.

We might consider removing the dropdown menu and replacing it with a label, because now the user can never use it as a selector, but it might be useful to just display what kind of output is being handled by the tool. However, making it a label would require some non-trivial refactoring, because currently the widgets of the data viewer are automatically reset whenever the current index of the dropdown is changed.

NOTE: this could be problematic in case of old layers that do not have the output type set as a custom property. If the layer is that old, though, we can not guarantee that we can handle its format properly, so I believe we should keep a conservative approach.