### PR TITLE
Add check for 'skip CI'; correctly set branches for IRMT and Engine

### DIFF
--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -11,6 +11,8 @@ jobs:
   
   Tests_and_docs:
     runs-on: ubuntu-18.04
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    # if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     env:
       GITHUB_DEF_BR: master
     steps:
@@ -21,8 +23,6 @@ jobs:
           python-version: 3.8
       - name: Clone engine and restore oqdata and docker container
         run: |
-          if: "!contains(github.event.head_commit.message, 'skip CI')"
-          # if: "! contains(toJSON(github.event.commits.*.message), '[skip CI]')"
           set -x
           echo " Check if this is a pull request or not"
           if [ -z "$GITHUB_HEAD_REF" ]

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -11,7 +11,7 @@ jobs:
   
   Tests_and_docs:
     runs-on: ubuntu-18.04
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    # if: "!contains(github.event.head_commit.message, 'ci skip')"
     # if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     env:
       GITHUB_DEF_BR: master

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -10,13 +10,10 @@ on:
 jobs:
   
   PLUGIN:
+    if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-18.04
     env:
-      GITHUB_PULL_REQUEST: ${{ github.event.number }}
-      GITHUB_DEF_BR:  ${{ github.event.repository.default_branch }}
-      GITHUB_REF:  ${{ github.ref }}
-      GITHUB_HD_REF:  ${{ github.head_ref }}
-      GITHUB_BS_REF:  ${{ github.base_ref }}
+      GITHUB_DEF_BR: master
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -27,12 +24,12 @@ jobs:
         run: |
           set -x
           echo " Check if this is a pull request or not"
-          if [ -z "$GITHUB_HD_REF" ]
+          if [ -z "$GITHUB_HEAD_REF" ]
              then
               echo " Is not a pull request, use branch: $GITHUB_DEF_BR"
               GITHUB_BR=`echo ${{ github.event.repository.default_branch }}`
              else
-              echo " Is a pull request, use branch: $GITHUB_HD_BR"
+              echo " Is a pull request, use branch: $GITHUB_HEAD_REF"
               GITHUB_BR=`echo ${{ github.head_ref }}`
           fi
           git clone -b $GITHUB_BR --depth=1 https://github.com/gem/oq-engine.git
@@ -65,12 +62,12 @@ jobs:
         run: |
           set -x
           echo " Check if this is a pull request or not"
-          if [ -z "$GITHUB_HD_REF" ]
+          if [ -z "$GITHUB_HEAD_REF" ]
              then
               echo " Is not a pull request, use branch: $GITHUB_DEF_BR"
               GITHUB_BR=`echo ${{ github.event.repository.default_branch }}`
              else
-              echo " Is a pull request, use branch: $GITHUB_HD_BR"
+              echo " Is a pull request, use branch: $GITHUB_HEAD_REF"
               GITHUB_BR=`echo ${{ github.head_ref }}`
           fi
           docker exec qgis sh -c "git clone -q -b $GITHUB_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -43,7 +43,7 @@ jobs:
           pip3 install -r requirements-py38-linux64.txt
           pip3 install -e .
           cd ..
-          echo "Restore demos for $ENGINE_BR branch "
+          echo "Restore OQ-Engine demos for $ENGINE_BR branch "
           mkdir ~/oqdata
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -27,12 +27,12 @@ jobs:
           if [ -z "$GITHUB_HEAD_REF" ]
              then
               echo " Is not a pull request, use branch: $GITHUB_DEF_BR"
-              GITHUB_BR=$GITHUB_DEF_BR
+              IRMT_BR=$GITHUB_DEF_BR
              else
               echo " Is a pull request, use branch: $GITHUB_HEAD_REF"
-              GITHUB_BR=$GITHUB_HEAD_REF
+              IRMT_BR=$GITHUB_HEAD_REF
           fi
-          ENGINE_BR=$GITHUB_BR
+          ENGINE_BR=$IRMT_BR
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
@@ -44,7 +44,7 @@ jobs:
           pip3 install -e .
           cd ..
           echo "Dump for $ENGINE_BR branch "
-          curl -sfLO https://artifacts.openquake.org/travis/oqdata-${GITHUB_BR}.zip
+          curl -sfLO https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip
           mkdir ~/oqdata
           oq restore oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
@@ -54,7 +54,7 @@ jobs:
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
           docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e DISPLAY=:99  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
-          -e BRANCH="$GITHUB_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y qgis/qgis:final-3_8_3
+          -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y qgis/qgis:final-3_8_3
           docker exec qgis bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
           docker exec qgis bash -c "python3 -m pip install pytest"
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
@@ -69,12 +69,16 @@ jobs:
           if [ -z "$GITHUB_HEAD_REF" ]
              then
               echo " Is not a pull request, use branch: $GITHUB_DEF_BR"
-              GITHUB_BR=$GITHUB_DEF_BR
+              IRMT_BR=$GITHUB_DEF_BR
              else
               echo " Is a pull request, use branch: $GITHUB_HEAD_REF"
