### PR TITLE
Reduce the maximum length of error messages

### DIFF
--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -157,7 +157,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
             elif level == 'C':
                 title = 'Error'
                 duration = duration if duration is not None else 0
-            max_msg_len = 200
+            max_msg_len = 100
             if len(message) > max_msg_len:
                 display_text = ("%s[...]" % message[:max_msg_len])
                 show_more = "[...]%s" % message[max_msg_len:]

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -157,7 +157,7 @@ def log_msg(message, tag='GEM OpenQuake IRMT plugin', level='I',
             elif level == 'C':
                 title = 'Error'
                 duration = duration if duration is not None else 0
-            max_msg_len = 100
+            max_msg_len = 120
             if len(message) > max_msg_len:
                 display_text = ("%s[...]" % message[:max_msg_len])
                 show_more = "[...]%s" % message[max_msg_len:]


### PR DESCRIPTION
Before this PR, error messages would be entirely displayed in the qgis message bar if they were below a threshold length of 200 characters. For longer messages, a button pointed to the full message.
@CatalinaYepes requested to reduce this threshold. A threshold of 120 characters looks good to me (it is approximately one line on my screen)