### PR TITLE
Preselect a running calculation if it is successfully started

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -652,6 +652,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             job_id = resp_dict['job_id']
             self.pointed_calc_id = job_id
             self.refresh_calc_list()
+            self.update_output_list(self.pointed_calc_id)
             return resp_dict
         else:
             log_msg(resp.text, level='C', message_bar=self.message_bar)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -648,8 +648,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self._handle_exception(exc)
                 return
         if resp.ok:
+            resp_dict = resp.json()
+            job_id = resp_dict['job_id']
+            self.pointed_calc_id = job_id
             self.refresh_calc_list()
-            return resp.json()
+            return resp_dict
         else:
             log_msg(resp.text, level='C', message_bar=self.message_bar)
 

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -40,6 +40,7 @@ changelog=
     * Moving the mouse over recovery curves, a dynamic annotation is displayed, showing the coordinates of the pointed element
     * Widgets to select multiple items have been replaced by more compact selectors that also allow text searching
     * Selectors for tag values are added to the GUI as tabs, each containing a multiselector for values of a different tag
+    * When a new OQ-Engine calculation is successfully launched, the corresponding row is highlighted in the list of calculations, and the list of its outputs is loaded
     3.7.1
     * Instead of the 'sourcegroups' output (that was removed from the OQ-Engine), the plugin can now load the new output 'events'
     * The user can choose if selecting the '.ini' file to run a OQ-Engine calculation, or letting the OQ-Engine automatically pick one from the list of input files.


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/658
As soon as the calculation starts, the list of outputs is cleaned up. When the calculation is complete, its list of outputs is automatically loaded.