### PR TITLE
Prefilter ground motion fields by event id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 services: docker
 
 language: python

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -839,10 +839,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             if row['type'] in (OQ_TO_LAYER_TYPES |
                                OQ_RST_TYPES |
                                OQ_EXTRACT_TO_VIEW_TYPES):
-                # TODO: remove check when gmf_data, dmg_by_event and
-                #       losses_by_event will be loadable also for event_based
-                if not (row['type'] in [  # 'gmf_data',
-                                        'dmg_by_event',
+                # TODO: remove check when dmg_by_event and losses_by_event
+                #       will be loadable also for event_based
+                if not (row['type'] in ['dmg_by_event',
                                         'losses_by_event']
                         and 'event_based' in calculation_mode):
                     num_actions += 1  # needs additional column for loader btn
@@ -897,10 +896,9 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                         action = 'Load table'
                     else:
                         action = 'Load layer'
-                    # TODO: remove check when gmf_data, dmg_by_event and
-                    # losses_by_event will be loadable also for event_based
-                    if (output['type'] in [  # 'gmf_data',
-                                           'dmg_by_event',
+                    # TODO: remove check when dmg_by_event and losses_by_event
+                    #       will be loadable also for event_based
+                    if (output['type'] in ['dmg_by_event',
                                            'losses_by_event']
                             and calculation_mode == 'event_based'):
                         continue

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -841,7 +841,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                                OQ_EXTRACT_TO_VIEW_TYPES):
                 # TODO: remove check when gmf_data, dmg_by_event and
                 #       losses_by_event will be loadable also for event_based
-                if not (row['type'] in ['gmf_data',
+                if not (row['type'] in [  # 'gmf_data',
                                         'dmg_by_event',
                                         'losses_by_event']
                         and 'event_based' in calculation_mode):
@@ -899,7 +899,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                         action = 'Load layer'
                     # TODO: remove check when gmf_data, dmg_by_event and
                     # losses_by_event will be loadable also for event_based
-                    if (output['type'] in ['gmf_data',
+                    if (output['type'] in [  # 'gmf_data',
                                            'dmg_by_event',
                                            'losses_by_event']
                             and calculation_mode == 'event_based'):

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -51,6 +51,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         self.create_num_sites_indicator()
         # NOTE: gmpe and gsim are synonyms
         self.create_rlz_or_stat_selector('Ground Motion Prediction Equation')
+        self.rlz_or_stat_cbx.setVisible(False)
         self.create_imt_selector()
 
         log_msg('Extracting number of events. Watch progress in QGIS task bar',
@@ -101,9 +102,13 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         #       need to move this block of code inside on_rlz_or_stat_changed()
         rlz = self.rlz_or_stat_cbx.itemData(
             self.rlz_or_stat_cbx.currentIndex())
-        gmf_data = self.npz_file[rlz]
-        self.num_sites_lbl.setText(
-            self.num_sites_msg % gmf_data.shape)
+        try:
+            gmf_data = self.npz_file[rlz]
+        except AttributeError:
+            self.num_sites_lbl.setText(self.num_sites_msg % 0)
+            return
+        else:
+            self.num_sites_lbl.setText(self.num_sites_msg % gmf_data.shape)
 
     def populate_rlz_or_stat_cbx(self):
         self.rlzs_or_stats = [key for key in sorted(self.npz_file)
@@ -129,8 +134,6 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         if not len(self.dataset):
             log_msg('No data corresponds to the chosen event and GMPE',
                     level='C', message_bar=self.iface.messageBar())
-            self.imt_cbx.clear()
-            self.set_ok_button()
             return
         imts = self.dataset.dtype.names[2:]  # discarding lon lat
         self.imt_cbx.clear()

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -140,7 +140,10 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             if 'GEM_QGIS_TEST' in os.environ:
                 self.set_ok_button()
             return
-        imts = self.dataset.dtype.names[2:]  # discarding lon lat
+        try:
+            imts = list(self.oqparam['hazard_imtls'].keys())
+        except KeyError:
+            imts = list(self.oqparam['risk_imtls'].keys())
         self.imt_cbx.clear()
         self.imt_cbx.setEnabled(True)
         self.imt_cbx.addItems(imts)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -62,9 +62,12 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
 
     def get_eid(self, num_events_npz):
         num_events = num_events_npz['num_events']
-        self.eid = QInputDialog.getInt(
-            self, "Select an event ID", "(range 0 - %s)" % num_events,
+        self.eid, ok = QInputDialog.getInt(
+            self, "Select an event ID", "range (0 - %s)" % num_events,
             0, 0, num_events)
+        if not ok:
+            self.reject()
+            return
         log_msg('Extracting ground motion fields.'
                 ' Watch progress in QGIS task bar',
                 level='I', message_bar=self.iface.messageBar())
@@ -175,7 +178,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
                     if field_name in ['lon', 'lat']:
                         continue
                     layer_field_name = d2l_field_names[field_name]
-                    value = float(row[field_name][self.eid])
+                    value = float(row[field_name])
                     feat.setAttribute(layer_field_name, value)
                 feat.setGeometry(QgsGeometry.fromPointXY(
                     QgsPointXY(row[0], row[1])))

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -50,7 +50,11 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             'Load ground motion fields as layer')
         self.create_num_sites_indicator()
         # NOTE: gmpe and gsim are synonyms
-        self.create_rlz_or_stat_selector('Ground Motion Prediction Equation')
+        self.create_rlz_or_stat_selector(
+            label='Ground Motion Prediction Equation')
+        # NOTE: we do not display the selector for realizations, but we can
+        # still update and use its contents (e.g. to display the gmpe
+        # corresponding to the chosen event)
         self.rlz_or_stat_cbx.setVisible(False)
         self.create_imt_selector()
 
@@ -133,6 +137,8 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
     def on_rlz_or_stat_changed(self):
         rlz = self.rlz_or_stat_cbx.itemData(
             self.rlz_or_stat_cbx.currentIndex())
+        gmpe = self.rlz_or_stat_cbx.currentText()
+        self.rlz_or_stat_lbl.setText("GMPE: %s" % gmpe)
         self.dataset = self.npz_file[rlz]
         if not len(self.dataset):
             log_msg('No data corresponds to the chosen event and GMPE',
@@ -160,9 +166,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
 
     def load_from_npz(self):
         for rlz, gsim in zip(self.rlzs_or_stats, self.gsims):
-            if (not self.load_all_rlzs_or_stats_chk.isChecked()
-                    and gsim != self.rlz_or_stat_cbx.currentText()):
-                continue
+            # NOTE: selecting only 1 event, we have only 1 gsim
             with WaitCursorManager('Creating layer for "%s"...'
                                    % gsim, self.iface.messageBar()):
                 self.build_layer(rlz_or_stat=rlz, gsim=gsim)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -126,6 +126,12 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         rlz = self.rlz_or_stat_cbx.itemData(
             self.rlz_or_stat_cbx.currentIndex())
         self.dataset = self.npz_file[rlz]
+        if not len(self.dataset):
+            log_msg('No data corresponds to the chosen event and GMPE',
+                    level='C', message_bar=self.iface.messageBar())
+            self.imt_cbx.clear()
+            self.set_ok_button()
+            return
         imts = self.dataset.dtype.names[2:]  # discarding lon lat
         self.imt_cbx.clear()
         self.imt_cbx.setEnabled(True)

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -22,6 +22,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from qgis.PyQt.QtWidgets import QInputDialog
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
@@ -62,10 +63,13 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
 
     def get_eid(self, num_events_npz):
         num_events = num_events_npz['num_events']
-        self.eid, ok = QInputDialog.getInt(
-            self.drive_engine_dlg,
-            "Select an event ID", "range (0 - %s)" % (num_events - 1),
-            0, 0, num_events - 1)
+        if 'GEM_QGIS_TEST' in os.environ:
+            self.eid, ok = 0, True
+        else:
+            self.eid, ok = QInputDialog.getInt(
+                self.drive_engine_dlg,
+                "Select an event ID", "range (0 - %s)" % (num_events - 1),
+                0, 0, num_events - 1)
         if not ok:
             self.reject()
             return

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -63,8 +63,9 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
     def get_eid(self, num_events_npz):
         num_events = num_events_npz['num_events']
         self.eid, ok = QInputDialog.getInt(
-            self, "Select an event ID", "range (0 - %s)" % num_events,
-            0, 0, num_events)
+            self.drive_engine_dlg,
+            "Select an event ID", "range (0 - %s)" % (num_events - 1),
+            0, 0, num_events - 1)
         if not ok:
             self.reject()
             return

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -116,6 +116,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # Disable ok_button until all user options are set
         self.ok_button = self.buttonBox.button(QDialogButtonBox.Ok)
         self.ok_button.setDisabled(True)
+        self.oqparam = self.drive_engine_dlg.get_oqparam()
 
     def on_extract_error(self, exception):
         if isinstance(exception, TaskCanceled):

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,8 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.8.0
+    * Ground motion fields are loaded from the OQ-Engine after pre-filtering them by event id, thus dramatically reducing data transfer and visualization time. This improvement made
+      it possible to enable the visualization of ground motion fields also for event-based calculations.
     * The list of calculation can be filtered by job id. This also makes possible to visualize old calculations that would not be listed among the most recent 100 calculations.
     * Ruptures are loaded through the OQ-Engine extract api, instead of exporting and loading the corresponding csv file.
     * Ruptures can be filtered by minimum magnitude, and a clear error message is displayed if no ruptures of such a high magnitude are found.

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -320,12 +320,15 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             output_dict['loading_time'] = loading_time
             self.time_consuming_outputs.append(output_dict)
             self.global_time_consuming_outputs.append(output_dict)
-        if output_dict['output_type'] in OQ_EXTRACT_TO_LAYER_TYPES:
+        output_type = output_dict['output_type']
+        if output_type in OQ_EXTRACT_TO_LAYER_TYPES:
             loaded_layer = self.irmt.iface.activeLayer()
-            self.assertIsNotNone(loaded_layer, 'No layer was loaded')
-            num_feats = loaded_layer.featureCount()
-            self.assertGreater(
-                num_feats, 0, 'The loaded layer does not contain any feature!')
+            if output_type != 'gmf_data':  # it could correctly produce no data
+                self.assertIsNotNone(loaded_layer, 'No layer was loaded')
+                num_feats = loaded_layer.featureCount()
+                self.assertGreater(
+                    num_feats, 0,
+                    'The loaded layer does not contain any feature!')
 
     def load_calc_output(
             self, calc, selected_output_type,

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -323,7 +323,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         output_type = output_dict['output_type']
         if output_type in OQ_EXTRACT_TO_LAYER_TYPES:
             loaded_layer = self.irmt.iface.activeLayer()
-            if output_type != 'gmf_data':  # it could correctly produce no data
+            if output_type == 'gmf_data':
+                if loaded_layer is None:
+                    print('\t\tWARNING: no layer was loaded. It should mean '
+                          'that no data could be loaded for the chosen eid')
+            else:
                 self.assertIsNotNone(loaded_layer, 'No layer was loaded')
                 num_feats = loaded_layer.featureCount()
                 self.assertGreater(

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -112,6 +112,8 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                                                  calc['description']))
             calc_output_list = \
                 cls.irmt.drive_oq_engine_server_dlg.get_output_list(calc['id'])
+            if isinstance(calc_output_list, Exception):
+                raise calc_output_list
             cls.output_list[calc['id']] = calc_output_list
             print('\t\tOutput types: %s' % ', '.join(
                 [output['type'] for output in calc_output_list]))


### PR DESCRIPTION
and enable their visualization for event-based calculations

TODO:
- [x] always call oqparam while loading any output from the engine
- [x] remove selector for rlzs, because given an eid it corresponds to one and only one rlz
- [x] remove checkbox to load all realizations and label for selector of realizations