### PR TITLE
Hack to fix wrong resizing of vertical headers in viewer dock

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -120,7 +120,7 @@ OUTPUT_TYPE_LOADERS = {
     'realizations': LoadCsvAsLayerDialog,
     'events': LoadCsvAsLayerDialog,
     'dmg_by_event': LoadCsvAsLayerDialog,
-    'losses_by_event': LoadCsvAsLayerDialog,
+    'agg_loss_table': LoadCsvAsLayerDialog,
     'agg_losses-stats': LoadCsvAsLayerDialog,
     'agg_risk': LoadCsvAsLayerDialog,
     'damages-rlzs': LoadDamagesRlzsAsLayerDialog,

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1181,7 +1181,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             #        'taxonomy=Stone-Masonry',
             #        'taxonomy=Unreinforced-Brick-Masonry',
             #        'taxonomy=Concrete'], dtype='|S35')
-            tag_values = [tag.split('=')[1] for tag in tags]
+            tag_values = [tag.split('=')[1] + '  ' for tag in tags]
             self.table.setVerticalHeaderLabels(tag_values)
         else:  # NOTE: case without '*'
             tag_values = []
@@ -1192,13 +1192,18 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         if self.tags[tag]['values'][tag_value]]
                     tag_values.extend(values)
             if tag_values:
-                self.table.setVerticalHeaderLabels([', '.join(tag_values)])
+                self.table.setVerticalHeaderLabels([
+                    ', '.join(tag_values) + '  '])
             else:
-                self.table.setVerticalHeaderLabels(['Total'])
+                self.table.setVerticalHeaderLabels(['Total  '])
         for row in range(nrows):
             for col in range(ncols):
                 self.table.setItem(
                     row, col, QTableWidgetItem(str(losses_array[row, col])))
+        # NOTE: vertical headers are not resized properly with respect to
+        # contents (they are cut on the right). I couldn't find any proper way
+        # to fix it, so I am adding a tail of 2 spaces to each header as a
+        # workaround (hack)
         self.table.resizeColumnsToContents()
 
     def draw(self):

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.11.0
+    * The OQ-Engine output 'losses_by_event' was renamed into 'agg_loss_table'
     * Fixed displaying full vertical headers in Data Viewer
     * The settings dialog was made scrollable
     * Hazard maps are grouped by POE

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.11.0
+    * Fixed displaying full vertical headers in Data Viewer
     * The settings dialog was made scrollable
     * Hazard maps are grouped by POE
     * Following a change in the OQ-Engine, agglosses are now loaded as agg_losses-stats

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -224,7 +224,7 @@ OQ_CSV_TO_LAYER_TYPES = set([
     'agg_losses-stats',
     'dmg_by_event',
     'events',
-    'losses_by_event',
+    'agg_loss_table',
     'realizations',
 ])
 OQ_EXTRACT_TO_LAYER_TYPES = set([


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/756

This also fixes renaming an oq-engine output as it was recently renamed engine-side (losses_by_event -> agg_loss_table)