### PR TITLE
Replaced output `agg_losses-stats` with aggrisk

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -120,7 +120,7 @@ OUTPUT_TYPE_LOADERS = {
     'realizations': LoadCsvAsLayerDialog,
     'events': LoadCsvAsLayerDialog,
     'risk_by_event': LoadCsvAsLayerDialog,
-    'agg_losses-stats': LoadCsvAsLayerDialog,
+    'aggrisk': LoadCsvAsLayerDialog,
     'agg_risk': LoadCsvAsLayerDialog,
     'damages-rlzs': LoadDamagesRlzsAsLayerDialog,
     'gmf_data': LoadGmfDataAsLayerDialog,

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -45,7 +45,7 @@ changelog=
     * Fixed displaying full vertical headers in Data Viewer
     * The settings dialog was made scrollable
     * Hazard maps are grouped by POE
-    * Following a change in the OQ-Engine, agglosses are now loaded as agg_losses-stats
+    * Following a change in the OQ-Engine, agglosses are now loaded as aggrisk
     * A parameter was added to switch between default hmaps styling and the styling used for SGC projects
     * Cross symbols rendered for OQ-Engine disaggregation outputs are opaque, wider and thicker than those used for other outputs (e.g. hcurves)
     * Following a change in the OQ Engine outputs, avg_damages-rlzs and avg_damages-stats were renamed into damages-rlzs and damages-stats

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -744,10 +744,10 @@ class LoadAggRiskTestCase(LoadOqEngineOutputsTestCase):
 
 class LoadAggLossesStatsTestCase(LoadOqEngineOutputsTestCase):
     @unittest.skipIf(
-        ONLY_OUTPUT_TYPE and ONLY_OUTPUT_TYPE != 'agg_losses-stats',
+        ONLY_OUTPUT_TYPE and ONLY_OUTPUT_TYPE != 'aggrisk',
         'only testing output type %s' % ONLY_OUTPUT_TYPE)
     def test_load_agg_losses_stats(self):
-        self.load_output_type('agg_losses-stats')
+        self.load_output_type('aggrisk')
 
 
 class LoadDmgByEventTestCase(LoadOqEngineOutputsTestCase):

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -229,7 +229,7 @@ RECOVERY_DEFAULTS['n_recovery_based_dmg_states'] = len(
 
 OQ_CSV_TO_LAYER_TYPES = set([
     'agg_risk',
-    'agg_losses-stats',
+    'aggrisk',
     'risk_by_event',
     'events',
     'realizations',


### PR DESCRIPTION
Companion of https://github.com/gem/oq-engine/pull/7227.