### PR TITLE
Select input files from zip or directory (and include subdirectories)

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -675,6 +675,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 _, zipped_file_name = tempfile.mkstemp()
                 with zipfile.ZipFile(zipped_file_name, 'w') as zipped_file:
                     zipdir(selected_dir, zipped_file)
+        else:  # given filenames
+            _, zipped_file_name = tempfile.mkstemp()
+            with zipfile.ZipFile(zipped_file_name, 'w') as zipped_file:
+                for file_name in file_names:
+                    zipped_file.write(file_name)
         with zipfile.ZipFile(zipped_file_name, 'r') as f:
             input_file_names = f.namelist()
         ini_file_names = [file_name for file_name in input_file_names

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -671,10 +671,10 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                         'irmt/run_oqengine_calc_dir', selected_dir)
             else:
                 raise NotImplementedError(select_from)
-        if select_from == 'Directory':
-            _, zipped_file_name = tempfile.mkstemp()
-            with zipfile.ZipFile(zipped_file_name, 'w') as zipped_file:
-                zipdir(selected_dir, zipped_file)
+            if select_from == 'Directory':
+                _, zipped_file_name = tempfile.mkstemp()
+                with zipfile.ZipFile(zipped_file_name, 'w') as zipped_file:
+                    zipdir(selected_dir, zipped_file)
         with zipfile.ZipFile(zipped_file_name, 'r') as f:
             input_file_names = f.namelist()
         ini_file_names = [file_name for file_name in input_file_names

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -34,7 +34,6 @@ from qgis.PyQt.QtCore import (QDir,
                               Qt,
                               QTimer,
                               pyqtSlot,
-                              QFileInfo,
                               QRegExp,
                               QSettings)
 
@@ -133,6 +132,13 @@ OUTPUT_TYPE_LOADERS = {
 }
 assert set(OUTPUT_TYPE_LOADERS) == OQ_TO_LAYER_TYPES, (
     OUTPUT_TYPE_LOADERS, OQ_TO_LAYER_TYPES)
+
+
+def zipdir(path, ziph):
+    # ziph is zipfile handle
+    for root, dirs, files in os.walk(path):
+        for file in files:
+            ziph.write(os.path.join(root, file))
 
 
 class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
@@ -547,7 +553,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             self.update_output_list(calc_id)
         elif action == 'Continue':
             self.update_output_list(calc_id)
-            self.run_calc(calc_id)
+            self.run_calc(calc_id=calc_id)
         else:
             raise NotImplementedError(action)
 
@@ -627,41 +633,48 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
         Run a calculation. If `calc_id` is given, it means we want to run
         a calculation re-using the output of the given calculation
         """
-        text = self.tr('Select the files needed to run the calculation,'
-                       ' or the zip archive containing those files.')
+        zipped_file_name = None
+        selected_dir = None
         if directory is None:
             default_dir = QSettings().value('irmt/run_oqengine_calc_dir',
                                             QDir.homePath())
         else:
             default_dir = directory
+        if isinstance(default_dir, int):
+            default_dir = os.path.expanduser('~')
         if not file_names:
-            file_names, __ = QFileDialog.getOpenFileNames(
-                self, text, default_dir)
-        if not file_names:
-            return
-        if directory is None:
-            selected_dir = QFileInfo(file_names[0]).dir().path()
-            QSettings().setValue('irmt/run_oqengine_calc_dir', selected_dir)
-        else:
-            file_names = [os.path.join(directory, os.path.basename(file_name))
-                          for file_name in file_names]
-        if len(file_names) == 1:
-            file_full_path = file_names[0]
-            _, file_ext = os.path.splitext(file_full_path)
-            if file_ext == '.zip':
-                zipped_file_name = file_full_path
-            else:
-                # NOTE: an alternative solution could be to check if the single
-                # file is .ini, to look for all the files specified in the .ini
-                # and to build a zip archive with all them
-                msg = "Please select all the files needed, or a zip archive"
-                log_msg(msg, level='C', message_bar=self.message_bar)
+            select_from, ok_pressed = QInputDialog.getItem(
+                self, self.tr('Select input data container'),
+                "Input data is in",
+                ['Directory', 'Zip archive'], 0, False)
+            if not ok_pressed:
                 return
-        else:
+            if select_from == 'Zip archive':
+                text = self.tr('Select a zip archive containing input files')
+                file_types = self.tr('Zip archives (*.zip)')
+                zipped_file_name = QFileDialog.getOpenFileName(
+                    self, text, default_dir, file_types)[0]
+                if not zipped_file_name:
+                    return
+                if directory is None:
+                    selected_dir = os.path.dirname(zipped_file_name)
+                    QSettings().setValue(
+                        'irmt/run_oqengine_calc_dir', selected_dir)
+            elif select_from == 'Directory':
+                text = self.tr('Select a directory containing input files')
+                selected_dir = QFileDialog.getExistingDirectory(
+                    self, text, default_dir)
+                if not selected_dir:
+                    return
+                if directory is None:
+                    QSettings().setValue(
+                        'irmt/run_oqengine_calc_dir', selected_dir)
+            else:
+                raise NotImplementedError(select_from)
+        if select_from == 'Directory':
             _, zipped_file_name = tempfile.mkstemp()
             with zipfile.ZipFile(zipped_file_name, 'w') as zipped_file:
-                for file_name in file_names:
-                    zipped_file.write(file_name)
+                zipdir(selected_dir, zipped_file)
         with zipfile.ZipFile(zipped_file_name, 'r') as f:
             input_file_names = f.namelist()
         ini_file_names = [file_name for file_name in input_file_names

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,8 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.9.0
+    * When pressing the button to run an OQ-Engine calculation or to continue from a previous one, the user can choose if selecting files from a zip file or from
+      a directory. In the latter case, also data available in nested directories will be sent to the OQ-Engine
     * The plugin uses `numpy.load(allow_pickle=False)` while extracting data from the OQ-Engine
     3.8.0
     * Ruptures are loaded from OQ-Engine outputs as separate layers, one for each geometry type (polygon, line or point), instead of representing lines as degenerate flat polygons.


### PR DESCRIPTION
Without this change, it would have been impossible to select all the input files for some calculations that include files in subdirectories.
I first tried a different approach with respect to the one implemented here, which consisted in modifying the file selector widget to accept the selection of both files and directories. However, it was tricky and a little confusing, so I changed the approach: when the user presses "run calculation", they have first to choose if they prefer to select input data from a directory or from a zip file. In case a directory is selected, also subdirectories are zipped together and sent to the engine.