### PR TITLE
Load ruptures as separate layers with proper geometry types

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -460,7 +460,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def build_layer(self, rlz_or_stat=None, taxonomy=None, poe=None,
                     loss_type=None, dmg_state=None, gsim=None, imt=None,
                     boundaries=None, geometry_type='point', wkt_geom_type=None,
-                    row_wkt_geom_types=None):
+                    row_wkt_geom_types=None, add_to_group=None):
         layer_name = self.build_layer_name(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt,
@@ -522,11 +522,19 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         except AttributeError:
             # the aggregation stuff might not exist for some loaders
             pass
-        root = QgsProject.instance().layerTreeRoot()
         QgsProject.instance().addMapLayer(self.layer, False)
-        root.insertLayer(0, self.layer)
+        if add_to_group:
+            tree_node = add_to_group
+        else:
+            tree_node = QgsProject.instance().layerTreeRoot()
+        tree_node.insertLayer(0, self.layer)
         self.iface.setActiveLayer(self.layer)
-        self.iface.zoomToActiveLayer()
+        if add_to_group:
+            # NOTE: zooming to group from caller function, to avoid repeating
+            #       it once per layer
+            pass
+        else:
+            self.iface.zoomToActiveLayer()
         log_msg('Layer %s was created successfully' % layer_name, level='S',
                 message_bar=self.iface.messageBar())
 

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -459,10 +459,12 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
 
     def build_layer(self, rlz_or_stat=None, taxonomy=None, poe=None,
                     loss_type=None, dmg_state=None, gsim=None, imt=None,
-                    boundaries=None, geometry_type='Point'):
+                    boundaries=None, geometry_type='point', wkt_geom_type=None,
+                    row_wkt_geom_types=None):
         layer_name = self.build_layer_name(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
-            loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt)
+            loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt,
+            geometry_type=geometry_type)
         field_types = self.get_field_types(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, imt=imt)
@@ -485,7 +487,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.read_npz_into_layer(
             field_types, rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, imt=imt,
-            boundaries=boundaries)
+            boundaries=boundaries, geometry_type=geometry_type,
+            wkt_geom_type=wkt_geom_type,
+            row_wkt_geom_types=row_wkt_geom_types)
         if (self.output_type == 'dmg_by_asset' and
                 not self.aggregate_by_site_ckb.isChecked()):
             self.layer.setCustomProperty('output_type', 'recovery_curves')

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -107,7 +107,7 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
     def load_from_npz(self):
         boundaries = gzip.decompress(self.npz_file['boundaries']).split(b'\n')
         row_wkt_geom_types = {
-            row_idx: QgsGeometry.fromWkt(boundary.decode('utf8')).type()
+            row_idx: QgsGeometry.fromWkt(boundary.decode('utf8')).wkbType()
             for row_idx, boundary in enumerate(boundaries)}
         wkt_geom_types = set(row_wkt_geom_types.values())
         if len(wkt_geom_types) > 1:
@@ -116,15 +116,19 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
         else:
             rup_group = None
         for wkt_geom_type in wkt_geom_types:
-            if wkt_geom_type == QgsWkbTypes.PolygonGeometry:
-                layer_geom_type = 'polygon'
-            elif wkt_geom_type == QgsWkbTypes.LineGeometry:
-                layer_geom_type = 'linestring'
-            elif wkt_geom_type == QgsWkbTypes.PointGeometry:
-                layer_geom_type = 'point'
+            if wkt_geom_type == QgsWkbTypes.Point:
+                layer_geom_type = "point"
+            elif wkt_geom_type == QgsWkbTypes.LineString:
+                layer_geom_type = "linestring"
+            elif wkt_geom_type == QgsWkbTypes.Polygon:
+                layer_geom_type = "polygon"
+            elif wkt_geom_type == QgsWkbTypes.MultiPoint:
+                layer_geom_type = "multipoint"
+            elif wkt_geom_type == QgsWkbTypes.MultiLineString:
+                layer_geom_type = "multilinestring"
+            elif wkt_geom_type == QgsWkbTypes.MultiPolygon:
+                layer_geom_type = "multipolygon"
             else:
-                # TODO: we might consider handling also multipoint,
-                # multilinestring and multipolygon
                 raise ValueError(
                     'Unexpected geometry type: %s' % wkt_geom_type)
             with WaitCursorManager(

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -117,6 +117,8 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
             elif wkt_geom_type == QgsWkbTypes.PointGeometry:
                 layer_geom_type = 'point'
             else:
+                # TODO: we might consider handling also multipoint,
+                # multilinestring and multipolygon
                 raise ValueError(
                     'Unexpected geometry type: %s' % wkt_geom_type)
             with WaitCursorManager(

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -26,7 +26,7 @@ import gzip
 from collections import OrderedDict
 from qgis.PyQt.QtWidgets import QDialog
 from qgis.core import (
-    QgsFeature, QgsGeometry, edit, QgsTask, QgsApplication)
+    QgsFeature, QgsGeometry, QgsWkbTypes, edit, QgsTask, QgsApplication)
 from svir.utilities.utils import log_msg, WaitCursorManager
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
 from svir.tasks.extract_npz_task import ExtractNpzTask
@@ -93,7 +93,9 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
 
     def build_layer_name(self, **kwargs):
         investigation_time = self.get_investigation_time()
-        self.layer_name = 'ruptures_%sy' % investigation_time
+        geometry_type = kwargs['geometry_type']
+        self.layer_name = '%s_ruptures_%sy' % (
+            geometry_type, investigation_time)
         return self.layer_name
 
     def get_field_types(self, **kwargs):
@@ -103,25 +105,47 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
 
     def load_from_npz(self):
         boundaries = gzip.decompress(self.npz_file['boundaries']).split(b'\n')
-        with WaitCursorManager(
-                'Creating layer for ruptures...', self.iface.messageBar()):
-            self.build_layer(boundaries=boundaries, geometry_type='Polygon')
-        style_by = self.style_by_cbx.itemData(self.style_by_cbx.currentIndex())
-        if style_by == 'mag':
-            self.style_maps(self.layer, style_by,
-                            self.iface, self.output_type)
-        else:  # 'trt'
-            self.style_categorized(layer=self.layer, style_by=style_by)
-        log_msg('Layer %s was loaded successfully' % self.layer_name,
-                level='S', message_bar=self.iface.messageBar())
+        row_wkt_geom_types = {
+            row_idx: QgsGeometry.fromWkt(boundary.decode('utf8')).type()
+            for row_idx, boundary in enumerate(boundaries)}
+        wkt_geom_types = set(row_wkt_geom_types.values())
+        for wkt_geom_type in wkt_geom_types:
+            if wkt_geom_type == QgsWkbTypes.PolygonGeometry:
+                layer_geom_type = 'polygon'
+            elif wkt_geom_type == QgsWkbTypes.LineGeometry:
+                layer_geom_type = 'linestring'
+            elif wkt_geom_type == QgsWkbTypes.PointGeometry:
+                layer_geom_type = 'point'
+            else:
+                raise ValueError(
+                    'Unexpected geometry type: %s' % wkt_geom_type)
+            with WaitCursorManager(
+                    'Creating layer for "%s" ruptures...' % layer_geom_type,
+                    self.iface.messageBar()):
+                self.build_layer(boundaries=boundaries,
+                                 geometry_type=layer_geom_type,
+                                 wkt_geom_type=wkt_geom_type,
+                                 row_wkt_geom_types=row_wkt_geom_types)
+            style_by = self.style_by_cbx.itemData(
+                self.style_by_cbx.currentIndex())
+            if style_by == 'mag':
+                self.style_maps(self.layer, style_by,
+                                self.iface, self.output_type)
+            else:  # 'trt'
+                self.style_categorized(layer=self.layer, style_by=style_by)
+            log_msg('Layer %s was loaded successfully' % self.layer_name,
+                    level='S', message_bar=self.iface.messageBar())
 
     def read_npz_into_layer(
-            self, field_types, rlz_or_stat, boundaries, **kwargs):
+            self, field_types, rlz_or_stat, boundaries,
+            wkt_geom_type, row_wkt_geom_types, **kwargs):
         with edit(self.layer):
             feats = []
             fields = self.layer.fields()
             field_names = [field.name() for field in fields]
             for row_idx, row in enumerate(self.npz_file['array']):
+                if row_wkt_geom_types[row_idx] != wkt_geom_type:
+                    continue
                 # add a feature
                 feat = QgsFeature(fields)
                 for field_name in field_names:

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.8.0
+    * Ruptures are loaded from OQ-Engine outputs as separate layers, one for each geometry type (polygon, line or point), instead of representing lines as degenerate flat polygons.
     * Ground motion fields are loaded from the OQ-Engine after pre-filtering them by event id, thus dramatically reducing data transfer and visualization time. This improvement made
       it possible to enable the visualization of ground motion fields also for event-based calculations.
     * Field data types of layers created from OQ-Engine outputs were fixed (they were wrongly all numeric before)

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -43,6 +43,8 @@ from qgis.core import (
                        QgsVectorLayer,
                        QgsVectorFileWriter,
                        Qgis,
+                       QgsRectangle,
+                       QgsLayerTreeLayer,
                        )
 from qgis.gui import QgsMessageBar, QgsMessageBarItem
 from qgis.utils import iface
@@ -1237,3 +1239,14 @@ def write_metadata_to_layer(
         if value is not None:
             lm.addKeywords("oquser:%s" % param, [str(value)])
     layer.setMetadata(lm)
+
+
+def zoom_to_group(group):
+    extent = QgsRectangle()
+    extent.setMinimal()
+    # Iterate through layers from group and combine their extent
+    for child in group.children():
+        if isinstance(child, QgsLayerTreeLayer):
+            extent.combineExtentWith(child.layer().extent())
+    iface.mapCanvas().setExtent(extent)
+    iface.mapCanvas().refresh()


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/715
Currently the oq-engine produces ruptures as polygons, but a change like https://github.com/gem/oq-engine/pull/5383 would allow to use lines instead of dengenerate polygons when needed.
With this PR I am creating different layers, one for each geometry type. It would also accept geometries other geometry types that are currently not produced by the oq-engine: point, multipoint, multilinestring or multipolygon.
If ruptures of multiple geometry types are found, layers are added to a group and zooming is done to the group extent.

Open issues:

- layer styles are not consistent across layers, so for instance the same TRT could be represented with different colors in layers corresponding to different geometry types (also because the number of classes could be different across layers). We might use an absolute range for magnitudes and collect the full set of trts in order to use consistent styles for layers with different geometries.
- with the previous approach (master) we could improve the styling by using map units properly, in order to make features visible also while zooming out; however, it would introduce some problems while coping with CRS.

Considering that this PR does not break the original behavior, producing with oq-engine master the same exact output, and it fixes the workflow in case the engine produces line geometries, I propose to merge this and to postpone the discussion on the open issues to a time when also @micheles can be involved.