### PR TITLE
WIP: load agg_curves-stats reading from new oq-engine export format

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -779,11 +779,6 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                                       OQ_EXTRACT_TO_VIEW_TYPES):
                     if output['type'] in (OQ_RST_TYPES |
                                           OQ_EXTRACT_TO_VIEW_TYPES):
-                        # FIXME: enable button for ebrisk as soon as the output
-                        # will be loadable
-                        if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
-                                calculation_mode == 'ebrisk'):
-                            continue
                         action = 'Show'
                     elif output['type'] in OQ_ZIPPED_TYPES:
                         if calculation_mode != 'multi_risk':

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -65,7 +65,6 @@ from svir.utilities.utils import (get_ui_class,
 from svir.recovery_modeling.recovery_modeling import (
     RecoveryModeling, fill_fields_multiselect)
 from svir.ui.list_multiselect_widget import ListMultiSelectWidget
-from svir.ui.list_multiselect_mono_widget import ListMultiSelectMonoWidget
 
 from svir import IS_SCIPY_INSTALLED, IS_MATPLOTLIB_INSTALLED
 
@@ -340,8 +339,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def create_tag_values_multiselect(self):
         title = 'Select tag values'
-        self.tag_values_multiselect = ListMultiSelectMonoWidget(
-            message_bar=self.iface.messageBar(), title=title)
+        self.tag_values_multiselect = ListMultiSelectWidget(title=title)
         self.tag_values_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self.tag_values_multiselect.select_all_btn.hide()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -319,6 +319,12 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_names_multiselect = ListMultiSelectWidget(title=title)
         self.tag_names_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.tag_names_multiselect.selected_widget.setSelectionMode(
+            QAbstractItemView.SingleSelection)
+        self.tag_names_multiselect.unselected_widget.setSelectionMode(
+            QAbstractItemView.SingleSelection)
+        self.tag_names_multiselect.select_all_btn.hide()
+        self.tag_names_multiselect.deselect_all_btn.hide()
         self.typeDepVLayout.addWidget(self.tag_names_multiselect)
         self.tag_names_multiselect.unselected_widget.itemClicked.connect(
             self.populate_tag_values_multiselect)
@@ -336,6 +342,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect = ListMultiSelectWidget(title=title)
         self.tag_values_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
+        self.tag_values_multiselect.select_all_btn.hide()
+        self.tag_values_multiselect.deselect_all_btn.hide()
         self.typeDepVLayout.addWidget(self.tag_values_multiselect)
         self.tag_values_multiselect.selection_changed.connect(
             self.update_selected_tag_values)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -794,7 +794,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     tag_value_idxs)
             else:
                 tup = (slice(None), rlzs_or_stats_idxs, loss_type_idx)
-                ordinates = self.agg_curves['array'][tup]
+            ordinates = self.agg_curves['array'][tup]
             unit = self.agg_curves['units'][loss_type_idx]
         self.plot.clear()
         if not ordinates.any():  # too much filtering

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -797,7 +797,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             # FIXME: currently forcing the selection of 2 tags and 1 value
             # per tag. I have to understand how to flatten the following:
             # tuple([value for value in tag_idxs.values()])]
