### PR TITLE
Fix enabling/disabling buttons that depend on current calculation

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -1099,8 +1099,13 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         self.run_calc_btn.setEnabled(enabled)
         self.calc_list_tbl.setEnabled(enabled)
         self.output_list_tbl.setEnabled(enabled)
-        self.download_datastore_btn.setEnabled(enabled)
-        self.show_calc_params_btn.setEnabled(enabled)
+        if enabled:
+            if self.current_calc_id is not None:
+                self.download_datastore_btn.setEnabled(enabled)
+                self.show_calc_params_btn.setEnabled(enabled)
+        else:
+            self.download_datastore_btn.setEnabled(enabled)
+            self.show_calc_params_btn.setEnabled(enabled)
         self.is_gui_enabled = enabled
 
     def reject(self):


### PR DESCRIPTION
Recently (in https://github.com/gem/oq-irmt-qgis/pull/560) I introduced a little bug: after reconnecting to the engine server, all buttons in the GUI were re-enabled, including those that are related to a specific calculation (those used to download the datastore or to visualize the parameters of the calculation).
Here I am checking that those buttons are re-enabled only if a calculation is currently selected.
