### PR TITLE
In import_layer_from_csv skip commented head lines

### DIFF
--- a/svir/dialogs/load_basic_csv_as_layer_dialog.py
+++ b/svir/dialogs/load_basic_csv_as_layer_dialog.py
@@ -24,7 +24,8 @@
 
 import os
 import tempfile
-from svir.utilities.utils import import_layer_from_csv, log_msg
+from svir.utilities.utils import (
+    import_layer_from_csv, log_msg, count_heading_commented_lines)
 from svir.utilities.shared import OQ_BASIC_CSV_TO_LAYER_TYPES
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -971,6 +971,8 @@ def import_layer_from_csv(parent,
                           subset=None,
                           add_to_legend=True,
                           add_on_top=False):
+    if not lines_to_skip_count:
+        lines_to_skip_count = count_heading_commented_lines(csv_path)
     url = QUrl.fromLocalFile(csv_path)
     url_query = QUrlQuery()
     url_query.addQueryItem('type', 'csv')


### PR DESCRIPTION
This should fix the headers in tables imported from csv, now that the OQ-Engine outputs contain commented lines on top.