### PR TITLE
Restore integration tests for recovery modeling

### DIFF
--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -496,5 +496,9 @@ def fill_fields_multiselect(fields_multiselect, layer):
                     and field.typeName() in NUMERIC_FIELD_TYPES]
     other_field_names = [field.name() for field in other_fields]
     fields_multiselect.clear()
-    fields_multiselect.add_selected_items(default_field_names)
-    fields_multiselect.add_unselected_items(other_field_names)
+    if default_field_names:
+        fields_multiselect.add_selected_items(default_field_names)
+        fields_multiselect.add_unselected_items(other_field_names)
+    else:
+        # NOTE: it works in most cases, but it could pre-load wrong fields
+        fields_multiselect.add_selected_items(other_field_names)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -691,14 +691,12 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 print('\t%s' % output)
 
     def load_recovery_curves(self, dlg, approach, n_simulations):
-        # FIXME: skipping test on recovery curves
-        print('\n\nSkipped test on recovery curves!')
-        # self._set_output_type('Recovery Curves')
-        # self.irmt.viewer_dock.approach_cbx.setCurrentIndex(
-        #     self.irmt.viewer_dock.approach_cbx.findText(approach))
-        # self.irmt.viewer_dock.n_simulations_sbx.setValue(n_simulations)
-        # self._change_selection()
-        # self._test_export()
+        self._set_output_type('Recovery Curves')
+        self.irmt.viewer_dock.approach_cbx.setCurrentIndex(
+            self.irmt.viewer_dock.approach_cbx.findText(approach))
+        self.irmt.viewer_dock.n_simulations_sbx.setValue(n_simulations)
+        self._change_selection()
+        self._test_export()
         dlg.loading_completed.emit(dlg)
 
     def load_uhs(self):


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/738
Recovery modeling tests were skipped because engine-side fields containing probabilities were removed the `_mean` suffix and because some textual fields were wrongly defined as numeric (see https://github.com/gem/oq-irmt-qgis/pull/773).
I am assuming now that if no fields are found with _mean suffix, then all fields are pre-selected as those containing probabilities (the user can unselect them if that's incorrect).