-            tup = (slice(None), slice(None), loss_type_idx) + tuple(
+            tup = (slice(None), stats_idxs, loss_type_idx) + tuple(
                 tag_value_idxs)
             ordinates = self.agg_curves['array'][tup]
             unit = self.agg_curves['units'][loss_type_idx]
@@ -805,54 +805,56 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if not ordinates.any():  # too much filtering
             self.plot_canvas.draw()
             return
-        marker = dict()
-        line_style = dict()
-        color_hex = dict()
-        for rlz_or_stat_idx, rlz_or_stat in enumerate(rlzs_or_stats):
-            marker[rlz_or_stat_idx] = self.markers[
-                rlz_or_stat_idx % len(self.markers)]
-            if self.bw_chk.isChecked():
-                line_styles_whole_cycles = (
-                    rlz_or_stat_idx // len(self.line_styles))
-                # NOTE: 85 is approximately 256 / 3
-                r = g = b = format(
-                    (85 * line_styles_whole_cycles) % 256, '02x')
-                color_hex_str = "#%s%s%s" % (r, g, b)
-                color = QColor(color_hex_str)
-                color_hex[rlz_or_stat_idx] = color.darker(120).name()
-                # here I am using i in order to cycle through all the
-                # line styles, regardless from the feature id
-                # (otherwise I might easily repeat styles, that are a
-                # small set of 4 items)
-                line_style[rlz_or_stat_idx] = self.line_styles[
-                    rlz_or_stat_idx % len(self.line_styles)]
-            else:
-                # here I am using the feature id in order to keep a
-                # matching between a curve and the corresponding point
-                # in the map
-                color_name = self.color_names[
-                    rlz_or_stat_idx % len(self.color_names)]
-                color = QColor(color_name)
-                color_hex[rlz_or_stat_idx] = color.darker(120).name()
-                line_style[rlz_or_stat_idx] = "-"  # solid
-            if output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
-                ords = ordinates[:, rlz_or_stat_idx]
-            self.plot.plot(
-                abscissa,
-                ords,
-                color=color_hex[rlz_or_stat_idx],
-                linestyle=line_style[rlz_or_stat_idx],
-                marker=marker[rlz_or_stat_idx],
-                label=rlz_or_stat,
-            )
-        # self.plot.plot(
+        # marker = dict()
+        # line_style = dict()
+        # color_hex = dict()
+        # for rlz_or_stat_idx, rlz_or_stat in enumerate(rlzs_or_stats):
+        #     marker[rlz_or_stat_idx] = self.markers[
+        #         rlz_or_stat_idx % len(self.markers)]
+        #     if self.bw_chk.isChecked():
+        #         line_styles_whole_cycles = (
+        #             rlz_or_stat_idx // len(self.line_styles))
+        #         # NOTE: 85 is approximately 256 / 3
+        #         r = g = b = format(
+        #             (85 * line_styles_whole_cycles) % 256, '02x')
+        #         color_hex_str = "#%s%s%s" % (r, g, b)
+        #         color = QColor(color_hex_str)
+        #         color_hex[rlz_or_stat_idx] = color.darker(120).name()
+        #         # here I am using i in order to cycle through all the
+        #         # line styles, regardless from the feature id
+        #         # (otherwise I might easily repeat styles, that are a
+        #         # small set of 4 items)
+        #         line_style[rlz_or_stat_idx] = self.line_styles[
+        #             rlz_or_stat_idx % len(self.line_styles)]
+        #     else:
+        #         # here I am using the feature id in order to keep a
+        #         # matching between a curve and the corresponding point
+        #         # in the map
+        #         color_name = self.color_names[
+        #             rlz_or_stat_idx % len(self.color_names)]
+        #         color = QColor(color_name)
+        #         color_hex[rlz_or_stat_idx] = color.darker(120).name()
+        #         line_style[rlz_or_stat_idx] = "-"  # solid
+        #     if output_type in ['agg_curves-rlzs', 'agg_curves-stats']:
+        #         ords = ordinates[:, rlz_or_stat_idx]
+        #     self.plot.plot(
         #         abscissa,
-        #         ordinates,
+        #         ords,
         #         color=color_hex[rlz_or_stat_idx],
         #         linestyle=line_style[rlz_or_stat_idx],
         #         marker=marker[rlz_or_stat_idx],
         #         label=rlz_or_stat,
-        # )
+        #     )
+        for ys, lab in zip(ordinates.T, rlzs_or_stats):
+            self.plot.plot(
+                    abscissa,
+                    ys,
+                    # color=color_hex[rlz_or_stat_idx],
+                    # linestyle=line_style[rlz_or_stat_idx],
+                    # marker=marker[rlz_or_stat_idx],
+                    # label=rlz_or_stat,
+                    label=lab
+            )
         self.plot.set_xscale('log')
         self.plot.set_yscale('linear')
         self.plot.set_xlabel('Return period (years)')

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -735,7 +735,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                           for stat in self.agg_curves['stats']]
             self.stats_multiselect.set_selected_items(self.stats)
         elif output_type == 'agg_curves-rlzs':
-            rlzs = ["Rlz %3d" % rlz
+            rlzs = ["Rlz %s" % rlz
                     for rlz in range(self.agg_curves['array'].shape[1])]
             self.rlzs_multiselect.set_selected_items(rlzs)
         else:
@@ -755,7 +755,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         rlzs_or_stats_idxs = []
         if self.output_type == 'agg_curves-rlzs':
             for rlz_idx in range(self.agg_curves['array'].shape[1]):
-                if "Rlz %3d" % rlz_idx in rlzs_or_stats:
+                if "Rlz %s" % rlz_idx in rlzs_or_stats:
                     rlzs_or_stats_idxs.append(rlz_idx)
         else:
             for stat_idx, stat in enumerate(self.agg_curves['stats']):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -65,6 +65,7 @@ from svir.utilities.utils import (get_ui_class,
 from svir.recovery_modeling.recovery_modeling import (
     RecoveryModeling, fill_fields_multiselect)
 from svir.ui.list_multiselect_widget import ListMultiSelectWidget
+from svir.ui.list_multiselect_mono_widget import ListMultiSelectMonoWidget
 
 from svir import IS_SCIPY_INSTALLED, IS_MATPLOTLIB_INSTALLED
 
@@ -339,7 +340,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def create_tag_values_multiselect(self):
         title = 'Select tag values'
-        self.tag_values_multiselect = ListMultiSelectWidget(title=title)
+        self.tag_values_multiselect = ListMultiSelectMonoWidget(
+            message_bar=self.iface.messageBar(), title=title)
         self.tag_values_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
         self.tag_values_multiselect.select_all_btn.hide()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1713,12 +1713,18 @@ class ViewerDock(QDockWidget, FORM_CLASS):
     def change_output_type(self, output_type):
         if output_type not in self.output_types_names:
             output_type = ''
+        prev_index = self.output_type_cbx.currentIndex()
         # get the index of the item that has the given string
         # and set the combobox to that item
-        index = self.output_type_cbx.findText(
+        target_index = self.output_type_cbx.findText(
             self.output_types_names[output_type])
-        if index != -1:
-            self.output_type_cbx.setCurrentIndex(index)
+        if target_index != -1:
+            self.output_type_cbx.setCurrentIndex(target_index)
+            if prev_index == target_index:
+                # NOTE: if the cbx does not change the selected item, the
+                # signal currentIndexChanged is not emitted, but we need to
+                # reset the GUI anyway
+                self.on_output_type_cbx_currentIndexChanged(target_index)
         layer = self.iface.activeLayer()
         if layer:
             layer_type = layer.customProperty('output_type')

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -657,9 +657,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tags = {}
         for tag_name in tag_names:
             self.tags[tag_name] = {
-                'selected': False,
-                'values': {value.decode('utf8'): False
-                           for value in self.agg_curves[tag_name]}}
+                'selected': True,
+                'values': {
+                    value.decode('utf8'): True if value_idx == 0 else False
+                    for value_idx, value in enumerate(
+                        self.agg_curves[tag_name])}}
 
     def _get_tags(self, session, hostname, calc_id, message_bar, with_star):
         with WaitCursorManager(
@@ -754,11 +756,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.stats_multiselect.set_selected_items(self.stats)
             self._build_tags()
             self.update_list_selected_edt()
-            self.tag_names_multiselect.set_unselected_items(
+            # by default, 1 value per tag is selected
+            self.tag_names_multiselect.set_unselected_items([])
+            self.tag_names_multiselect.set_selected_items(
                 list(self.tags.keys()))
-            self.tag_names_multiselect.set_selected_items([])
-            self.tag_values_multiselect.set_unselected_items([])
-            self.tag_values_multiselect.set_selected_items([])
             self.filter_agg_curves()
         elif output_type == 'agg_curves-rlzs':
             rlzs = ["Rlz %3d" % rlz

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -319,12 +319,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_names_multiselect = ListMultiSelectWidget(title=title)
         self.tag_names_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
-        self.tag_names_multiselect.selected_widget.setSelectionMode(
-            QAbstractItemView.SingleSelection)
-        self.tag_names_multiselect.unselected_widget.setSelectionMode(
-            QAbstractItemView.SingleSelection)
-        self.tag_names_multiselect.select_all_btn.hide()
-        self.tag_names_multiselect.deselect_all_btn.hide()
         self.typeDepVLayout.addWidget(self.tag_names_multiselect)
         self.tag_names_multiselect.unselected_widget.itemClicked.connect(
             self.populate_tag_values_multiselect)
@@ -342,8 +336,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_values_multiselect = ListMultiSelectWidget(title=title)
         self.tag_values_multiselect.setSizePolicy(
             QSizePolicy.MinimumExpanding, QSizePolicy.MinimumExpanding)
-        self.tag_values_multiselect.select_all_btn.hide()
-        self.tag_values_multiselect.deselect_all_btn.hide()
         self.typeDepVLayout.addWidget(self.tag_values_multiselect)
         self.tag_values_multiselect.selection_changed.connect(
             self.update_selected_tag_values)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -437,15 +437,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         # outputs might be skipped, therefore it would not be needed
         calc_id = calc['id']
         output_type = output['type']
-        # TODO: when ebrisk becomes loadable, let's not skip this
-        if (output['type'] in OQ_EXTRACT_TO_VIEW_TYPES and
-                calc['calculation_mode'] == 'ebrisk'):
-            self._store_skipped_attempt(
-                calc_id, calc['calculation_mode'],
-                calc['description'], output_type)
-            print('\t\tSKIPPED')
-            return 'skipped'
-        # NOTE: loading zipped output only for multi_risk
+        # NOTE: loading zipped input files only for multi_risk
         if output_type == 'input' and calc['calculation_mode'] != 'multi_risk':
             self._store_skipped_attempt(
                 calc_id, calc['calculation_mode'],

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -245,11 +245,9 @@ OQ_TO_LAYER_TYPES = (OQ_CSV_TO_LAYER_TYPES |
                      OQ_ZIPPED_TYPES)
 OQ_RST_TYPES = set([
     'fullreport'])
-# FIXME: agg_curves-stats calls extract/agg_curves/loss_type, that was removed
-#        engine side
 OQ_EXTRACT_TO_VIEW_TYPES = set([
      'agg_curves-rlzs',
-     # 'agg_curves-stats',
+     'agg_curves-stats',
      'dmg_by_asset_aggr',
      'losses_by_asset_aggr',
      'avg_losses-stats_aggr'])


### PR DESCRIPTION
Some specifications from @raoanirudh:
- [x] by default, for each tag name, preselect 1 tag value
- [ ] add the possibility to select multiple tags and multiple values per tag (PT: in order to obtain a 2D array that is suitable for plotting, we must force the selection of one and only one value for each tag. However, it is possible to make different selections, and then add the filtered data to the same plot)
- [ ] also for agg_curves-rlz add selectors for tags and their values with the same behavior
- [ ] when displaying plots for multiple tag values, they should have different colors and corresponding legend (we could use different symbols for realizations/stats, and different colors for tags (PT: I need to better investigate this aspect)