### PR TITLE
Add to exported recovery curves info about approach, n_simulations, assets

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1505,6 +1505,15 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         csv_headline += (
             "OpenQuake Integrated Risk Modelling Toolkit v%s\r\n"
             % irmt_version)
+        if self.output_type == 'recovery_curves':
+            approach = self.approach_cbx.currentText()
+            n_simulations = self.n_simulations_sbx.value()
+            asset_ids = [
+                feat['id']
+                for feat in self.iface.activeLayer().selectedFeatures()]
+            csv_headline += "# Recovery time approach: %s\r\n" % approach
+            csv_headline += "# n_simulations: %s\r\n" % n_simulations
+            csv_headline += "# Asset ids: %s\r\n" % ", ".join(asset_ids)
         with open(filename, 'w', newline='') as csv_file:
             csv_file.write(csv_headline)
             writer = csv.writer(csv_file)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1512,7 +1512,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 feat['id']
                 for feat in self.iface.activeLayer().selectedFeatures()]
             csv_headline += "# Recovery time approach: %s\r\n" % approach
-            csv_headline += "# n_simulations: %s\r\n" % n_simulations
+            csv_headline += "# Number of simulations: %s\r\n" % n_simulations
             csv_headline += "# Asset ids: %s\r\n" % ", ".join(asset_ids)
         with open(filename, 'w', newline='') as csv_file:
             csv_file.write(csv_headline)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1377,7 +1377,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self.on_container_hover(event, self.legend)
 
     def on_container_hover(self, event, container):
-        if self.output_type in OQ_EXTRACT_TO_VIEW_TYPES:
+        if self.output_type in OQ_EXTRACT_TO_VIEW_TYPES | 'recovery_curves':
             return False
         for line in container.get_lines():
             if line.contains(event)[0]:

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1378,6 +1378,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def on_container_hover(self, event, container):
         if self.output_type in OQ_EXTRACT_TO_VIEW_TYPES | 'recovery_curves':
+            # NOTE: recovery curves correspond to many points in the map, but
+            # only one id can be retrieved from the line. Highlighting only one
+            # of the points might be misleading, so it's probably better to
+            # avoid highlighting anything at all in such case.
             return False
         for line in container.get_lines():
             if line.contains(event)[0]:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -28,6 +28,7 @@ changelog=
     * The user can choose if selecting the '.ini' file to run a OQ-Engine calculation, or letting the OQ-Engine automatically pick one from the list of input files.
     * A note about updating the SSL certificate bundle on MacOS was added to the manual
     * Buttons to load OQ-Engine outputs have been rearranged in order to keep the most significant ones to the left
+    * Some additional information is available in exported csv files with recovery curves (recovery time approach, number of simulations, selected asset ids)
     3.7.0
     * Loading the OQ-Engine output 'dmg_by_asset', it is possible to aggregate assets by site (as in the previous implementation) or to load the raw data
       as it is compatible with the recovery modeling tool


### PR DESCRIPTION
This way the user has all the necessary information to be able to re-calculate a recovery curve.

Fixes https://github.com/gem/oq-irmt-qgis/issues/612