### PR TITLE
Unskip test running risk on top of hazard, then removing both calculations

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -531,6 +531,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             except Exception as exc:
                 log_msg('Unhandled exception: %s' % exc,
                         level='C', exception=exc)
+                return exc
+            if resp is None or not resp.ok:
+                raise RuntimeError(
+                    'Unable to retrieve the log for calc #%s: %s'
+                    % (calc_id, resp))
             calc_log = json.loads(resp.text)
             self.calc_log_line[calc_id] = start + len(calc_log)
             return '\n'.join([','.join(row) for row in calc_log])
@@ -545,6 +550,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             except HANDLED_EXCEPTIONS as exc:
                 self._handle_exception(exc)
                 return exc
+            if resp is None or not resp.ok:
+                raise RuntimeError(
+                    'Unable to retrieve the status for calc #%s: %s'
+                    % (calc_id, resp))
             calc_status = json.loads(resp.text)
         return calc_status
 

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -192,9 +192,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         demo_dir = demo_dir_list[0]
         filepaths = glob.glob(os.path.join(demo_dir, '*'))
         hazard_calc_id = self.run_calc(filepaths, 'hazard')
-        # FIXME: we should re-enable testing a risk calc on top of hazard
-        # risk_calc_id = self.run_calc(filepaths, 'risk', hazard_calc_id)
-        # self.irmt.drive_oq_engine_server_dlg.remove_calc(risk_calc_id)
+        risk_calc_id = self.run_calc(filepaths, 'risk', hazard_calc_id)
+        self.irmt.drive_oq_engine_server_dlg.remove_calc(risk_calc_id)
         self.irmt.drive_oq_engine_server_dlg.remove_calc(hazard_calc_id)
 
     def get_calc_status(self, calc_id):

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -146,6 +146,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print('\t%s' % output)
 
     def run_calc(self, input_files, job_type='hazard', calc_id=None):
+        if hasattr(self, 'timer'):
+            self.timer.timeout.disconnect()
         resp = self.irmt.drive_oq_engine_server_dlg.run_calc(
             calc_id=calc_id, file_names=input_files, use_default_ini=True)
         calc_id = resp['job_id']

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -147,7 +147,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     def run_calc(self, input_files, job_type='hazard', calc_id=None):
         if hasattr(self, 'timer'):
-            self.timer.timeout.disconnect()
+            self.timer.stop()
+            delattr(self, 'timer')
         resp = self.irmt.drive_oq_engine_server_dlg.run_calc(
             calc_id=calc_id, file_names=input_files, use_default_ini=True)
         calc_id = resp['job_id']

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -157,8 +157,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self.timer.timeout.connect(
             lambda: self.refresh_calc_log(calc_id))
         self.timer.start(3000)  # refresh time in milliseconds
-        # show the log before the first iteration of the timer
-        self.refresh_calc_log(calc_id)
         timeout = 240
         start_time = time.time()
         while time.time() - start_time < timeout:


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/688

In master I was keeping this skipped because it was causing some issues while running the risk part of the calculation and attempting to remove both calculations afterwards. We can see if we still have those connection issues and if meanwhile everything is solved engine-side about removing calculations.