### PR TITLE
Select current OQ-Engine calculation also while moving across the list with arrow keys

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -300,6 +300,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             'Description', 'Job ID', 'Calculation Mode', 'Owner', 'Status']
         col_widths = [340, 60, 135, 70, 80]
         if not self.calc_list:
+            self.calc_list_tbl.blockSignals(True)
             if self.calc_list_tbl.rowCount() > 0:
                 self.calc_list_tbl.clearContents()
                 self.calc_list_tbl.setRowCount(0)
@@ -310,6 +311,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 self.calc_list_tbl.horizontalHeader().setStyleSheet(
                     "font-weight: bold;")
                 self.set_calc_list_widths(col_widths)
+            self.calc_list_tbl.blockSignals(False)
             return False
         actions = [
             {'label': 'Console', 'bg_color': '#3cb3c5', 'txt_color': 'white'},
@@ -318,6 +320,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             {'label': 'Continue', 'bg_color': 'white', 'txt_color': 'black'},
             {'label': 'Abort', 'bg_color': '#d9534f', 'txt_color': 'white'},
         ]
+        self.calc_list_tbl.blockSignals(True)
         self.calc_list_tbl.clearContents()
         self.calc_list_tbl.setRowCount(len(self.calc_list))
         self.calc_list_tbl.setColumnCount(len(selected_keys) + len(actions))
@@ -388,6 +391,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         if (self.pointed_calc_id and
                 self.output_list_tbl.rowCount() == 0):
             self.update_output_list(self.pointed_calc_id)
+        self.calc_list_tbl.blockSignals(False)
         return True
 
     def get_row_by_calc_id(self, calc_id):
@@ -675,12 +679,13 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         else:
             return result
 
-    @pyqtSlot(int, int)
-    def on_calc_list_tbl_cellClicked(self, row, column):
-        self.calc_list_tbl.selectRow(row)
+    @pyqtSlot(int, int, int, int)
+    def on_calc_list_tbl_currentCellChanged(
+            self, curr_row, curr_column, prev_row, prev_col):
+        self.calc_list_tbl.selectRow(curr_row)
         # find QTableItem corresponding to that calc_id
         calc_id_col_idx = 1
-        item_calc_id = self.calc_list_tbl.item(row, calc_id_col_idx)
+        item_calc_id = self.calc_list_tbl.item(curr_row, calc_id_col_idx)
         calc_id = int(item_calc_id.text())
         if self.pointed_calc_id == calc_id:
             # if you click again on the row that was selected, it unselects it

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -41,6 +41,7 @@ changelog=
     * Widgets to select multiple items have been replaced by more compact selectors that also allow text searching
     * Selectors for tag values are added to the GUI as tabs, each containing a multiselector for values of a different tag
     * When a new OQ-Engine calculation is successfully launched, the corresponding row is highlighted in the list of calculations, and the list of its outputs is loaded
+    * Moving the cursor through the list of available OQ-Engine calculations, the calculation corresponding to the highlighted cell is automatically selected and its list of outputs is displayed
     3.7.1
     * Instead of the 'sourcegroups' output (that was removed from the OQ-Engine), the plugin can now load the new output 'events'
     * The user can choose if selecting the '.ini' file to run a OQ-Engine calculation, or letting the OQ-Engine automatically pick one from the list of input files.


### PR DESCRIPTION
Moving the cursor through the list of available OQ-Engine calculations, the calculation corresponding to the highlighted cell is automatically selected and its list of outputs is displayed.

Fixes https://github.com/gem/oq-irmt-qgis/issues/382