### PR TITLE
Decode data right after extraction

### DIFF
--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -59,9 +59,7 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
 
     def finalize_init(self, extracted_npz):
         self.exposure_metadata = extracted_npz
-        self.tag_names = sorted(
-            [tag_name.decode('utf8')
-             for tag_name in self.exposure_metadata['tagnames']])
+        self.tag_names = sorted(self.exposure_metadata['tagnames'])
         self.exposure_categories = sorted(self.exposure_metadata['array'])
         self.risk_categories = sorted(self.exposure_metadata['multi_risk'])
         self.perils = set(
@@ -104,10 +102,9 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
         self.taxonomies_gbx.setLayout(self.taxonomies_gbx_v_layout)
         self.taxonomies_lbl = QLabel("Taxonomies")
         self.taxonomies_multisel = MultiSelectComboBox(self)
-        self.taxonomies_multisel.add_unselected_items(
-            sorted([taxonomy.decode('utf8')
-                    for taxonomy in self.exposure_metadata['taxonomy']
-                    if taxonomy != '?']))
+        self.taxonomies_multisel.add_unselected_items(sorted([
+            taxonomy for taxonomy in self.exposure_metadata['taxonomy']
+            if taxonomy != '?']))
         self.taxonomies_gbx_v_layout.addWidget(self.taxonomies_lbl)
         self.taxonomies_gbx_v_layout.addWidget(self.taxonomies_multisel)
         self.taxonomies_gbx.toggled[bool].connect(
@@ -170,7 +167,7 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
 
     def on_tag_changed(self, tag_name):
         tag_values = sorted([
-            value.decode('utf8') for value in self.exposure_metadata[tag_name]
+            value for value in self.exposure_metadata[tag_name]
             if value != '?'])
         self.tag_values_multisel.clear()
         self.tag_values_multisel.add_unselected_items(tag_values)

--- a/svir/dialogs/load_asset_risk_as_layer_dialog.py
+++ b/svir/dialogs/load_asset_risk_as_layer_dialog.py
@@ -57,8 +57,8 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
             self.finalize_init, self.on_extract_error)
         QgsApplication.taskManager().addTask(self.extract_npz_task)
 
-    def finalize_init(self, extracted_npz):
-        self.exposure_metadata = extracted_npz
+    def finalize_init(self, extracted_dict):
+        self.exposure_metadata = extracted_dict
         self.tag_names = sorted(self.exposure_metadata['tagnames'])
         self.exposure_categories = sorted(self.exposure_metadata['array'])
         self.risk_categories = sorted(self.exposure_metadata['multi_risk'])
@@ -197,7 +197,7 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
                        and name not in self.tag_names}
         return field_types
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_extracted_into_layer(self, field_names, **kwargs):
         with edit(self.layer):
             lons = self.dataset['lon']
             lats = self.dataset['lat']
@@ -242,9 +242,9 @@ class LoadAssetRiskAsLayerDialog(LoadOutputAsLayerDialog):
             params=extract_params)
         QgsApplication.taskManager().addTask(self.extract_npz_task)
 
-    def on_asset_risk_downloaded(self, extracted_npz):
-        self.npz_file = extracted_npz
-        self.dataset = self.npz_file['array']
+    def on_asset_risk_downloaded(self, extracted_dict):
+        self.extracted_dict = extracted_dict
+        self.dataset = self.extracted_dict['array']
         with WaitCursorManager('Creating layer...', self.iface.messageBar()):
             self.build_layer()
             self.style_maps(

--- a/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_dmg_by_asset_as_layer_dialog.py
@@ -112,9 +112,9 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
 
     def on_rlz_or_stat_changed(self):
         self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentText()]
-        self.taxonomies = numpy.unique(self.dataset['taxonomy']).tolist()
-        self.taxonomies = [taxonomy.decode('utf8')
-                           for taxonomy in self.taxonomies]
+        self.taxonomies = [
+            tax.decode('utf8').strip('"')
+            for tax in numpy.unique(self.dataset['taxonomy']).tolist()]
         self.populate_taxonomy_cbx(self.taxonomies)
         self.set_ok_button()
 
@@ -250,7 +250,8 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         F32 = numpy.float32
         dmg_by_site = collections.defaultdict(float)  # lon, lat -> dmg
         for rec in npz[rlz_or_stat]:
