### PR TITLE
Avoid to print the traceback of connection errors in integration tests

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -1125,10 +1125,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     ' spelled correctly and that you are using the right'
                     ' url and port in the host setting)')
             exception = exc
+            level = 'C'
             if isinstance(exc, (ConnectionError, ProtocolError,
                                 RemoteDisconnected)):
                 exception = None
-            log_msg(err_msg, level='C', message_bar=self.message_bar,
+                level = 'W'
+            log_msg(err_msg, level=level, message_bar=self.message_bar,
                     exception=exception)
         else:
             # sanity check (it should never occur)

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -56,7 +56,7 @@ from requests.exceptions import (ConnectionError,
                                  SSLError,
                                  )
 from http.client import RemoteDisconnected
-from urrlib3.exceptions import ProtocolError
+from urllib3.exceptions import ProtocolError
 from requests.packages.urllib3.exceptions import (
     LocationParseError)
 from svir.utilities.shared import (OQ_TO_LAYER_TYPES,

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -55,6 +55,8 @@ from requests.exceptions import (ConnectionError,
                                  ReadTimeout,
                                  SSLError,
                                  )
+from http.client import RemoteDisconnected
+from urrlib3.exceptions import ProtocolError
 from requests.packages.urllib3.exceptions import (
     LocationParseError)
 from svir.utilities.shared import (OQ_TO_LAYER_TYPES,
@@ -1095,6 +1097,8 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             err_msg += ' (you could try prepending http:// or https://)'
             log_msg(err_msg, level='C', message_bar=self.message_bar)
         elif isinstance(exc, (ConnectionError,
+                              ProtocolError,
+                              RemoteDisconnected,
                               InvalidSchema,
                               MissingSchema,
                               ReadTimeout,
@@ -1120,8 +1124,12 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                     ' (please make sure the username and password are'
                     ' spelled correctly and that you are using the right'
                     ' url and port in the host setting)')
+            exception = exc
+            if isinstance(exc, (ConnectionError, ProtocolError,
+                                RemoteDisconnected)):
+                exception = None
             log_msg(err_msg, level='C', message_bar=self.message_bar,
-                    exception=exc)
+                    exception=exception)
         else:
             # sanity check (it should never occur)
             raise TypeError(


### PR DESCRIPTION
I am also handling some additional error types