### PR TITLE
Set field data types correctly while loading oq-engine outputs

### DIFF
--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -6,7 +6,7 @@ docker rm -f qgis || true
 docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/oq-irmt-qgis \
  -e DISPLAY=:99 \
- qgis/qgis:release-3_10
+ qgis/qgis:final-3_8_3
 
 docker exec -it qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
 

--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -6,7 +6,7 @@ docker rm -f qgis || true
 docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/oq-irmt-qgis \
  -e DISPLAY=:99 \
- qgis/qgis:final-3_8_3
+ qgis/qgis:release-3_10
 
 docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
 

--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -8,6 +8,6 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e DISPLAY=:99 \
  qgis/qgis:release-3_10
 
-docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
+docker exec -it qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
 
 docker exec -it qgis sh -c "export PYTHONPATH=$PYTHONPATH:/oq-irmt-qgis; cd /oq-irmt-qgis/svir; make doc"

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -24,7 +24,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e GEM_QGIS_TEST=y \
  qgis/qgis:release-3_10
 
-docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
+docker exec -it qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
 
 docker exec -it qgis sh -c "git clone -q -b $BRANCH --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$BRANCH'"
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -22,7 +22,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e BRANCH="$BRANCH" \
  -e SELECTED_CALC_ID="$SELECTED_CALC_ID" \
  -e GEM_QGIS_TEST=y \
- qgis/qgis:final-3_8_3
+ qgis/qgis:release-3_10
 
 docker exec -it qgis sh -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
 

--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -22,7 +22,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e BRANCH="$BRANCH" \
  -e SELECTED_CALC_ID="$SELECTED_CALC_ID" \
  -e GEM_QGIS_TEST=y \
- qgis/qgis:release-3_10
+ qgis/qgis:final-3_8_3
 
 docker exec -it qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
 

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -7,7 +7,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/tests_directory \
  -e DISPLAY=:99 \
  -e GEM_QGIS_TEST=y \
- qgis/qgis:release-3_10
+ qgis/qgis:final-3_8_3
 
 docker exec -it qgis bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
 docker exec -it qgis bash -c "python3 -m pip install pytest"

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -9,7 +9,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e GEM_QGIS_TEST=y \
  qgis/qgis:release-3_10
 
-docker exec -it qgis bash -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
+docker exec -it qgis bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
 docker exec -it qgis bash -c "python3 -m pip install pytest"
 
 # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -7,7 +7,7 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/tests_directory \
  -e DISPLAY=:99 \
  -e GEM_QGIS_TEST=y \
- qgis/qgis:final-3_8_3
+ qgis/qgis:release-3_10
 
 docker exec -it qgis bash -c "apt update; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
 docker exec -it qgis bash -c "python3 -m pip install pytest"

--- a/svir/calculations/calculate_utils.py
+++ b/svir/calculations/calculate_utils.py
@@ -69,7 +69,7 @@ def add_attribute(proposed_attr_name, dtype, layer):
     elif dtype in ('U', 'I'):  # FIXME: what for unsigned int?
         qtype = QVariant.Int
         qname = 'integer'
-    else:  # FIXME: treating everything else as numeric (it might be wrong)
+    else:  # FIXME: treating everything else as double (it might be wrong)
         qtype = QVariant.Double
         qname = 'double'
     field = QgsField(proposed_attr_name, qtype)

--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -193,7 +193,8 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
     def get_field_types(self, **kwargs):
         field_types = {name: self.dataset[name].dtype.char
                        for name in self.dataset.dtype.names
-                       if name not in ['lon', 'lat'].extend(self.tag_names)}
+                       if name not in ['lon', 'lat']
+                       and name not in self.tag_names}
         return field_types
 
     def read_npz_into_layer(self, field_names, **kwargs):

--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -28,7 +28,6 @@ from qgis.PyQt.QtWidgets import (
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication,)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import WaitCursorManager, log_msg
 from svir.ui.multi_select_combo_box import MultiSelectComboBox
 from svir.tasks.extract_npz_task import ExtractNpzTask