-            if taxonomy == 'All' or taxonomy.encode('utf8') == rec['taxonomy']:
+            if (taxonomy == 'All'
+                    or taxonomy == rec['taxonomy'].decode('utf8').strip('"')):
                 value = rec[loss_type]['%s_mean' % dmg_state]
                 dmg_by_site[rec['lon'], rec['lat']] += value
         data = numpy.zeros(
@@ -311,5 +312,3 @@ class LoadDmgByAssetAsLayerDialog(LoadOutputAsLayerDialog):
                             rlz_or_stat, loss_type), self.iface.messageBar()):
                         self.build_layer(rlz_or_stat, loss_type=loss_type)
                         self.style_curves()
-        if self.npz_file is not None:
-            self.npz_file.close()

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -66,8 +66,8 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             self.on_extract_error)
         QgsApplication.taskManager().addTask(self.extract_npz_task)
 
-    def get_eid(self, num_events_npz):
-        num_events = num_events_npz['num_events']
+    def get_eid(self, num_events_dict):
+        num_events = num_events_dict['num_events']
         if 'GEM_QGIS_TEST' in os.environ:
             self.eid, ok = 0, True
         else:
@@ -87,8 +87,8 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             self.on_extract_error, params={'event_id': self.eid})
         QgsApplication.taskManager().addTask(self.extract_npz_task)
 
-    def finalize_init(self, gmf_data_npz):
-        self.npz_file = gmf_data_npz
+    def finalize_init(self, gmf_data_dict):
+        self.gmf_data_dict = gmf_data_dict
         self.populate_rlz_or_stat_cbx()
         self.show_num_sites()
         self.adjustSize()
@@ -110,7 +110,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         rlz = self.rlz_or_stat_cbx.itemData(
             self.rlz_or_stat_cbx.currentIndex())
         try:
-            gmf_data = self.npz_file[rlz]
+            gmf_data = self.gmf_data_dict[rlz]
         except AttributeError:
             self.num_sites_lbl.setText(self.num_sites_msg % 0)
             return
@@ -118,16 +118,16 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             self.num_sites_lbl.setText(self.num_sites_msg % gmf_data.shape)
 
     def populate_rlz_or_stat_cbx(self):
-        self.rlzs_or_stats = [key for key in sorted(self.npz_file)
+        self.rlzs_or_stats = [key for key in sorted(self.gmf_data_dict)
                               if key not in ('imtls', 'array')]
         with WaitCursorManager(
                 'Extracting...', message_bar=self.iface.messageBar()):
-            self.rlzs_npz = extract_npz(
+            self.rlzs_dict = extract_npz(
                 self.session, self.hostname, self.calc_id, 'realizations',
                 message_bar=self.iface.messageBar(), params=None)
         # rlz[1] is the branch_path field
         self.gsims = [rlz[1].decode('utf8').strip('"')
-                      for rlz in self.rlzs_npz['array']]
+                      for rlz in self.rlzs_dict['array']]
         self.rlz_or_stat_cbx.clear()
         self.rlz_or_stat_cbx.setEnabled(True)
         for gsim, rlz in zip(self.gsims, self.rlzs_or_stats):
@@ -139,7 +139,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             self.rlz_or_stat_cbx.currentIndex())
         gmpe = self.rlz_or_stat_cbx.currentText()
         self.rlz_or_stat_lbl.setText("GMPE: %s" % gmpe)
-        self.dataset = self.npz_file[rlz]
+        self.dataset = self.gmf_data_dict[rlz]
         if not len(self.dataset):
             log_msg('No data corresponds to the chosen event and GMPE',
                     level='W', message_bar=self.iface.messageBar())
@@ -164,7 +164,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         else:
             super().accept()
 
