### PR TITLE
Chained multiselect

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -363,6 +363,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         unselected_tag_values = [tag_value for tag_value in tag_values
                                  if not tag_values[tag_value]]
         cbx = getattr(self, "%s_values_multiselect" % tag_name)
+        cbx.clear()
+        if cbx.mono:
+            cbx.add_selected_items([''])
         cbx.add_selected_items(sorted(selected_tag_values))
         cbx.add_unselected_items(sorted(unselected_tag_values))
         # if self.tag_with_all_values:
@@ -389,7 +392,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.dmg_by_asset_aggr = extract_npz(
                 self.session, self.hostname, self.calc_id, output_type,
                 message_bar=self.iface.messageBar(), params=params)
-        if self.dmg_by_asset_aggr is None:
+        if (self.dmg_by_asset_aggr is None
+                or 'array' not in self.dmg_by_asset_aggr):
+            msg = 'No data corresponds to the current selection'
+            log_msg(msg, level='W', message_bar=self.iface.messageBar())
+            self.plot.clear()
             return
         self.draw_dmg_by_asset_aggr()
 
@@ -473,7 +480,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.filter_agg_curves()
 
     def update_selected_tag_values(self, tag_name):
-        cbx = getattr(self, "%s_values_multiselect" % tag_name)
+        self.current_tag_name = tag_name
+        cbx = getattr(self, "%s_values_multiselect" % self.current_tag_name)
         for tag_value in cbx.get_selected_items():
             self.tags[self.current_tag_name]['values'][tag_value] = True
         for tag_value in cbx.get_unselected_items():

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -432,8 +432,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             if self.tags[tag_name]['selected']:
                 for value in self.tags[tag_name]['values']:
                     if self.tags[tag_name]['values'][value]:
-                        # NOTE: this would not work for multiple values per tag
-                        params[tag_name] = value
+                        if tag_name in params:
+                            params[tag_name].append(value)
+                        else:
+                            params[tag_name] = [value]
         to_extract = 'agg_losses/%s' % self.loss_type_cbx.currentText()
         with WaitCursorManager(
                 'Extracting...', message_bar=self.iface.messageBar()):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -326,21 +326,28 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.tag_names_multiselect.selection_changed.connect(
             self.update_selected_tag_names)
 
-    def toggle_tag_values_multiselect(self, tag_name, tag_name_is_checked):
+    def toggle_tag_values_multiselect(
+            self, tag_name, tag_name_is_checked, mono=True):  # FIXME
         lbl = getattr(self, "%s_values_lbl" % tag_name, None)
         cbx = getattr(self, "%s_values_multiselect" % tag_name, None)
         if not lbl and not cbx and tag_name_is_checked:
             setattr(self, "%s_values_lbl" % tag_name,
                     QLabel('%s values' % tag_name))
             setattr(self, "%s_values_multiselect" % tag_name,
-                    MultiSelectComboBox(self))
+                    MultiSelectComboBox(self, mono=mono))
             self.typeDepVLayout.addWidget(
                 getattr(self, "%s_values_lbl" % tag_name))
             self.typeDepVLayout.addWidget(
                 getattr(self, "%s_values_multiselect" % tag_name))
-            getattr(self, "%s_values_multiselect"
-                    % tag_name).selection_changed.connect(
-                        lambda: self.update_selected_tag_values(tag_name))
+            if mono:
+                getattr(self, "%s_values_multiselect"
+                        % tag_name).currentIndexChanged.connect(
+                            lambda idx: self.update_selected_tag_values(
+                                tag_name))
+            else:
+                getattr(self, "%s_values_multiselect"
+                        % tag_name).selection_changed.connect(
+                            lambda: self.update_selected_tag_values(tag_name))
             self.populate_tag_values_multiselect(tag_name)
         elif lbl and cbx and not tag_name_is_checked:
             delattr(self, "%s_values_lbl" % tag_name)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -395,7 +395,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if (self.dmg_by_asset_aggr is None
                 or 'array' not in self.dmg_by_asset_aggr):
             msg = 'No data corresponds to the current selection'
