### PR TITLE
Fix field types loading Asset Damage Distribution

### DIFF
--- a/svir/dialogs/load_damages_rlzs_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_rlzs_as_layer_dialog.py
@@ -170,8 +170,16 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
             self.default_field_name = "%s_%s" % (
                 self.loss_type_cbx.currentText(),
                 self.dmg_state_cbx.currentText())
-        # NOTE: assuming that all fields are numeric
-        field_types = {field_name: 'F' for field_name in field_names}
+        if self.aggregate_by_site_ckb.isChecked():
+            field_types = {field_name: 'F' for field_name in field_names}
+        else:
+            field_types = {}
+            for field_name in field_names:
+                try:
+                    field_types[field_name] = self.dataset.dtype[
+                        field_name].kind
+                except KeyError:
+                    field_types[field_name] = 'F'
         return field_types
 
     def read_npz_into_layer(self, field_types, **kwargs):
@@ -183,6 +191,7 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
             self.read_npz_into_layer_no_aggr(field_types, **kwargs)
 
     def read_npz_into_layer_no_aggr(self, field_types, **kwargs):
+        field_names = list(field_types)
         rlz_or_stat = kwargs['rlz_or_stat']
         loss_type = kwargs['loss_type']
         with edit(self.layer):
@@ -191,7 +200,7 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
             for row in data:
                 # add a feature
                 feat = QgsFeature(self.layer.fields())
-                for field_name, field_type in field_types.items():
+                for field_name in field_names:
                     if field_name in ['lon', 'lat']:
                         continue
                     elif field_name in data.dtype.names:
@@ -211,6 +220,7 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
 
     def read_npz_into_layer_aggr_by_site(self, field_types, **kwargs):
+        field_names = list(field_types)
         rlz_or_stat = kwargs['rlz_or_stat']
         loss_type = kwargs['loss_type']
         taxonomy = kwargs['taxonomy']
@@ -222,16 +232,13 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
             for row in grouped_by_site:
                 # add a feature
                 feat = QgsFeature(self.layer.fields())
-                field_idx = 0
-                for field_name, field_type in field_types.items():
+                for field_name_idx, field_name in enumerate(field_names):
                     if field_name in ['lon', 'lat']:
-                        field_idx += 1
                         continue
-                    value = row[field_idx].item()
+                    value = row[field_name_idx].item()
                     if isinstance(value, bytes):
                         value = value.decode('utf8')
                     feat.setAttribute(field_name, value)
-                    field_idx += 1
                 feat.setGeometry(QgsGeometry.fromPointXY(
                     QgsPointXY(row['lon'], row['lat'])))
                 feats.append(feat)

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.11.1
+version=3.11.2
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.11.2
+    * Fixed a bug in the assignment of field types while loading the OQ-Engine Asset Damage Distribution output as layer
     3.11.1
     * Like 3.11.0, but without the "experimental" flag
     3.11.0


### PR DESCRIPTION
Some strings were forced to be stored into fields defined as float. QGIS 3.10 was not complaining about it, but it caused some subtle side-effects; QGIS 3.16 instead raises an exception in that case.