-    def load_from_npz(self):
+    def load_from_extracted_dict(self):
         for rlz, gsim in zip(self.rlzs_or_stats, self.gsims):
             # NOTE: selecting only 1 event, we have only 1 gsim
             with WaitCursorManager('Creating layer for "%s"...'
@@ -191,7 +191,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         added_field_name = add_attribute(field_name, field_type, self.layer)
         return added_field_name
 
-    def read_npz_into_layer(self, field_types, rlz_or_stat, **kwargs):
+    def read_extracted_into_layer(self, field_types, rlz_or_stat, **kwargs):
         with edit(self.layer):
             feats = []
             fields = self.layer.fields()
@@ -199,7 +199,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             dataset_field_names = list(self.get_field_types().keys())
             d2l_field_names = dict(
                 list(zip(dataset_field_names[2:], layer_field_names)))
-            for row in self.npz_file[rlz_or_stat]:
+            for row in self.gmf_data_dict[rlz_or_stat]:
                 # add a feature
                 feat = QgsFeature(fields)
                 for field_name in dataset_field_names:

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -172,8 +172,6 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
                 self.build_layer(rlz_or_stat=rlz, gsim=gsim)
                 self.style_maps(self.layer, self.default_field_name,
                                 self.iface, self.output_type)
-        if self.npz_file is not None:
-            self.npz_file.close()
 
     def build_layer_name(self, gsim=None, **kwargs):
         self.imt = self.imt_cbx.currentText()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -64,16 +64,16 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         self.ok_button.setEnabled(True)
 
     def populate_dataset(self):
-        self.dataset = self.npz_file['all']
+        self.dataset = self.extracted_dict['all']
 
     def populate_rlz_or_stat_cbx(self):
-        self.rlzs_or_stats = self.npz_file['all'].dtype.names[2:]
+        self.rlzs_or_stats = self.extracted_dict['all'].dtype.names[2:]
         for rlz_or_stat in self.rlzs_or_stats:
             self.rlz_or_stat_cbx.addItem(rlz_or_stat)
 
     def on_rlz_or_stat_changed(self):
         rlz_or_stat = self.rlz_or_stat_cbx.currentText()
-        dataset = self.npz_file['all'][rlz_or_stat]
+        dataset = self.extracted_dict['all'][rlz_or_stat]
         self.imts = [imt for imt in dataset.dtype.names]
         self.imt_cbx.clear()
         for imt in self.imts:
@@ -115,10 +115,10 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
     def on_iml_changed(self):
         self.set_ok_button()
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_extracted_into_layer(self, field_names, **kwargs):
         with edit(self.layer):
-            lons = self.npz_file['all']['lon']
-            lats = self.npz_file['all']['lat']
+            lons = self.extracted_dict['all']['lon']
+            lats = self.extracted_dict['all']['lat']
             feats = []
             for row_idx, row in enumerate(self.dataset):
                 feat = QgsFeature(self.layer.fields())
@@ -134,7 +134,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
                 msg = 'There was a problem adding features to the layer.'
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
 
-    def load_from_npz(self):
+    def load_from_extracted_dict(self):
         with WaitCursorManager('Creating layer...', self.iface.messageBar()):
             self.build_layer()
             self.style_curves()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -138,5 +138,3 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         with WaitCursorManager('Creating layer...', self.iface.messageBar()):
             self.build_layer()
             self.style_curves()
-        if self.npz_file is not None:
-            self.npz_file.close()

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -99,14 +99,14 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         # that has to be discarded too)
         self.rlzs_or_stats = [
             rlz_or_stat
-            for rlz_or_stat in self.npz_file['all'].dtype.names[2:]
+            for rlz_or_stat in self.extracted_dict['all'].dtype.names[2:]
             if rlz_or_stat != 'vs30']
         self.rlz_or_stat_cbx.clear()
         self.rlz_or_stat_cbx.setEnabled(True)
         self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.extracted_dict['all'][self.rlz_or_stat_cbx.currentText()]
         self.imts = {imt: self.dataset[imt].dtype.names
                      for imt in self.dataset.dtype.names}
         self.imt_cbx.clear()
@@ -119,7 +119,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         #       which currently is always true.
         #       If different realizations have a different number of sites, we
         #       need to move this block of code inside on_rlz_or_stat_changed()
-        rlz_or_stat_data = self.npz_file['all'][
+        rlz_or_stat_data = self.extracted_dict['all'][
             self.rlz_or_stat_cbx.currentText()]
         self.num_sites_lbl.setText(
             self.num_sites_msg % rlz_or_stat_data.shape)
@@ -167,10 +167,10 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             field_types[field_name] = 'F'
         return field_types
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_extracted_into_layer(self, field_names, **kwargs):
         with edit(self.layer):
-            lons = self.npz_file['all']['lon']
-            lats = self.npz_file['all']['lat']
+            lons = self.extracted_dict['all']['lon']
+            lats = self.extracted_dict['all']['lat']
             feats = []
             for row_idx, row in enumerate(self.dataset):
                 # add a feature
@@ -191,7 +191,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
                 msg = 'There was a problem adding features to the layer.'
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
 
-    def load_from_npz(self):
+    def load_from_extracted_dict(self):
         for rlz_or_stat in self.rlzs_or_stats:
             if (not self.load_all_rlzs_or_stats_chk.isChecked()
                     and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -221,5 +221,3 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
                                             self.default_field_name,
                                             self.iface,
                                             self.output_type)
-        if self.npz_file is not None:
-            self.npz_file.close()

--- a/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
+++ b/svir/dialogs/load_losses_by_asset_as_layer_dialog.py
@@ -101,9 +101,9 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
 
     def on_rlz_or_stat_changed(self):
         self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentText()]
-        self.taxonomies = numpy.unique(self.dataset['taxonomy']).tolist()
-        self.taxonomies = [taxonomy.decode('utf8')
-                           for taxonomy in self.taxonomies]
+        self.taxonomies = [
+            tax.decode('utf8').strip('"')
+            for tax in numpy.unique(self.dataset['taxonomy']).tolist()]
         self.populate_taxonomy_cbx(self.taxonomies)
         self.set_ok_button()
 
@@ -187,8 +187,6 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
                         self.style_maps(self.layer,
                                         self.default_field_name,
                                         self.iface, self.output_type)
-        if self.npz_file is not None:
-            self.npz_file.close()
 
     def group_by_site(self, npz, rlz_or_stat, loss_type, taxonomy='All'):
         # example:
@@ -197,7 +195,8 @@ class LoadLossesByAssetAsLayerDialog(LoadOutputAsLayerDialog):
         F32 = numpy.float32
         loss_by_site = collections.defaultdict(float)  # lon, lat -> loss
         for rec in npz[rlz_or_stat]:
-            if taxonomy == 'All' or taxonomy.encode('utf8') == rec['taxonomy']:
+            if (taxonomy == 'All'
+                    or taxonomy == rec['taxonomy'].decode('utf8').strip('"')):
                 loss_by_site[rec['lon'], rec['lat']] += rec[loss_type]
         data = numpy.zeros(len(loss_by_site),
                            [('lon', F32), ('lat', F32), (loss_type, F32)])

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -128,8 +128,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                     message_bar=self.iface.messageBar(), exception=exception)
         self.reject()
 