-            log_msg(msg, level='W', message_bar=self.iface.messageBar())
+            log_msg(msg, level='W', message_bar=self.iface.messageBar(),
+                    duration=5)
             self.plot.clear()
             return
         self.draw_dmg_by_asset_aggr()
@@ -459,7 +460,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if (self.losses_by_asset_aggr is None
                 or 'array' not in self.losses_by_asset_aggr):
             msg = 'No data corresponds to the current selection'
-            log_msg(msg, level='W', message_bar=self.iface.messageBar())
+            log_msg(msg, level='W', message_bar=self.iface.messageBar(),
+                    duration=5)
             self.plot.clear()
             return
         self.draw_losses_by_asset_aggr()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -456,7 +456,11 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.losses_by_asset_aggr = extract_npz(
                 self.session, self.hostname, self.calc_id, to_extract,
                 message_bar=self.iface.messageBar(), params=params)
-        if self.losses_by_asset_aggr is None:
+        if (self.losses_by_asset_aggr is None
+                or 'array' not in self.losses_by_asset_aggr):
+            msg = 'No data corresponds to the current selection'
+            log_msg(msg, level='W', message_bar=self.iface.messageBar())
+            self.plot.clear()
             return
         self.draw_losses_by_asset_aggr()
 

--- a/svir/ui/multi_select_combo_box.py
+++ b/svir/ui/multi_select_combo_box.py
@@ -37,10 +37,13 @@ class MultiSelectComboBox(QComboBox):
         self.activated.connect(self.itemClicked)
 
     def on_select_all_toggled(self, state):
+        self.blockSignals(True)
         for i in range(2, self.mlist.count()):
             checkbox = self.mlist.itemWidget(self.mlist.item(i))
             if self.search_bar.text().lower() in checkbox.text().lower():
                 checkbox.setChecked(state)
+        self.blockSignals(False)
+        self.selection_changed.emit()
 
     def itemClicked(self, idx):
         if idx not in [self.SEARCH_BAR_IDX, self.SELECT_ALL_IDX]:

--- a/svir/ui/multi_select_combo_box.py
+++ b/svir/ui/multi_select_combo_box.py
@@ -145,7 +145,7 @@ class MultiSelectComboBox(QComboBox):
             selected_text = self.currentText()
             for i in range(self.count()):
                 item_text = self.itemText(i)
-                if item_text != selected_text:
+                if item_text and item_text != selected_text:
                     items.append(item_text)
             return items
         for i in range(2, self.mlist.count()):

--- a/svir/ui/multi_select_combo_box.py
+++ b/svir/ui/multi_select_combo_box.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (
     QLineEdit, QCheckBox, QComboBox, QListWidget, QListWidgetItem,
-    QApplication, QMainWindow)
+    QApplication, QMainWindow, QWidget, QVBoxLayout)
 from PyQt5.QtCore import QEvent, pyqtSignal
 from PyQt5.QtGui import QCursor
 
@@ -13,9 +13,12 @@ class MultiSelectComboBox(QComboBox):
     selection_changed = pyqtSignal()
     item_was_clicked = pyqtSignal(str, bool)
 
-    def __init__(self, parent):
+    def __init__(self, parent, mono=False):
 
         super().__init__(parent)
+        self.mono = mono
+        if self.mono:
+            return
 
         self.mlist = QListWidget(self)
         self.line_edit = QLineEdit(self)
@@ -46,12 +49,17 @@ class MultiSelectComboBox(QComboBox):
         self.selection_changed.emit()
 
     def itemClicked(self, idx):
+        if self.mono:
+            self.item_was_clicked.emit(self.currentText(), True)
+            return super().itemClicked(idx)
         if idx not in [self.SEARCH_BAR_IDX, self.SELECT_ALL_IDX]:
             checkbox = self.mlist.itemWidget(self.mlist.item(idx))
             checkbox.setChecked(not checkbox.isChecked())
             self.item_was_clicked.emit(checkbox.text(), checkbox.isChecked())
 
     def hidePopup(self):
