### PR TITLE
Use ScenarioDamage risk test in integration tests

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -558,7 +558,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             log_msg(msg, level='C', message_bar=self.message_bar)
         return
 
-    def run_calc(self, calc_id=None, file_names=None, directory=None):
+    def run_calc(self, calc_id=None, file_names=None, directory=None,
+                 use_default_ini=False):
         """
         Run a calculation. If `calc_id` is given, it means we want to run
         a calculation re-using the output of the given calculation
@@ -603,16 +604,20 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         ini_file_names = [file_name for file_name in input_file_names
                           if os.path.splitext(file_name)[1] == '.ini']
         if len(ini_file_names) > 1:
-            selected_file_name, ok_pressed = QInputDialog.getItem(
-                self, "Selection of the .ini file",
-                "Select a file or press Cancel to let the OQ-Engine pick"
-                " one by default",
-                [os.path.basename(file_name) for file_name in ini_file_names],
-                0, False)
-            if ok_pressed and selected_file_name:
-                job_ini_filename = selected_file_name
-            else:
+            if use_default_ini:
                 job_ini_filename = None
+            else:
+                selected_file_name, ok_pressed = QInputDialog.getItem(
+                    self, "Selection of the .ini file",
+                    "Select a file or press Cancel to let the OQ-Engine pick"
+                    " one by default",
+                    [os.path.basename(file_name)
+                     for file_name in ini_file_names],
+                    0, False)
+                if ok_pressed and selected_file_name:
+                    job_ini_filename = selected_file_name
+                else:
+                    job_ini_filename = None
         elif len(ini_file_names) == 1:
             job_ini_filename = os.path.basename(ini_file_names[0])
         else:

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -147,7 +147,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     def run_calc(self, input_files, job_type='hazard', calc_id=None):
         resp = self.irmt.drive_oq_engine_server_dlg.run_calc(
-            calc_id=calc_id, file_names=input_files)
+            calc_id=calc_id, file_names=input_files, use_default_ini=True)
         calc_id = resp['job_id']
         print("Running %s calculation #%s" % (job_type, calc_id))
         self.timer = QTimer()
@@ -178,8 +178,13 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         risk_demos_path = os.path.join(
             os.pardir, 'oq-engine', 'demos', 'risk')
         risk_demos_dirs = glob.glob(os.path.join(risk_demos_path, "*", ""))
-        # NOTE: using the first risk demo found
-        demo_dir = risk_demos_dirs[0]
+        # NOTE: assuming to find ScenarioDamage folder
+        demo_dir_list = [demo_dir
+                         for demo_dir in risk_demos_dirs
+                         if "ScenarioDamage" in demo_dir]
+        self.assertEquals(len(demo_dir_list), 1,
+                          "Demo directory ScenarioDamage was not found")
+        demo_dir = demo_dir_list[0]
         filepaths = glob.glob(os.path.join(demo_dir, '*'))
         hazard_calc_id = self.run_calc(filepaths, 'hazard')
         risk_calc_id = self.run_calc(filepaths, 'risk', hazard_calc_id)


### PR DESCRIPTION
I was using a fragile approach to run the first found risk demo, but recently something changed and the test was not running as expected anymore. Another problem was that, in case of multiple ini files, the plugin now asks the user which one to use for the calculation, which would put the tests on hold, waiting for a response from the user. Now, while running tests, I use instead the original approach to let the engine guess which ini file to use from those that are available.