@@ -191,21 +190,11 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
                 self.category_cbx.currentText())
         return layer_name
 
-    def get_field_names(self, **kwargs):
-        field_names = [name for name in self.dataset.dtype.names
-                       if name not in self.tag_names and
-                       name not in ['lon', 'lat']]
-        return field_names
-
-    def add_field_to_layer(self, field_name):
-        try:
-            # NOTE: add_numeric_attribute uses the native qgis editing manager
-            added_field_name = add_numeric_attribute(field_name, self.layer)
-        except TypeError as exc:
-            log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
-                    exception=exc)
-            return
-        return added_field_name
+    def get_field_types(self, **kwargs):
+        field_types = {name: self.dataset[name].dtype.char
+                       for name in self.dataset.dtype.names
+                       if name not in ['lon', 'lat'].extend(self.tag_names)}
+        return field_types
 
     def read_npz_into_layer(self, field_names, **kwargs):
         with edit(self.layer):

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -178,15 +178,15 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         field_types = {field_name: 'F' for field_name in field_names}
         return field_types
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_npz_into_layer(self, field_types, **kwargs):
         if self.aggregate_by_site_ckb.isChecked():
-            self.read_npz_into_layer_aggr_by_site(field_names, **kwargs)
+            self.read_npz_into_layer_aggr_by_site(field_types, **kwargs)
         else:
             # do not aggregate by site, then aggregate by zone afterwards if
             # required
-            self.read_npz_into_layer_no_aggr(field_names, **kwargs)
+            self.read_npz_into_layer_no_aggr(field_types, **kwargs)
 
-    def read_npz_into_layer_no_aggr(self, field_names, **kwargs):
+    def read_npz_into_layer_no_aggr(self, field_types, **kwargs):
         rlz_or_stat = kwargs['rlz_or_stat']
         loss_type = kwargs['loss_type']
         with edit(self.layer):
@@ -195,19 +195,19 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             for row in data:
                 # add a feature
                 feat = QgsFeature(self.layer.fields())
-                for field_name_idx, field_name in enumerate(field_names):
+                for field_name, field_type in field_types.items():
                     if field_name in ['lon', 'lat']:
                         continue
                     elif field_name in data.dtype.names:
                         value = row[field_name]
-                        try:
-                            value = float(value)
-                        except ValueError:
+                        if data[field_name].dtype.char == 'S':
                             value = str(value, encoding='utf8').strip('"')
+                        else:
+                            value = float(value)
                     else:
                         value = float(
                             row[loss_type][field_name[len(loss_type)+1:]])
-                    feat.setAttribute(field_names[field_name_idx], value)
+                    feat.setAttribute(field_name, value)
                 feat.setGeometry(QgsGeometry.fromPointXY(
                     QgsPointXY(row['lon'], row['lat'])))
                 feats.append(feat)
@@ -216,7 +216,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
                 msg = 'There was a problem adding features to the layer.'
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
 
-    def read_npz_into_layer_aggr_by_site(self, field_names, **kwargs):
+    def read_npz_into_layer_aggr_by_site(self, field_types, **kwargs):
         rlz_or_stat = kwargs['rlz_or_stat']
         loss_type = kwargs['loss_type']
         taxonomy = kwargs['taxonomy']
@@ -228,11 +228,14 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             for row in grouped_by_site:
                 # add a feature
                 feat = QgsFeature(self.layer.fields())
-                for field_name_idx, field_name in enumerate(field_names):
+                field_idx = 0
+                for field_name, field_type in field_types.items():
                     if field_name in ['lon', 'lat']:
+                        field_idx += 1
                         continue
-                    value = float(row[field_name_idx])
-                    feat.setAttribute(field_names[field_name_idx], value)
+                    value = float(row[field_idx])
+                    feat.setAttribute(field_name, value)
+                    field_idx += 1
                 feat.setGeometry(QgsGeometry.fromPointXY(
                     QgsPointXY(row['lon'], row['lat'])))
                 feats.append(feat)

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -174,7 +174,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             self.default_field_name = "%s_%s_mean" % (
                 self.loss_type_cbx.currentText(),
                 self.dmg_state_cbx.currentText())