+        if self.mono:
+            return super().hidePopup()
         width = self.width()
         height = self.mlist.height()
         x = (QCursor.pos().x()
@@ -68,6 +76,8 @@ class MultiSelectComboBox(QComboBox):
             super().hidePopup()
 
     def stateChanged(self, state):
+        if self.mono:
+            return super().stateChanged(state)
         # NOTE: not using state
         selected_data = ""
         for i in range(2, self.mlist.count()):
@@ -87,18 +97,28 @@ class MultiSelectComboBox(QComboBox):
         self.item_was_clicked.emit(text, state)
 
     def add_selected_items(self, items):
+        if self.mono:
+            return super().addItems(items)
         self.addItems(items, selected=True)
 
     def add_unselected_items(self, items):
+        if self.mono:
+            return super().addItems(items)
         self.addItems(items, selected=False)
 
     def set_selected_items(self, items):
+        if self.mono:
+            return
         self.set_items_selection(items, True)
 
     def set_unselected_items(self, items):
+        if self.mono:
+            return
         self.set_items_selection(items, False)
 
     def set_items_selection(self, items, checked):
+        if self.mono:
+            return
         for i in range(2, self.mlist.count()):
             checkbox = self.mlist.itemWidget(self.mlist.item(i))
             if checkbox.text() in items:
@@ -108,6 +128,11 @@ class MultiSelectComboBox(QComboBox):
 
     def get_selected_items(self):
         items = []
+        if self.mono:
+            if super().currentText():
+                return [super().currentText()]
+            else:
+                return []
         for i in range(2, self.mlist.count()):
             checkbox = self.mlist.itemWidget(self.mlist.item(i))
             if checkbox.isChecked():
@@ -116,6 +141,13 @@ class MultiSelectComboBox(QComboBox):
 
     def get_unselected_items(self):
         items = []
+        if self.mono:
+            selected_text = self.currentText()
+            for i in range(self.count()):
+                item_text = self.itemText(i)
+                if item_text != selected_text:
+                    items.append(item_text)
+            return items
         for i in range(2, self.mlist.count()):
             checkbox = self.mlist.itemWidget(self.mlist.item(i))
             if not checkbox.isChecked():
@@ -123,6 +155,8 @@ class MultiSelectComboBox(QComboBox):
         return items
 
     def addItem(self, text, user_data=None, selected=False):
+        if self.mono:
+            return super().addItem(text, user_data)
         # NOTE: not using user_data
         list_widget_item = QListWidgetItem(self.mlist)
         checkbox = QCheckBox(self)
@@ -136,6 +170,8 @@ class MultiSelectComboBox(QComboBox):
         checkbox.setChecked(selected)
 
     def currentText(self):
+        if self.mono:
+            return super().currentText()
         items = self.line_edit.text().split('; ')
         if len(items) == 1 and not items[0]:
             # avoid returning ['']
@@ -144,10 +180,14 @@ class MultiSelectComboBox(QComboBox):
             return items
 
     def addItems(self, texts, selected=False):
+        if self.mono:
+            return super().addItems(texts)
         for text in texts:
             self.addItem(text, selected=selected)
 
     def count(self):
+        if self.mono:
+            return super().count()
         # do not count search bar and toggle select all
         count = self.mlist.count() - 2
         if count < 0:
@@ -155,6 +195,11 @@ class MultiSelectComboBox(QComboBox):
         return count
 
     def selected_count(self):
+        if self.mono:
+            if self.currentIndex() == -1:
+                return 0
+            else:
+                return 1
         return len(self.get_selected_items())
 
     def onSearch(self, search_str):
@@ -179,6 +224,8 @@ class MultiSelectComboBox(QComboBox):
         self.line_edit.setPlaceholderText(text)
 
     def clear(self):
+        if self.mono:
+            return super().clear()
         self.mlist.clear()
         self.search_bar = QLineEdit(self)
         self.search_item = QListWidgetItem(self.mlist)
@@ -195,16 +242,22 @@ class MultiSelectComboBox(QComboBox):
         self.search_bar.textChanged[str].connect(self.onSearch)
 
     def wheelEvent(self, wheel_event):
+        if self.mono:
+            return super().wheelEvent(wheel_event)
         # do not handle the wheel event
         pass
 
     def eventFilter(self, obj, event):
+        if self.mono:
+            return super().eventFilter(obj, event)
         if obj == self.line_edit and event.type() == QEvent.MouseButtonRelease:
             self.showPopup()
             return False
         return False
 
     def keyPressedEvent(self, event):
+        if self.mono:
+            return super().keyPressedEvent(event)
         # do not handle key event
         pass
 
@@ -212,6 +265,8 @@ class MultiSelectComboBox(QComboBox):
     #     pass
 
     def setCurrentText(self, texts):
+        if self.mono:
+            return super().setCurrentText(texts)
         for i in range(2, self.mlist.count()):
             checkbox = self.mlist.itemWidget(self.mlist.item(i))
             checkbox_str = checkbox.text()
@@ -219,6 +274,8 @@ class MultiSelectComboBox(QComboBox):
                 checkbox.setChecked(True)
 
     def resetSelection(self):
+        if self.mono:
+            return self.resetSelection()
         for i in range(2, self.mlist.count()):
             checkbox = self.mlist.itemWidget(self.mlist.item(i))
             checkbox.setChecked(False)
@@ -229,11 +286,17 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
 
     win = QMainWindow()
-    mscb = MultiSelectComboBox(win)
+    wdg = QWidget()
+    wdg.setLayout(QVBoxLayout())
+    win.setCentralWidget(wdg)
+    mscb = MultiSelectComboBox(wdg)
     mscb.addItem("ITA")
     mscb.addItem("FRA")
     mscb.addItem("GER")
     mscb.addItems(["Rlz_%2d" % rlz for rlz in range(1, 100)])
-    win.layout().addWidget(mscb)
+    mscbmono = MultiSelectComboBox(wdg, mono=True)
+    mscbmono.addItems(mscb.get_unselected_items())
+    wdg.layout().addWidget(mscb)
+    wdg.layout().addWidget(mscbmono)
     win.show()
     app.exec_()

--- a/svir/ui/multi_select_combo_box.py
+++ b/svir/ui/multi_select_combo_box.py
@@ -11,7 +11,7 @@ class MultiSelectComboBox(QComboBox):
     SEARCH_BAR_IDX = 0
     SELECT_ALL_IDX = 1
     selection_changed = pyqtSignal()
-    item_was_clicked = pyqtSignal(str)
+    item_was_clicked = pyqtSignal(str, bool)
 
     def __init__(self, parent):
 
@@ -46,7 +46,7 @@ class MultiSelectComboBox(QComboBox):
         if idx not in [self.SEARCH_BAR_IDX, self.SELECT_ALL_IDX]:
             checkbox = self.mlist.itemWidget(self.mlist.item(idx))
             checkbox.setChecked(not checkbox.isChecked())
-            self.item_was_clicked.emit(checkbox.text())
+            self.item_was_clicked.emit(checkbox.text(), checkbox.isChecked())
 
     def hidePopup(self):
         width = self.width()
@@ -80,8 +80,8 @@ class MultiSelectComboBox(QComboBox):
         self.line_edit.setToolTip(selected_data)
         self.selection_changed.emit()
 
-    def on_checkbox_stateChanged(self, text):
-        self.item_was_clicked.emit(text)
+    def on_checkbox_stateChanged(self, text, state):
+        self.item_was_clicked.emit(text, state)
 
     def add_selected_items(self, items):
         self.addItems(items, selected=True)
@@ -128,7 +128,8 @@ class MultiSelectComboBox(QComboBox):
         self.mlist.setItemWidget(list_widget_item, checkbox)
         checkbox.stateChanged.connect(self.stateChanged)
         checkbox.stateChanged.connect(
-            lambda state: self.on_checkbox_stateChanged(checkbox.text()))
+            lambda state: self.on_checkbox_stateChanged(
+                checkbox.text(), state))
         checkbox.setChecked(selected)
 
     def currentText(self):


### PR DESCRIPTION
When a tag name is selected, a corresponding multiselector for its values is added to the GUI if needed, and when it is unchecked, the corresponding multiselector is removed if present.
In case we want to use a simple selector that looks like a normal combobox, we can use a modified version of the MultiSelectComboBox that is compatible with the API of QComboBox.