### PR TITLE
In integration tests, make sure calculations are completed correctly

### DIFF
--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -89,6 +89,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         cls.irmt.drive_oq_engine_server(show=False, hostname=cls.hostname)
         # NOTE: calc_list must be retrieved BEFORE starting any test
         cls.calc_list = cls.irmt.drive_oq_engine_server_dlg.calc_list
+        if isinstance(cls.calc_list, Exception):
+            raise cls.calc_list
         cls.output_list = {}
         try:
             selected_calc_id = int(os.environ.get('SELECTED_CALC_ID'))
@@ -216,6 +218,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             return
         if calc_status['status'] in ('complete', 'failed'):
             self.timer.stop()
+            if calc_status['status'] == 'falied':
+                print('Calculation #%s failed' % calc_id)
         calc_log = self.irmt.drive_oq_engine_server_dlg.get_calc_log(calc_id)
         if isinstance(calc_log, Exception):
             print("An exception occurred: %s" % calc_log)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -167,17 +167,21 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             time.sleep(0.1)
         calc_status = self.get_calc_status(calc_id)
         if isinstance(calc_status, Exception):
+            print('Removing calculation #%s' % calc_id)
             resp = self.irmt.drive_oq_engine_server_dlg.remove_calc(calc_id)
             print('After reaching the timeout of %s seconds, the %s'
                   ' calculation raised the exception "%s", and it was deleted'
                   % (timeout, job_type, calc_status))
             raise calc_status
         if not calc_status['status'] == 'complete':
+            print('Removing calculation #%s' % calc_id)
             resp = self.irmt.drive_oq_engine_server_dlg.remove_calc(calc_id)
             raise TimeoutError(
                 'After reaching the timeout of %s seconds, the %s'
                 ' calculation was in the state "%s", and it was deleted'
                 % (timeout, job_type, calc_status))
+        else:
+            print('Calculation #%s was completed' % calc_id)
         return calc_id
 
     def test_run_calculation(self):
@@ -194,7 +198,9 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         filepaths = glob.glob(os.path.join(demo_dir, '*'))
         hazard_calc_id = self.run_calc(filepaths, 'hazard')
         risk_calc_id = self.run_calc(filepaths, 'risk', hazard_calc_id)
+        print('Removing calculation #%s' % risk_calc_id)
         self.irmt.drive_oq_engine_server_dlg.remove_calc(risk_calc_id)
+        print('Removing calculation #%s' % hazard_calc_id)
         self.irmt.drive_oq_engine_server_dlg.remove_calc(hazard_calc_id)
 
     def get_calc_status(self, calc_id):


### PR DESCRIPTION
I noticed that in some cases it is not clear from the log that a calculation was completed successfully, so I am adding some prints to clearly state when a calculation is complete, when it failed, when it is removed afterwards.
I've also noticed that in some very rare cases all integration tests fail from the beginning while attempting to retrieve the list of calculations. I could add a loop to retry until a timeout is reached, but it is tricky stuff that I prefer to avoid for now.