-        # FIXME: check if it's ok to have all numeric fields
+        # NOTE: assuming that all fields are numeric
         field_types = {field_name: 'F' for field_name in field_names}
         return field_types
 

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -27,7 +27,6 @@ import collections
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import (WaitCursorManager,
                                   log_msg,
                                   get_loss_types,
@@ -157,7 +156,7 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             layer_name = "dmg_by_asset_%s_%s" % (rlz_or_stat, loss_type)
         return layer_name
 
-    def get_field_names(self, **kwargs):
+    def get_field_types(self, **kwargs):
         loss_type = kwargs['loss_type']
         dmg_state = kwargs['dmg_state']
         if self.aggregate_by_site_ckb.isChecked():
@@ -175,13 +174,9 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             self.default_field_name = "%s_%s_mean" % (
                 self.loss_type_cbx.currentText(),
                 self.dmg_state_cbx.currentText())
-        return field_names
-
-    def add_field_to_layer(self, field_name):
-        # NOTE: add_numeric_attribute uses the native qgis editing manager
-        added_field_name = add_numeric_attribute(
-            field_name, self.layer)
-        return added_field_name
+        # FIXME: check if it's ok to have all numeric fields
+        field_types = {field_name: 'F' for field_name in field_names}
+        return field_types
 
     def read_npz_into_layer(self, field_names, **kwargs):
         if self.aggregate_by_site_ckb.isChecked():

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -147,12 +147,12 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         added_field_name = add_attribute(field_name, field_type, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_names, rlz_or_stat, **kwargs):
+    def read_npz_into_layer(self, field_types, rlz_or_stat, **kwargs):
         with edit(self.layer):
             feats = []
             fields = self.layer.fields()
             layer_field_names = [field.name() for field in fields]
-            dataset_field_names = self.get_field_types().keys()
+            dataset_field_names = list(self.get_field_types().keys())
             d2l_field_names = dict(
                 list(zip(dataset_field_names[2:], layer_field_names)))
             for row in self.npz_file[rlz_or_stat]:

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -108,7 +108,8 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
                     continue
                 for iml in self.dataset[rlz_or_stat][imt].dtype.names:
                     field_name = "%s_%s_%s" % (rlz_or_stat, imt, iml)
-                    field_types[field_name] = 'F'  # FIXME: check if type is ok
+                    # NOTE: assuming that all fields are numeric
+                    field_types[field_name] = 'F'
         return field_types
 
     def on_iml_changed(self):

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -25,7 +25,6 @@
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import log_msg, WaitCursorManager
 from svir.tasks.extract_npz_task import ExtractNpzTask
 
@@ -97,8 +96,8 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         layer_name = "hcurves_%sy" % investigation_time
         return layer_name
 
-    def get_field_names(self, **kwargs):
-        field_names = []
+    def get_field_types(self, **kwargs):
+        field_types = {}
         for rlz_or_stat in self.rlzs_or_stats:
             if (not self.load_all_rlzs_or_stats_chk.isChecked()
                     and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):
@@ -109,15 +108,11 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
                     continue
                 for iml in self.dataset[rlz_or_stat][imt].dtype.names:
                     field_name = "%s_%s_%s" % (rlz_or_stat, imt, iml)
-                    field_names.append(field_name)
-        return field_names
+                    field_types[field_name] = 'F'  # FIXME: check if type is ok
+        return field_types
 
     def on_iml_changed(self):
         self.set_ok_button()
-
-    def add_field_to_layer(self, field_name):
-        added_field_name = add_numeric_attribute(field_name, self.layer)
-        return added_field_name
 
     def read_npz_into_layer(self, field_names, **kwargs):
         with edit(self.layer):

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -26,7 +26,6 @@ from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
 from qgis.PyQt.QtCore import Qt
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import WaitCursorManager, log_msg
 from svir.tasks.extract_npz_task import ExtractNpzTask
 
@@ -154,28 +153,19 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
                 rlz_or_stat, imt, poe, investigation_time)
         return layer_name
 
