### PR TITLE
Hack to fix resizing the dialog loading ruptures

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -150,7 +150,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.vlayout.addWidget(self.load_multicol_ckb)
 
     def create_min_mag_dsb(self):
-        self.min_mag_lbl = QLabel('Minimum magnitude')
+        self.min_mag_lbl = QLabel()
         self.min_mag_dsb = QDoubleSpinBox(self)
         self.min_mag_dsb.setRange(0, 10)
         self.min_mag_dsb.setDecimals(1)
@@ -158,6 +158,10 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.min_mag_dsb.setValue(4.0)
         self.vlayout.addWidget(self.min_mag_lbl)
         self.vlayout.addWidget(self.min_mag_dsb)
+        # NOTE: if we don't modify the text of the label after adding the
+        # widget to the layout, the adjustSize does not work properly, for some
+        # unknown reason
+        self.min_mag_lbl.setText('Minimum magnitude')
 
     def create_rlz_or_stat_selector(self, all_ckb=False, label='Realization'):
         self.rlz_or_stat_lbl = QLabel(label)


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/703

Exploring one by one the steps done by the loader for hcurves (that resizes the dialog correctly) I found out that the line that actually modified the behavior was just changing the text of a label. I tried doing the same in the dialog for ruptures, and I found out that what changes the adjustSize behavior is the fact that a label is modified after adding it to the layout where it belongs. This is a very bizarre behavior that I am unable to explain and that should be further investigated. I've added a note in the code about this.