-    def finalize_init(self, extracted_npz):
-        self.npz_file = extracted_npz
+    def finalize_init(self, extracted_dict):
+        self.extracted_dict = extracted_dict
         self.populate_out_dep_widgets()
         self.adjustSize()
         self.set_ok_button()
@@ -371,7 +371,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.set_ok_button()
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.extracted_dict[self.rlz_or_stat_cbx.currentText()]
         self.set_ok_button()
 
     def on_loss_type_changed(self):
@@ -397,7 +397,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         raise NotImplementedError()
 
     def populate_rlz_or_stat_cbx(self):
-        self.rlzs_or_stats = [key for key in sorted(self.npz_file)
+        self.rlzs_or_stats = [key for key in sorted(self.extracted_dict)
                               if key not in ('imtls', 'array')]
         self.rlz_or_stat_cbx.clear()
         self.rlz_or_stat_cbx.setEnabled(True)
@@ -413,7 +413,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         #       which currently is always true.
         #       If different realizations have a different number of sites, we
         #       need to move this block of code inside on_rlz_or_stat_changed()
-        rlz_or_stat_data = self.npz_file[self.rlz_or_stat_cbx.currentText()]
+        rlz_or_stat_data = self.extracted_dict[
+            self.rlz_or_stat_cbx.currentText()]
         self.num_sites_lbl.setText(
             self.num_sites_msg % rlz_or_stat_data.shape)
 
@@ -426,10 +427,10 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def get_field_types(self, **kwargs):
         raise NotImplementedError()
 
-    def read_npz_into_layer(self, field_types, **kwargs):
+    def read_extracted_into_layer(self, field_types, **kwargs):
         raise NotImplementedError()
 
-    def load_from_npz(self):
+    def load_from_extracted_dict(self):
         raise NotImplementedError()
 
     def add_field_to_layer(self, field_name, field_type):
@@ -441,7 +442,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
     def get_investigation_time(self):
         if self.output_type in ('hcurves', 'uhs', 'hmaps', 'ruptures'):
             try:
-                investigation_time = self.npz_file['investigation_time']
+                investigation_time = self.extracted_dict['investigation_time']
             except KeyError as exc:
                 msg = ('investigation_time not found. It is mandatory for %s.'
                        ' Please check if the ouptut was produced by an'
@@ -484,7 +485,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 del field_types[field_name]
                 field_types[added_field_name] = field_type
 
-        self.read_npz_into_layer(
+        self.read_extracted_into_layer(
             field_types, rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, imt=imt,
             boundaries=boundaries, geometry_type=geometry_type,
@@ -872,7 +873,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             pass
         self.hide()
         if self.output_type in OQ_EXTRACT_TO_LAYER_TYPES:
-            self.load_from_npz()
+            self.load_from_extracted_dict()
             if self.output_type in ('losses_by_asset',
                                     'dmg_by_asset',
                                     'avg_losses-stats'):

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -961,7 +961,4 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         except Exception:
             # it's connected only for some loaders
             pass
-        if (hasattr(self, 'npz_file') and self.npz_file is not None
-                and self.output_type in OQ_TO_LAYER_TYPES):
-            self.npz_file.close()
         super().reject()

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -64,9 +64,9 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
 
     def populate_dataset(self):
         self.rlzs_or_stats = [
-            key for key in sorted(self.npz_file['all'].dtype.names)
+            key for key in sorted(self.extracted_dict['all'].dtype.names)
             if key not in ('lon', 'lat')]
-        self.dataset = self.npz_file['all']
+        self.dataset = self.extracted_dict['all']
         self.poes = self.dataset[self.rlzs_or_stats[0]].dtype.names
         self.poe_cbx.clear()
         self.poe_cbx.setEnabled(True)
@@ -82,7 +82,8 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         self.show_num_sites()
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.extracted_dict[
+            'all'][self.rlz_or_stat_cbx.currentText()]
         self.poes = self.dataset.dtype.names
         self.poe_cbx.clear()
         self.poe_cbx.setEnabled(True)
@@ -106,11 +107,11 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         field_types = {field_name: 'F' for field_name in field_names}
         return field_types
 
-    def read_npz_into_layer(self, field_names, **kwargs):
+    def read_extracted_into_layer(self, field_names, **kwargs):
         poe = kwargs['poe']
         with edit(self.layer):
-            lons = self.npz_file['all']['lon']
-            lats = self.npz_file['all']['lat']
+            lons = self.extracted_dict['all']['lon']
+            lats = self.extracted_dict['all']['lat']
             feats = []
             for row_idx, row in enumerate(self.dataset):
                 # add a feature
@@ -127,7 +128,7 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
                 msg = 'There was a problem adding features to the layer.'
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
 
-    def load_from_npz(self):
+    def load_from_extracted_dict(self):
         for poe in self.poes:
             if (self.load_selected_only_ckb.isChecked()
                     and poe != self.poe_cbx.currentText()):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -768,13 +768,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
         with WaitCursorManager(
                 'Extracting...', message_bar=self.iface.messageBar()):
-            rlzs_npz = extract_npz(
+            rlzs_dict = extract_npz(
                 session, hostname, calc_id, 'realizations',
                 message_bar=self.iface.messageBar())
-        if rlzs_npz is None:
+        if rlzs_dict is None:
             return
         # rlz[1] is the branch-path field
-        rlzs = [rlz[1].decode('utf8').strip('"') for rlz in rlzs_npz['array']]
+        rlzs = [rlz[1].decode('utf8').strip('"') for rlz in rlzs_dict['array']]
         self.rlz_cbx.blockSignals(True)
         self.rlz_cbx.clear()
         self.rlz_cbx.addItems(rlzs)
@@ -822,17 +822,17 @@ class ViewerDock(QDockWidget, FORM_CLASS):
     def _get_tags(self, session, hostname, calc_id, message_bar, with_star):
         with WaitCursorManager(
                 'Extracting...', message_bar=self.iface.messageBar()):
-            tags_npz = extract_npz(
+            tags_dict = extract_npz(
                 session, hostname, calc_id, 'asset_tags',
                 message_bar=message_bar)
-        if tags_npz is None:
+        if tags_dict is None:
             return
         tags_list = []
-        for tag_name in tags_npz:
+        for tag_name in tags_dict:
             # if tag_name == 'array':
             if tag_name in ['id', 'array']:
                 continue
-            for tag in tags_npz[tag_name]:
+            for tag in tags_dict[tag_name]:
                 if tag[-1] != '?':
                     tags_list.append(tag)
         self.tags = {}
@@ -854,13 +854,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if self.output_type == 'losses_by_asset_aggr':
             with WaitCursorManager(
                     'Extracting...', message_bar=self.iface.messageBar()):
-                rlzs_npz = extract_npz(
+                rlzs_dict = extract_npz(
                     session, hostname, calc_id, 'realizations',
                     message_bar=self.iface.messageBar())
-            if rlzs_npz is None:
+            if rlzs_dict is None:
                 return
             self.rlzs = [rlz[1].decode('utf8')  # branch_path
-                         for rlz in rlzs_npz['array']]
+                         for rlz in rlzs_dict['array']]
         self._get_tags(session, hostname, calc_id, self.iface.messageBar(),
                        with_star=True)
 
@@ -875,14 +875,15 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             to_extract = 'agg_losses/%s' % loss_types[0]
             with WaitCursorManager(
                     'Extracting...', message_bar=self.iface.messageBar()):
-                npz = extract_npz(session, hostname, calc_id, to_extract,
-                                  message_bar=self.iface.messageBar())
+                extracted_dict = extract_npz(
+                    session, hostname, calc_id, to_extract,
+                    message_bar=self.iface.messageBar())
             # stats might be unavailable in case of a single realization
-            if len(npz['stats']) == 0:
+            if len(extracted_dict['stats']) == 0:
                 # NOTE: writing 'mean' instead of 'rlz-0' would be equivalent
                 self.stats = ['rlz-0']
             else:
-                self.stats = npz['stats']
+                self.stats = extracted_dict['stats']
 
         self.tag_names_multiselect.clear()
         tag_names = sorted(self.tags.keys())

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -780,8 +780,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.rlz_cbx.addItems(rlzs)
         self.rlz_cbx.blockSignals(False)
 
-        loss_types = [lt.decode('utf8')
-                      for lt in composite_risk_model_attrs['loss_types']]
+        loss_types = composite_risk_model_attrs['loss_types']
         self.loss_type_cbx.blockSignals(True)
         self.loss_type_cbx.clear()
         self.loss_type_cbx.addItems(loss_types)
@@ -795,15 +794,12 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.filter_dmg_by_asset_aggr()
 
     def _build_tags(self):
-        tag_names = sorted([
-            tag_name.decode('utf8')
-            for tag_name in self.exposure_metadata['tagnames']])
+        tag_names = sorted(self.exposure_metadata['tagnames'])
         self.tags = {}
         for tag_idx, tag_name in enumerate(tag_names):
             tag_values = sorted([
-                value.decode('utf8')
-                for value in self.exposure_metadata[tag_name]
-                if value != b'?'])
+                value for value in self.exposure_metadata[tag_name]
+                if value != '?'])
             self.tags[tag_name] = {
                 'selected': True if tag_idx == 0 else False,
                 'values': {
@@ -837,7 +833,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             if tag_name in ['id', 'array']:
                 continue
             for tag in tags_npz[tag_name]:
-                tag = tag.decode('utf8')
                 if tag[-1] != '?':
                     tags_list.append(tag)
         self.tags = {}
@@ -864,7 +859,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     message_bar=self.iface.messageBar())
             if rlzs_npz is None:
                 return
-            self.rlzs = [rlz[1].decode('utf-8')  # branch_path
+            self.rlzs = [rlz[1].decode('utf8')  # branch_path
                          for rlz in rlzs_npz['array']]
         self._get_tags(session, hostname, calc_id, self.iface.messageBar(),
                        with_star=True)
@@ -939,7 +934,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                              if self.tags[tag_name]['values'][val]][0]
                 params[tag_name] = tag_value
         loss_types = [
-            loss_type.decode('utf8')
+            loss_type
             for loss_type in composite_risk_model_attrs['loss_types']]
         self.loss_type_cbx.blockSignals(True)
         self.loss_type_cbx.clear()
@@ -1006,8 +1001,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                                 self.agg_curves[tag_name]).index(tag_value)
                             tag_value_idxs[tag_name].append(tag_value_idx)
             else:
-                for tag in self.aggregate_by:
-                    tag_name = tag.decode('utf8')
+                for tag_name in self.aggregate_by:
                     # FIXME: check if currentIndex is ok
                     tag_value_idx = getattr(
                         self,
@@ -1092,7 +1086,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.plot.set_xscale('log')
         self.plot.set_yscale('linear')
         self.plot.set_xlabel('Return period (years)')
-        self.plot.set_ylabel('Loss (%s)' % unit.decode('utf8'))
+        self.plot.set_ylabel('Loss (%s)' % unit)
         title = 'Loss type: %s' % self.loss_type_cbx.currentText()
         self.plot.set_title(title)
         self.plot.grid(which='both')
@@ -1168,8 +1162,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         tags = None
         try:
             # NOTE: case with '*'
-            tags = [tag.decode('utf8')
-                    for tag in self.losses_by_asset_aggr['tags']]
+            tags = self.losses_by_asset_aggr['tags']
         except KeyError:
             # NOTE: case without '*'
             pass
@@ -1886,7 +1879,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 loss_type = self.loss_type_cbx.currentText()
                 abs_rel = self.abs_rel_cbx.currentText()
                 loss_type_idx = self.loss_type_cbx.currentIndex()
-                unit = self.agg_curves['units'][loss_type_idx].decode('utf8')
+                unit = self.agg_curves['units'][loss_type_idx]
                 csv_file.write("# Loss type: %s\r\n" % loss_type)
                 csv_file.write("# Absolute or relative: %s\r\n" % abs_rel)
                 csv_file.write("# Measurement unit: %s\r\n" % unit)
@@ -1912,7 +1905,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 loss_type = self.loss_type_cbx.currentText()
                 abs_rel = self.abs_rel_cbx.currentText()
                 loss_type_idx = self.loss_type_cbx.currentIndex()
-                unit = self.agg_curves['units'][loss_type_idx].decode('utf8')
+                unit = self.agg_curves['units'][loss_type_idx]
                 csv_file.write("# Loss type: %s\r\n" % loss_type)
                 csv_file.write("# Absolute or relative: %s\r\n" % abs_rel)
                 csv_file.write("# Measurement unit: %s\r\n" % unit)
@@ -1934,7 +1927,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                             # FIXME: using only the first stat
                             for tval_idx in tag_value_idxs[tag_name]:
                                 tval = self.agg_curves[tag_name][tval_idx]
-                                headers.append(tval.decode('utf8'))
+                                headers.append(tval)
                             break
                 if has_single_tag_value or has_single_tag_value is None:
                     headers.extend(stats)
@@ -1976,8 +1969,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     "# Tags: %s\r\n" % (
                         self.get_list_selected_tags_str() or 'None'))
                 try:
-                    tags = [tag.decode('utf8')
-                            for tag in self.losses_by_asset_aggr['tags']]
+                    tags = self.losses_by_asset_aggr['tags']
                     tag = tags[0]
                     # a tag is like 'taxonomy=Wood'
                     tag_name = tag.split('=')[0]


### PR DESCRIPTION
In most cases, it avoids to keep decoding objects afterwards. It does not improve things in cases such as: the extracted dictionary contains a key 'array' and the array has for instance a column with bytes. In that kind of situation, I am still decoding those bytes afterwards.

NOTE: this change highlighted a corner case in which the plugin-side complains that it is impossible to read pickled data with allow_pickle=False. I created a branch engine-side called `fix-extract-val-none` that should address also that corner case. The point seems to be that if in the extracted object there is a key for which the value is None, it would still export it with type object. Instead of None, I am using an empty list, and it seems to work as expected (although I am not sure if it is the right thing to do).