-    def get_field_names(self, **kwargs):
+    def get_field_types(self, **kwargs):
+        field_types = {}
         if self.load_multicol_ckb.isChecked():
-            field_names = []
             for imt in self.imts:
                 for poe in self.imts[imt]:
                     field_name = "%s-%s" % (imt, poe)
-                    field_names.append(field_name)
+                    field_types[field_name] = 'F'
         else:
             imt = kwargs['imt']
             poe = kwargs['poe']
-            field_names = ['%s-%s' % (imt, poe)]
-        return field_names
-
-    def add_field_to_layer(self, field_name):
-        try:
-            # NOTE: add_numeric_attribute uses the native qgis editing manager
-            added_field_name = add_numeric_attribute(field_name, self.layer)
-        except TypeError as exc:
-            log_msg(str(exc), level='C', message_bar=self.iface.messageBar(),
-                    exception=exc)
-            return
-        return added_field_name
+            field_name = '%s-%s' % (imt, poe)
+            field_types[field_name] = 'F'
+        return field_types
 
     def read_npz_into_layer(self, field_names, **kwargs):
         with edit(self.layer):

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -27,7 +27,6 @@ import collections
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import WaitCursorManager, log_msg, get_loss_types
 from svir.tasks.extract_npz_task import ExtractNpzTask
 
@@ -132,17 +131,11 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             raise NotImplementedError(self.output_type)
         return layer_name
 
-    def get_field_names(self, **kwargs):
+    def get_field_types(self, **kwargs):
         loss_type = kwargs['loss_type']
-        field_names = ['lon', 'lat', loss_type]
+        field_types = {'lon': 'F', 'lat': 'F', loss_type: 'S'}
         self.default_field_name = loss_type
-        return field_names
-
-    def add_field_to_layer(self, field_name):
-        # NOTE: add_numeric_attribute uses the native qgis editing manager
-        added_field_name = add_numeric_attribute(
-            field_name, self.layer)
-        return added_field_name
+        return field_types
 
     def read_npz_into_layer(self, field_names, **kwargs):
         rlz_or_stat = kwargs['rlz_or_stat']

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -137,7 +137,7 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         self.default_field_name = loss_type
         return field_types
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_npz_into_layer(self, field_types, **kwargs):
         rlz_or_stat = kwargs['rlz_or_stat']
         loss_type = kwargs['loss_type']
         taxonomy = kwargs['taxonomy']
@@ -148,11 +148,14 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
             for row in grouped_by_site:
                 # add a feature
                 feat = QgsFeature(self.layer.fields())
-                for field_name_idx, field_name in enumerate(field_names):
+                field_idx = 0
+                for field_name, field_type in field_types.items():
                     if field_name in ['lon', 'lat']:
+                        field_idx += 1
                         continue
-                    value = float(row[field_name_idx])
-                    feat.setAttribute(field_names[field_name_idx], value)
+                    value = float(row[field_idx])
+                    feat.setAttribute(field_name, value)
+                    field_idx += 1
                 feat.setGeometry(QgsGeometry.fromPointXY(
                     QgsPointXY(row['lon'], row['lat'])))
                 feats.append(feat)

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -133,7 +133,7 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
 
     def get_field_types(self, **kwargs):
         loss_type = kwargs['loss_type']
-        field_types = {'lon': 'F', 'lat': 'F', loss_type: 'S'}
+        field_types = {'lon': 'F', 'lat': 'F', loss_type: 'F'}
         self.default_field_name = loss_type
         return field_types
 

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -605,7 +605,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         if num_unique_values > 2:
             renderer = QgsGraduatedSymbolRenderer.createRenderer(
                 layer,
-                QgsExpression.quotedColumnRef(style_by),
+                style_by,
                 min(num_unique_values, style['classes']),
                 mode,
                 symbol.clone(),
@@ -631,8 +631,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                     unique_value, symbol, str(unique_value))
                 # entry for the list of category items
                 categories.append(category)
-            renderer = QgsCategorizedSymbolRenderer(
-                QgsExpression.quotedColumnRef(style_by), categories)
+            renderer = QgsCategorizedSymbolRenderer(style_by, categories)
         else:
             renderer = QgsSingleSymbolRenderer(symbol.clone())
         if add_null_class and NULL in unique_values:
