### PR TITLE
Add possibility to run integration test for only one output type and/or for only one calc id

### DIFF
--- a/scripts/run_integration_tests.sh
+++ b/scripts/run_integration_tests.sh
@@ -20,7 +20,8 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -e DISPLAY=:99 \
  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
  -e BRANCH="$BRANCH" \
- -e SELECTED_CALC_ID="$SELECTED_CALC_ID" \
+ -e ONLY_CALC_ID="$ONLY_CALC_ID" \
+ -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" \
  -e GEM_QGIS_TEST=y \
  qgis/qgis:final-3_8_3
 

--- a/svir/how_to_run_tests.txt
+++ b/svir/how_to_run_tests.txt
@@ -12,7 +12,10 @@ make unittest
 make integrationtest
 
 # to run integration tests for only one specific oq-engine calculation (e.g. 5):
-SELECTED_CALC_ID=5 make integrationtest
+ONLY_CALC_ID=5 make integrationtest
+
+# to run integration tests for only one specific oq-engine output type (e.g. hcurves):
+ONLY_OUTPUT_TYPE=hcurves
 
 # to run all tests:
 make test


### PR DESCRIPTION
It was already possible to run tests for only one calc id, but it was not skipping some other tests, e.g. testing running a new calculation, etc.