-              GITHUB_BR=$GITHUB_HEAD_REF
+              IRMT_BR=$GITHUB_HEAD_REF
           fi
-          docker exec qgis sh -c "git clone -q -b $GITHUB_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
+          ENGINE_BR=$IRMT_BR
+          if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
+              ENGINE_BR='master';
+          fi
+          docker exec qgis sh -c "git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "qgis_setup.sh svir"
           docker exec -t qgis sh -c "cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: Make docs

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   
-  PLUGIN:
+  Tests and docs:
     if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -27,22 +27,26 @@ jobs:
           if [ -z "$GITHUB_HEAD_REF" ]
              then
               echo " Is not a pull request, use branch: $GITHUB_DEF_BR"
-              GITHUB_BR=`echo ${{ github.event.repository.default_branch }}`
+              GITHUB_BR=$GITHUB_DEF_BR
              else
               echo " Is a pull request, use branch: $GITHUB_HEAD_REF"
-              GITHUB_BR=`echo ${{ github.head_ref }}`
+              GITHUB_BR=$GITHUB_HEAD_REF
           fi
-          git clone -b $GITHUB_BR --depth=1 https://github.com/gem/oq-engine.git
+          ENGINE_BR=$GITHUB_BR
+          if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
+              ENGINE_BR='master';
+          fi
+          git clone -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git
           PY_VER=`echo py${{ matrix.python-version }} | tr -d .`
           echo $PY_VER
           cd oq-engine
           pip3 install -r requirements-py38-linux64.txt
           pip3 install -e .
           cd ..
-          echo "Dump for $GITHUB_BR branch "
+          echo "Dump for $ENGINE_BR branch "
           curl -sfLO https://artifacts.openquake.org/travis/oqdata-${GITHUB_BR}.zip
           mkdir ~/oqdata
-          oq restore oqdata-${GITHUB_BR}.zip ~/oqdata
+          oq restore oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           sleep 10 
           curl http://172.17.0.1:8800/v1/engine_version
@@ -65,10 +69,10 @@ jobs:
           if [ -z "$GITHUB_HEAD_REF" ]
              then
               echo " Is not a pull request, use branch: $GITHUB_DEF_BR"
-              GITHUB_BR=`echo ${{ github.event.repository.default_branch }}`
+              GITHUB_BR=$GITHUB_DEF_BR
              else
               echo " Is a pull request, use branch: $GITHUB_HEAD_REF"
-              GITHUB_BR=`echo ${{ github.head_ref }}`
+              GITHUB_BR=$GITHUB_HEAD_REF
           fi
           docker exec qgis sh -c "git clone -q -b $GITHUB_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "qgis_setup.sh svir"

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   
-  Tests and docs:
+  Tests_and_docs:
     if: "!contains(github.event.head_commit.message, 'skip CI')"
     runs-on: ubuntu-18.04
     env:

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -43,10 +43,9 @@ jobs:
           pip3 install -r requirements-py38-linux64.txt
           pip3 install -e .
           cd ..
-          echo "Dump for $ENGINE_BR branch "
-          curl -sfLO https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip
+          echo "Restore demos for $ENGINE_BR branch "
           mkdir ~/oqdata
-          oq restore oqdata-${ENGINE_BR}.zip ~/oqdata
+          oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           sleep 10 
           curl http://172.17.0.1:8800/v1/engine_version

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   
   Tests_and_docs:
-    if: "!contains(github.event.head_commit.message, 'skip CI')"
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip CI]')"
     runs-on: ubuntu-18.04
     env:
       GITHUB_DEF_BR: master

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -10,7 +10,6 @@ on:
 jobs:
   
   Tests_and_docs:
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip CI]')"
     runs-on: ubuntu-18.04
     env:
       GITHUB_DEF_BR: master
@@ -22,6 +21,8 @@ jobs:
           python-version: 3.8
       - name: Clone engine and restore oqdata and docker container
         run: |
+          if: "!contains(github.event.head_commit.message, 'skip CI')"
+          # if: "! contains(toJSON(github.event.commits.*.message), '[skip CI]')"
           set -x
           echo " Check if this is a pull request or not"
           if [ -z "$GITHUB_HEAD_REF" ]

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -11,7 +11,7 @@ jobs:
   
   Tests_and_docs:
     runs-on: ubuntu-18.04
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     # if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     env:
       GITHUB_DEF_BR: master

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -11,8 +11,6 @@ jobs:
   
   Tests_and_docs:
     runs-on: ubuntu-18.04
-    # if: "!contains(github.event.head_commit.message, 'ci skip')"
-    # if: "! contains(toJSON(github.event.commits.*.message), '[skip ci]')"
     env:
       GITHUB_DEF_BR: master
     steps:


### PR DESCRIPTION
Attempting to fix the behavior of CI both for PRs and for daily runs.

To fix: 
- [x] adding (skip CI) did not prevent it from running the job anyway.
- [ ] it looks like github.event.repository.default_branch does not retrieve any value, so I put `master` explicitly instead (it does not look so bad anyway, since we are likely going to keep using master as default branch both on IRMT and Engine