@@ -719,8 +718,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             # entry for the list of category items
             categories.append(category)
         # create renderer object
-        renderer = QgsCategorizedSymbolRenderer(
-            QgsExpression.quotedColumnRef(style_by), categories)
+        renderer = QgsCategorizedSymbolRenderer(style_by, categories)
         # assign the created renderer to the layer
         if renderer is not None:
             layer.setRenderer(renderer)

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -465,7 +465,6 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         field_types = self.get_field_types(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, imt=imt)
-        field_names = field_types.keys()
 
         # create layer
         self.layer = QgsVectorLayer(
@@ -478,9 +477,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 if field_name == self.default_field_name:
                     self.default_field_name = added_field_name
                 # replace field_name with the actual added_field_name
-                field_name_idx = field_names.index(field_name)
-                field_names.remove(field_name)
-                field_names.insert(field_name_idx, added_field_name)
+                field_type = field_types[field_name]
+                del field_types[field_name]
+                field_types[added_field_name] = field_type
 
         self.read_npz_into_layer(
             field_types, rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -102,7 +102,7 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
             field_names.extend([
                 "%s_%s" % (rlz_or_stat, imt)
                 for imt in self.dataset[rlz_or_stat][poe].dtype.names])
-        # FIXME: check that all fields are numeric
+        # NOTE: assuming that all fields are numeric
         field_types = {field_name: 'F' for field_name in field_names}
         return field_types
 

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -25,7 +25,6 @@
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.calculations.calculate_utils import add_numeric_attribute
 from svir.utilities.utils import log_msg, WaitCursorManager
 from svir.tasks.extract_npz_task import ExtractNpzTask
 
@@ -96,20 +95,16 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         layer_name = "uhs_poe-%s_%sy" % (poe, investigation_time)
         return layer_name
 
-    def get_field_names(self, **kwargs):
+    def get_field_types(self, **kwargs):
         poe = kwargs['poe']
         field_names = []
         for rlz_or_stat in self.rlzs_or_stats:
             field_names.extend([
                 "%s_%s" % (rlz_or_stat, imt)
                 for imt in self.dataset[rlz_or_stat][poe].dtype.names])
-        return field_names
-
-    def add_field_to_layer(self, field_name):
-        # NOTE: add_numeric_attribute uses the native qgis editing manager
-        added_field_name = add_numeric_attribute(
-            field_name, self.layer)
-        return added_field_name
+        # FIXME: check that all fields are numeric
+        field_types = {field_name: 'F' for field_name in field_names}
+        return field_types
 
     def read_npz_into_layer(self, field_names, **kwargs):
         poe = kwargs['poe']

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -1240,7 +1240,7 @@ class Irmt(object):
             style['color_from'], style['color_to'])
         graduated_renderer = QgsGraduatedSymbolRenderer.createRenderer(
             self.iface.activeLayer(),
-            QgsExpression.quotedColumnRef(target_field),
+            target_field,
             style['classes'],
             style['mode'],
             QgsSymbol.defaultSymbol(self.iface.activeLayer().geometryType()),

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.8.0
+    * Field data types of layers created from OQ-Engine outputs were fixed (they were wrongl all numeric before)
     * The list of calculation can be filtered by job id. This also makes possible to visualize old calculations that would not be listed among the most recent 100 calculations.
     * Ruptures are loaded through the OQ-Engine extract api, instead of exporting and loading the corresponding csv file.
     * Ruptures can be filtered by minimum magnitude, and a clear error message is displayed if no ruptures of such a high magnitude are found.


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/712

While doing this I made also some refactoring to reduce duplication in methods that add attributes to layers and methods that retrieve field names and types.
I also removed QgsExpression.quotedColumnRef where it was not needed. I am still using it in expressions for rule-based classification, to properly quote field names inside the expression, but it is not needed otherwise.
I made changes to a dozen of files, so I have to be careful that everything still works properly.
In some cases I am assuming that fields are numeric, but I still have to double-check that it is true in those cases.