### PR TITLE
Set selected features color depending on the output type

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -768,8 +768,10 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         effect.setOpacity(1)
         effect.setColor(QColor(255, 255, 255))
         effect.setBlurLevel(1)
+
         renderer.paintEffect().appendEffect(effect)
         renderer.paintEffect().setEnabled(True)
+
         self.layer.setRenderer(renderer)
         self.layer.setOpacity(0.7)
         self.layer.triggerRepaint()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1570,19 +1570,24 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     selected_imt = self.imt_cbx.currentText()
                 field_names = []
                 for field in self.iface.activeLayer().fields():
-                    print(field.name())
                     if field.name() == 'fid':
                         continue
                     if self.output_type == 'hcurves':
                         # field names are like 'mean_PGA_0.005'
                         rlz_or_stat, imt, iml = field.name().split('_')
-                        print(rlz_or_stat, imt, iml)
+                        print("stat = %s\nimt = %s\niml = %s" % (
+                            rlz_or_stat, imt, iml))
+                        print("selected_imt = %s" % selected_imt)
                         if imt != selected_imt:
+                            print('imt != selected_imt')
                             continue
                     else:  # 'uhs'
                         # field names are like 'mean_PGA'
                         rlz_or_stat, _ = field.name().split('_')
                     if rlz_or_stat not in selected_rlzs_or_stats:
+                        print("selected_rlzs_or_stats = %s" %
+                              selected_rlzs_or_stats)
+                        print('rlz_or_stat not in selected_rlzs_or_stats')
                         continue
                     field_names.append(field.name())
                 investigation_time = float(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1570,11 +1570,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     selected_imt = self.imt_cbx.currentText()
                 field_names = []
                 for field in self.iface.activeLayer().fields():
+                    print(field.name())
                     if field.name() == 'fid':
                         continue
                     if self.output_type == 'hcurves':
                         # field names are like 'mean_PGA_0.005'
                         rlz_or_stat, imt, iml = field.name().split('_')
+                        print(rlz_or_stat, imt, iml)
                         if imt != selected_imt:
                             continue
                     else:  # 'uhs'
@@ -1596,7 +1598,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     csv_file.write(
                         '# return_period = %.0f\r\n' % return_period)
                 headers = ['lon', 'lat']
+                print(field_names)
                 headers.extend(field_names)
+                print(headers)
                 writer.writerow(headers)
                 for feature in self.iface.activeLayer().selectedFeatures():
                     values = [feature[field_name]

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -183,6 +183,21 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
         self.plot_canvas.mpl_connect('motion_notify_event', self.on_plot_hover)
 
+    def create_annot(self):
+        self.annot = self.plot.annotate(
+            "", xy=(0, 0), xytext=(-20, 20), textcoords="offset points",
+            bbox=dict(boxstyle="round", fc="w"),
+            arrowprops=dict(arrowstyle="->"))
+        self.annot.set_visible(False)
+
+    def update_annot(self, ind):
+        x, y = self.line.get_data()
+        xlab = x[ind["ind"][0]]
+        ylab = y[ind["ind"][0]]
+        self.annot.xy = (xlab, ylab)
+        self.annot.set_text("%.0f days, %.0f%%" % (xlab, ylab))
+        self.annot.get_bbox_patch().set_alpha(0.4)
+
     def create_loss_type_selector(self):
         self.loss_type_lbl = QLabel('Loss Type')
         self.loss_type_lbl.setSizePolicy(
@@ -963,7 +978,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 lon = feature.geometry().asPoint().x()
                 lat = feature.geometry().asPoint().y()
 
-                self.plot.plot(
+                self.line, = self.plot.plot(
                     curve['abscissa'],
                     curve['ordinates'],
                     color=curve['color'],
@@ -974,6 +989,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     gid=str(site),
                     picker=5  # 5 points tolerance
                 )
+                if self.output_type == 'recovery_curves':
+                    self.create_annot()
         if self.output_type == 'hcurves':
             self.plot.set_xscale('log')
             self.plot.set_yscale('log')
@@ -1373,6 +1390,20 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if not self.on_container_hover(event, self.plot):
             if hasattr(self.legend, 'get_lines'):
                 self.on_container_hover(event, self.legend)
+        if self.output_type == 'recovery_curves':
+            vis = self.annot.get_visible()
+            if event.inaxes == self.plot:
+                if not hasattr(self, 'line'):
+                    return
+                cont, ind = self.line.contains(event)
+                if cont:
+                    self.update_annot(ind)
+                    self.annot.set_visible(True)
+                    self.plot_figure.canvas.draw_idle()
+                else:
+                    if vis:
+                        self.annot.set_visible(False)
+                        self.plot_figure.canvas.draw_idle()
 
     def on_container_hover(self, event, container):
         if self.output_type in (

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1735,11 +1735,14 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         event.accept()
 
     def change_output_type(self, output_type):
+        current_index = self.output_type_cbx.currentIndex()
         if output_type not in self.output_types_names:
             output_type = ''
         # get the index of the item that has the given string
         # and set the combobox to that item
-        index = self.output_type_cbx.findText(
+        target_index = self.output_type_cbx.findText(
             self.output_types_names[output_type])
-        if index != -1:
-            self.output_type_cbx.setCurrentIndex(index)
+        if target_index != -1:
+            self.output_type_cbx.setCurrentIndex(target_index)
+        if target_index == current_index:
+            self.output_type_cbx.currentIndexChanged.emit(current_index)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -84,6 +84,7 @@ FORM_CLASS = get_ui_class('ui_viewer_dock.ui')
 
 
 class ViewerDock(QDockWidget, FORM_CLASS):
+
     def __init__(self, iface, action):
         """Constructor for the viewer dock.
 
@@ -1575,19 +1576,19 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     if self.output_type == 'hcurves':
                         # field names are like 'mean_PGA_0.005'
                         rlz_or_stat, imt, iml = field.name().split('_')
-                        print("stat = %s\nimt = %s\niml = %s" % (
-                            rlz_or_stat, imt, iml))
-                        print("selected_imt = %s" % selected_imt)
+                        # print("stat = %s\nimt = %s\niml = %s" % (
+                        #     rlz_or_stat, imt, iml))
+                        # print("selected_imt = %s" % selected_imt)
                         if imt != selected_imt:
-                            print('imt != selected_imt')
+                            # print('imt != selected_imt')
                             continue
                     else:  # 'uhs'
                         # field names are like 'mean_PGA'
                         rlz_or_stat, _ = field.name().split('_')
                     if rlz_or_stat not in selected_rlzs_or_stats:
-                        print("selected_rlzs_or_stats = %s" %
-                              selected_rlzs_or_stats)
-                        print('rlz_or_stat not in selected_rlzs_or_stats')
+                        # print("selected_rlzs_or_stats = %s" %
+                        #       selected_rlzs_or_stats)
+                        # print('rlz_or_stat not in selected_rlzs_or_stats')
                         continue
                     field_names.append(field.name())
                 investigation_time = float(
@@ -1603,9 +1604,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     csv_file.write(
                         '# return_period = %.0f\r\n' % return_period)
                 headers = ['lon', 'lat']
-                print(field_names)
                 headers.extend(field_names)
-                print(headers)
                 writer.writerow(headers)
                 for feature in self.iface.activeLayer().selectedFeatures():
                     values = [feature[field_name]

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -101,7 +101,7 @@ from svir.utilities.shared import (DEBUG,
                                    PROJECT_TEMPLATE,
                                    THEME_TEMPLATE,
                                    INDICATOR_TEMPLATE,
-                                   OQ_CURVE_TYPES,
+                                   OQ_XMARKER_TYPES,
                                    OPERATORS_DICT)
 from svir.ui.tool_button_with_help_link import QToolButtonWithHelpLink
 from svir.processing_provider.provider import Provider
@@ -486,7 +486,7 @@ class Irmt(object):
         if layer:
             output_type = layer.customProperty('output_type') or ''
         p = QgsProject.instance()
-        if output_type in OQ_CURVE_TYPES:
+        if output_type in OQ_XMARKER_TYPES:
             # set a darker color for selected features in the project
             p.writeEntry('Gui', '/SelectionColorRedPart', 255)
             p.writeEntry('Gui', '/SelectionColorGreenPart', 0)

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -514,8 +514,6 @@ class Irmt(object):
                 self.initial_selection_color_alpha_part))
 
         self.viewer_dock.change_output_type(output_type)
-        # self.viewer_tock.gui_reset_complete.connect(
-        #     self.viewer_dock.layer_changed())
 
     def add_menu_item(self,
                       action_name,

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -57,7 +57,7 @@ from qgis.PyQt.QtCore import (
                               QUrlQuery,
                               )
 from qgis.PyQt.QtWidgets import QAction, QFileDialog, QApplication, QMenu
-from qgis.PyQt.QtGui import QIcon, QDesktopServices
+from qgis.PyQt.QtGui import QIcon, QDesktopServices, QColor
 
 from svir.dialogs.viewer_dock import ViewerDock
 from svir.utilities.import_sv_data import get_loggedin_downloader
@@ -101,6 +101,7 @@ from svir.utilities.shared import (DEBUG,
                                    PROJECT_TEMPLATE,
                                    THEME_TEMPLATE,
                                    INDICATOR_TEMPLATE,
+                                   OQ_CURVE_TYPES,
                                    OPERATORS_DICT)
 from svir.ui.tool_button_with_help_link import QToolButtonWithHelpLink
 from svir.processing_provider.provider import Provider
@@ -157,17 +158,31 @@ class Irmt(object):
         # 'selected_project_definition_idx', 'project_definitions'
         self.supplemental_information = {}
 
+        self.iface.initializationCompleted.connect(
+            self.on_iface_initialization_completed)
+
+        # get or create directory to store input files for the OQ-Engine
+        self.ipt_dir = self.get_ipt_dir()
+
+        self.provider = None
+
+    def on_iface_initialization_completed(self):
         self.iface.currentLayerChanged.connect(self.current_layer_changed)
         self.iface.newProjectCreated.connect(self.current_layer_changed)
         self.iface.projectRead.connect(self.current_layer_changed)
         QgsProject.instance().layersAdded.connect(self.layers_added)
         QgsProject.instance().layersRemoved.connect(
             self.layers_removed)
-
-        # get or create directory to store input files for the OQ-Engine
-        self.ipt_dir = self.get_ipt_dir()
-
-        self.provider = None
+        # save the default selection color settings
+        p = QgsProject.instance()
+        self.initial_selection_color_red_part = p.readNumEntry(
+            'Gui', '/SelectionColorRedPart')[0]
+        self.initial_selection_color_green_part = p.readNumEntry(
+            'Gui', '/SelectionColorGreenPart')[0]
+        self.initial_selection_color_blue_part = p.readNumEntry(
+            'Gui', '/SelectionColorBluePart')[0]
+        self.initial_selection_color_alpha_part = p.readNumEntry(
+            'Gui', '/SelectionColorAlphaPart')[0]
 
     def initProcessing(self):
         self.provider = Provider()
@@ -470,6 +485,34 @@ class Irmt(object):
         output_type = ''
         if layer:
             output_type = layer.customProperty('output_type') or ''
+        p = QgsProject.instance()
+        if output_type in OQ_CURVE_TYPES:
+            # set a darker color for selected features in the project
+            p.writeEntry('Gui', '/SelectionColorRedPart', 255)
+            p.writeEntry('Gui', '/SelectionColorGreenPart', 0)
+            p.writeEntry('Gui', '/SelectionColorBluePart', 0)
+            p.writeEntry('Gui', '/SelectionColorAlphaPart', 255)
+            self.iface.mapCanvas().setSelectionColor(QColor(255, 0, 0, 255))
+        else:
+            # restore intial selection color
+            p.writeEntry(
+                'Gui', '/SelectionColorRedPart',
+                self.initial_selection_color_red_part)
+            p.writeEntry(
+                'Gui', '/SelectionColorGreenPart',
+                self.initial_selection_color_green_part)
+            p.writeEntry(
+                'Gui', '/SelectionColorBluePart',
+                self.initial_selection_color_blue_part)
+            p.writeEntry(
+                'Gui', '/SelectionColorAlphaPart',
+                self.initial_selection_color_alpha_part)
+            self.iface.mapCanvas().setSelectionColor(QColor(
+                self.initial_selection_color_red_part,
+                self.initial_selection_color_green_part,
+                self.initial_selection_color_blue_part,
+                self.initial_selection_color_alpha_part))
+
         self.viewer_dock.change_output_type(output_type)
         self.viewer_dock.layer_changed()
 

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -514,7 +514,8 @@ class Irmt(object):
                 self.initial_selection_color_alpha_part))
 
         self.viewer_dock.change_output_type(output_type)
-        self.viewer_dock.layer_changed()
+        # self.viewer_tock.gui_reset_complete.connect(
+        #     self.viewer_dock.layer_changed())
 
     def add_menu_item(self,
                       action_name,

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -35,6 +35,7 @@ changelog=
       algorithm, that automatically styles the output joined layer
     * Re-added and updated the user manual chapter about aggregating points by zone
     * Scripts running tests and building the user manual have been fixed
+    * The color for selected features is red for layers that use a cross symbol in the map (e.g. hazard curves and uniform hazard spectra)
     3.7.1
     * Instead of the 'sourcegroups' output (that was removed from the OQ-Engine), the plugin can now load the new output 'events'
     * The user can choose if selecting the '.ini' file to run a OQ-Engine calculation, or letting the OQ-Engine automatically pick one from the list of input files.

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -36,6 +36,7 @@ changelog=
     * Re-added and updated the user manual chapter about aggregating points by zone
     * Scripts running tests and building the user manual have been fixed
     * The color for selected features is red for layers that use a cross symbol in the map (e.g. hazard curves and uniform hazard spectra)
+    * Moving the mouse over recovery curves, a dynamic annotation is displayed, showing the coordinates of the pointed element
     3.7.1
     * Instead of the 'sourcegroups' output (that was removed from the OQ-Engine), the plugin can now load the new output 'events'
     * The user can choose if selecting the '.ini' file to run a OQ-Engine calculation, or letting the OQ-Engine automatically pick one from the list of input files.

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -252,7 +252,7 @@ OQ_EXTRACT_TO_VIEW_TYPES = set([
      'dmg_by_asset_aggr',
      'losses_by_asset_aggr',
      'avg_losses-stats_aggr'])
-OQ_CURVE_TYPES = set(['hcurves', 'uhs', 'recovery_curves'])
+OQ_XMARKER_TYPES = set(['hcurves', 'uhs', 'recovery_curves'])
 OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES)
 
 LOG_LEVELS = {'I': 'Info (high verbosity)',

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -252,7 +252,7 @@ OQ_EXTRACT_TO_VIEW_TYPES = set([
      'dmg_by_asset_aggr',
      'losses_by_asset_aggr',
      'avg_losses-stats_aggr'])
-OQ_CURVE_TYPES = set(['hcurves', 'uhs', 'dmg_by_asset'])
+OQ_CURVE_TYPES = set(['hcurves', 'uhs', 'recovery_curves'])
 OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES)
 
 LOG_LEVELS = {'I': 'Info (high verbosity)',

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -252,6 +252,7 @@ OQ_EXTRACT_TO_VIEW_TYPES = set([
      'dmg_by_asset_aggr',
      'losses_by_asset_aggr',
      'avg_losses-stats_aggr'])
+OQ_CURVE_TYPES = set(['hcurves', 'uhs', 'dmg_by_asset'])
 OQ_ALL_TYPES = (OQ_TO_LAYER_TYPES | OQ_RST_TYPES | OQ_EXTRACT_TO_VIEW_TYPES)
 
 LOG_LEVELS = {'I': 'Info (high verbosity)',


### PR DESCRIPTION
We are also connecting some signals (e.g. currentLayerChanged) after iface.initializationCompleted is emitted.
On currentLayerChanged, if the current layer is one of those that use a cross symbol, then the selected features color becomes red. Otherwise, the original color is used (that by default is yellow)

Also fixes https://github.com/gem/oq-irmt-qgis/issues/614