### PR TITLE
In unit tests, force qgis to use OGR_SQLITE_JOURNAL=delete...

### DIFF
--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -10,4 +10,5 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
 
 docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit python3-nose"
 
-docker exec -it qgis sh -c "export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; nosetests3 -v /tests_directory/svir/test/unit/"
+# OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
+docker exec -it qgis sh -c "export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete nosetests3 -v /tests_directory/svir/test/unit/"


### PR DESCRIPTION
...to avoid reference gpkgs to be modified on reading.

First step towards https://github.com/gem/oq-irmt-qgis/issues/654