### PR TITLE
Fix an issue saving colors to QSettings

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -29,6 +29,7 @@ changelog=
     * A note about updating the SSL certificate bundle on MacOS was added to the manual
     * Buttons to load OQ-Engine outputs have been rearranged in order to keep the most significant ones to the left
     * Some additional information is available in exported csv files with recovery curves (recovery time approach, number of simulations, selected asset ids)
+    * Fixed an error in managing integer values in QSettings using parameter type=int, that returned negative values (casting to int instead)
     3.7.0
     * Loading the OQ-Engine output 'dmg_by_asset', it is possible to aggregate assets by site (as in the previous implementation) or to load the raw data
       as it is compatible with the recovery modeling tool

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -865,10 +865,9 @@ def get_style(layer, message_bar, restore_defaults=False):
         color_from_rgba = DEFAULT_SETTINGS['color_from_rgba']
     else:
         try:
-            color_from_rgba = settings.value(
+            color_from_rgba = int(settings.value(
                 'irmt/style_color_from',
-                DEFAULT_SETTINGS['color_from_rgba'],
-                type=int)
+                DEFAULT_SETTINGS['color_from_rgba']))
         except TypeError:
             msg = ('The type of the stored setting "style_color_from" was not'
                    ' valid, so the default has been restored.')
@@ -879,10 +878,9 @@ def get_style(layer, message_bar, restore_defaults=False):
         color_to_rgba = DEFAULT_SETTINGS['color_to_rgba']
     else:
         try:
-            color_to_rgba = settings.value(
+            color_to_rgba = int(settings.value(
                 'irmt/style_color_to',
-                DEFAULT_SETTINGS['color_to_rgba'],
-                type=int)
+                DEFAULT_SETTINGS['color_to_rgba']))
         except TypeError:
             msg = ('The type of the stored setting "style_color_to" was not'
                    ' valid, so the default has been restored.')
@@ -891,14 +889,13 @@ def get_style(layer, message_bar, restore_defaults=False):
     color_to = QColor().fromRgba(color_to_rgba)
     mode = (DEFAULT_SETTINGS['style_mode']
             if restore_defaults
-            else settings.value(
-                'irmt/style_mode', DEFAULT_SETTINGS['style_mode'], type=int))
+            else int(settings.value(
+                'irmt/style_mode', DEFAULT_SETTINGS['style_mode'])))
     classes = (DEFAULT_SETTINGS['style_classes']
                if restore_defaults
-               else settings.value(
+               else int(settings.value(
                    'irmt/style_classes',
-                   DEFAULT_SETTINGS['style_classes'],
-                   type=int))
+                   DEFAULT_SETTINGS['style_classes'])))
     # look for the setting associated to the layer if available
     force_restyling = None
     if layer is not None:


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/626

For some reason, the following two lines give different results:
```python 
settings.value('irmt/style_mode', DEFAULT_SETTINGS['style_mode'], type=int))
int(settings.value('irmt/style_mode', DEFAULT_SETTINGS['style_mode'])))
```
The first one returns a negative value, different with respect to the number written as string in the setting. In MacOS, such negative number could not be accepted while doing
`color_from = QColor().fromRgba(color_from_rgba)`, whereas it was accepted in Linux.