### PR TITLE
Enable the user to select which ini file will be used in a OQ-Engine calculation

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -599,8 +599,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 for file_name in file_names:
                     zipped_file.write(file_name)
         selected_file_name, ok_pressed = QInputDialog.getItem(
-            self, "Select the ini file (or press cancel to use a default)",
-            "File name:",
+            self, "Selection of the .ini file",
+            "Select a file or press Cancel to let the OQ-Engine pick"
+            " one by default",
             [os.path.basename(file_name) for file_name in file_names
              if os.path.splitext(file_name)[1] == '.ini'],
             0, False)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -598,17 +598,27 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             with zipfile.ZipFile(zipped_file_name, 'w') as zipped_file:
                 for file_name in file_names:
                     zipped_file.write(file_name)
-        selected_file_name, ok_pressed = QInputDialog.getItem(
-            self, "Selection of the .ini file",
-            "Select a file or press Cancel to let the OQ-Engine pick"
-            " one by default",
-            [os.path.basename(file_name) for file_name in file_names
-             if os.path.splitext(file_name)[1] == '.ini'],
-            0, False)
-        if ok_pressed and selected_file_name:
-            job_ini_filename = selected_file_name
+        with zipfile.ZipFile(zipped_file_name, 'r') as f:
+            input_file_names = f.namelist()
+        ini_file_names = [file_name for file_name in input_file_names
+                          if os.path.splitext(file_name)[1] == '.ini']
+        if len(ini_file_names) > 1:
+            selected_file_name, ok_pressed = QInputDialog.getItem(
+                self, "Selection of the .ini file",
+                "Select a file or press Cancel to let the OQ-Engine pick"
+                " one by default",
+                [os.path.basename(file_name) for file_name in ini_file_names],
+                0, False)
+            if ok_pressed and selected_file_name:
+                job_ini_filename = selected_file_name
+            else:
+                job_ini_filename = None
+        elif len(ini_file_names) == 1:
+            job_ini_filename = os.path.basename(ini_file_names[0])
         else:
-            job_ini_filename = None
+            msg = "No .ini file was found"
+            log_msg(msg, level='C', message_bar=self.message_bar)
+            return
         run_calc_url = "%s/v1/calc/run" % self.hostname
         with WaitCursorManager('Starting calculation...', self.message_bar):
             if calc_id is not None:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -31,6 +31,7 @@ changelog=
     * While selecting assets for recovery modeling, a new checkbox enables/disables recalculating recovery curves on-the-fly
     * Another checkbox enables/disables the selection of all the assets that share the same coordinates, when the user clicks on a feature in the map
     * Instead of the 'sourcegroups' output (that was removed from the OQ-Engine), the plugin can now load the new output 'events'
+    * The user can choose if selecting the '.ini' file to run a OQ-Engine calculation, or letting the OQ-Engine automatically pick one from the list of input files.
     3.6.1
     * Calls to QgsVectorLayer.getFeatures() are optimized, reading only the necessary fields and ignoring geometries if unneeded
     * Multi-peril input files containing geometries as WKT can be loaded as layers


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/611
After selecting the input files, a dialog is displayed, containing a combobox from which the user can select one of the '.ini' files that are available in the list of the input files.
If the user presses "cancel", the engine will pick a ini file by default. Otherwise the chosen file will be used.