### PR TITLE
Replace deprecated writeAsVectorFormatV2 -> writeAsVectorFormatV3

### DIFF
--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -771,11 +771,7 @@ class Irmt(object):
             else:
                 raise RuntimeError('Layer invalid')
         else:
-            writer_error = save_layer_as(
-                layer, dest_filename, 'GPKG')
-            if writer_error:
-                raise RuntimeError(
-                    'Could not save geopackage. Error code: %s' % writer_error)
+            save_layer_as(layer, dest_filename, 'GPKG')
             layer = QgsVectorLayer(
                 dest_filename, 'Socioeconomic data', 'ogr')
             if layer.isValid():

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -771,12 +771,11 @@ class Irmt(object):
             else:
                 raise RuntimeError('Layer invalid')
         else:
-            writer_error, error_msg = save_layer_as(
+            writer_error = save_layer_as(
                 layer, dest_filename, 'GPKG')
             if writer_error:
                 raise RuntimeError(
-                    'Could not save geopackage. %s: %s' % (writer_error,
-                                                           error_msg))
+                    'Could not save geopackage. Error code: %s' % writer_error)
             layer = QgsVectorLayer(
                 dest_filename, 'Socioeconomic data', 'ogr')
             if layer.isValid():

--- a/svir/test/unit/test_calculate_indices.py
+++ b/svir/test/unit/test_calculate_indices.py
@@ -27,7 +27,7 @@ import os
 import sys
 import tempfile
 from copy import deepcopy
-from qgis.core import QgsVectorLayer
+from qgis.core import QgsVectorLayer, QgsVectorFileWriter
 
 from svir.calculations.calculate_utils import (calculate_node,
                                                get_node_attr_id_and_name,
@@ -325,7 +325,10 @@ class CalculateCompositeVariableTestCase(unittest.TestCase):
             write_output(self.layer, self.data_dir_name, res_layer_name)
 
         _, out_layer_path = tempfile.mkstemp(suffix='.gpkg')
-        save_layer_as(self.layer, out_layer_path, 'GPKG')
+        writer_error = save_layer_as(self.layer, out_layer_path, 'GPKG')
+        if writer_error != QgsVectorFileWriter.WriterError.NoError:
+            raise RuntimeError(
+                'Could not save geopackage. Error code: %s' % writer_error)
         out_layer = QgsVectorLayer(
             out_layer_path, 'svi_calculation_first_round', 'ogr')
 
@@ -356,7 +359,10 @@ class CalculateCompositeVariableTestCase(unittest.TestCase):
         self.assertEqual(proj_def, proj_def_svi_calc_first_round)
 
         _, out_layer_path = tempfile.mkstemp(suffix='.gpkg')
-        save_layer_as(self.layer, out_layer_path, 'GPKG')
+        writer_error = save_layer_as(self.layer, out_layer_path, 'GPKG')
+        if writer_error != QgsVectorFileWriter.WriterError.NoError:
+            raise RuntimeError(
+                'Could not save geopackage. Error code: %s' % writer_error)
         out_layer = QgsVectorLayer(
             out_layer_path, 'svi_calculation_second_round', 'ogr')
 
@@ -388,11 +394,11 @@ def calculate_education_node(proj_def, operator, layer):
 
 def write_output(res_layer, data_dir_name, res_layer_name):
     res_layer_path = os.path.join(data_dir_name, res_layer_name + '.gpkg')
-    writer_error, error_msg = save_layer_as(
+    writer_error = save_layer_as(
         res_layer, res_layer_path, 'GPKG')
-    if writer_error:
-        raise RuntimeError('Could not save geopackage. %s: %s' % (writer_error,
-                                                                  error_msg))
+    if writer_error != QgsVectorFileWriter.WriterError.NoError:
+        raise RuntimeError(
+            'Could not save geopackage. Error code: %s' % writer_error)
 
 
 proj_def_svi_calc_first_round = {

--- a/svir/test/unit/test_calculate_indices.py
+++ b/svir/test/unit/test_calculate_indices.py
@@ -325,10 +325,7 @@ class CalculateCompositeVariableTestCase(unittest.TestCase):
             write_output(self.layer, self.data_dir_name, res_layer_name)
 
         _, out_layer_path = tempfile.mkstemp(suffix='.gpkg')
-        writer_error = save_layer_as(self.layer, out_layer_path, 'GPKG')
-        if writer_error != QgsVectorFileWriter.WriterError.NoError:
-            raise RuntimeError(
-                'Could not save geopackage. Error code: %s' % writer_error)
+        save_layer_as(self.layer, out_layer_path, 'GPKG')
         out_layer = QgsVectorLayer(
             out_layer_path, 'svi_calculation_first_round', 'ogr')
 
@@ -359,10 +356,7 @@ class CalculateCompositeVariableTestCase(unittest.TestCase):
         self.assertEqual(proj_def, proj_def_svi_calc_first_round)
 
         _, out_layer_path = tempfile.mkstemp(suffix='.gpkg')
-        writer_error = save_layer_as(self.layer, out_layer_path, 'GPKG')
-        if writer_error != QgsVectorFileWriter.WriterError.NoError:
-            raise RuntimeError(
-                'Could not save geopackage. Error code: %s' % writer_error)
+        save_layer_as(self.layer, out_layer_path, 'GPKG')
         out_layer = QgsVectorLayer(
             out_layer_path, 'svi_calculation_second_round', 'ogr')
 
@@ -394,11 +388,7 @@ def calculate_education_node(proj_def, operator, layer):
 
 def write_output(res_layer, data_dir_name, res_layer_name):
     res_layer_path = os.path.join(data_dir_name, res_layer_name + '.gpkg')
-    writer_error = save_layer_as(
-        res_layer, res_layer_path, 'GPKG')
-    if writer_error != QgsVectorFileWriter.WriterError.NoError:
-        raise RuntimeError(
-            'Could not save geopackage. Error code: %s' % writer_error)
+    save_layer_as(res_layer, res_layer_path, 'GPKG')
 
 
 proj_def_svi_calc_first_round = {

--- a/svir/thread_worker/upload_worker.py
+++ b/svir/thread_worker/upload_worker.py
@@ -26,7 +26,7 @@ from __future__ import print_function
 import os
 import shutil
 import json
-from qgis.core import QgsCoordinateReferenceSystem
+from qgis.core import QgsCoordinateReferenceSystem, QgsVectorFileWriter
 
 from svir.thread_worker.abstract_worker import AbstractWorker
 from svir.utilities.utils import (
@@ -70,15 +70,14 @@ class UploadWorker(AbstractWorker):
             # we need to build a shapefile from it
             self.set_message.emit(tr(
                 'Writing the shapefile to be uploaded...'))
-            writer_error, error_msg = save_layer_as(
+            writer_error = save_layer_as(
                 self.current_layer, data_file,
                 'ESRI Shapefile',
                 crs=QgsCoordinateReferenceSystem(
                     4326, QgsCoordinateReferenceSystem.EpsgCrsId))
-            if writer_error:
+            if writer_error != QgsVectorFileWriter.WriterError.NoError:
                 raise RuntimeError(
-                    'Could not save shapefile. %s: %s' % (writer_error,
-                                                          error_msg))
+                    'Could not save shapefile. Error code: %s' % writer_error)
         file_size_mb = os.path.getsize(data_file)
         file_size_mb += os.path.getsize(self.file_stem + '.shx')
         file_size_mb += os.path.getsize(self.file_stem + '.dbf')

--- a/svir/thread_worker/upload_worker.py
+++ b/svir/thread_worker/upload_worker.py
@@ -70,14 +70,11 @@ class UploadWorker(AbstractWorker):
             # we need to build a shapefile from it
             self.set_message.emit(tr(
                 'Writing the shapefile to be uploaded...'))
-            writer_error = save_layer_as(
+            save_layer_as(
                 self.current_layer, data_file,
                 'ESRI Shapefile',
                 crs=QgsCoordinateReferenceSystem(
                     4326, QgsCoordinateReferenceSystem.EpsgCrsId))
-            if writer_error != QgsVectorFileWriter.WriterError.NoError:
-                raise RuntimeError(
-                    'Could not save shapefile. Error code: %s' % writer_error)
         file_size_mb = os.path.getsize(data_file)
         file_size_mb += os.path.getsize(self.file_stem + '.shx')
         file_size_mb += os.path.getsize(self.file_stem + '.dbf')

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1064,13 +1064,13 @@ def import_layer_from_csv(parent,
 
 def check_writer_error(writer_error):
     if hasattr(QgsVectorFileWriter.WriterError, 'NoError'):
-        if writer_error != QgsVectorFileWriter.WriterError.NoError:
+        if writer_error[0] != QgsVectorFileWriter.WriterError.NoError:
             raise RuntimeError(
-                'Could not save layer. Error code: %s' % writer_error)
+                'Could not save layer. %s: %s' % writer_error[:2])
     else:
-        if writer_error:
+        if writer_error[0] != 0:
             raise RuntimeError(
-                'Could not save layer. %s: %s' % writer_error)
+                'Could not save layer. %s: %s' % writer_error[:2])
 
 
 def listdir_fullpath(path):

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -860,7 +860,7 @@ def save_layer_as(orig_layer, dest_path, save_format, crs=None):
         ctc = QgsCoordinateTransformContext()
         if crs is not None:
             ctc.addCoordinateOperation(orig_layer.crs(), crs, 'proj')
-        writer_error = QgsVectorFileWriter.writeAsVectorFormatV2(
+        writer_error = QgsVectorFileWriter.writeAsVectorFormatV3(
             orig_layer, dest_path, ctc, options)
     locale.setlocale(locale.LC_NUMERIC, old_lc_numeric)
     return writer_error

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1063,6 +1063,12 @@ def import_layer_from_csv(parent,
 
 
 def check_writer_error(writer_error):
+    # NOTE: depending on the QGIS version, writer_error has a different number
+    # of elements (in newer versions, some additional information like the path
+    # of saved data is added). However, the first 2 elements are the always the
+    # error code and the error message (that might be empty in case of
+    # success). The enum specifying the NoError code was not present in old
+    # QGIS versions.
     if hasattr(QgsVectorFileWriter.WriterError, 'NoError'):
         if writer_error[0] != QgsVectorFileWriter.WriterError.NoError:
             raise RuntimeError(

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -860,8 +860,12 @@ def save_layer_as(orig_layer, dest_path, save_format, crs=None):
         ctc = QgsCoordinateTransformContext()
         if crs is not None:
             ctc.addCoordinateOperation(orig_layer.crs(), crs, 'proj')
-        writer_error = QgsVectorFileWriter.writeAsVectorFormatV3(
-            orig_layer, dest_path, ctc, options)
+        if Qgis.QGIS_VERSION_INT < 32000:
+            writer_error = QgsVectorFileWriter.writeAsVectorFormatV2(
+                orig_layer, dest_path, ctc, options)
+        else:
+            writer_error = QgsVectorFileWriter.writeAsVectorFormatV3(
+                orig_layer, dest_path, ctc, options)
     locale.setlocale(locale.LC_NUMERIC, old_lc_numeric)
     return writer_error
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1046,8 +1046,9 @@ def import_layer_from_csv(parent,
             return
         writer_error = save_layer_as(
             layer, dest_filename, save_format)
-        if writer_error != QgsVectorFileWriter.NoError:
-            raise RuntimeError('Could not save layer: %s' % writer_error)
+        if writer_error != QgsVectorFileWriter.WriterError.NoError:
+            raise RuntimeError(
+                'Could not save layer. Error code: %s' % writer_error)
         layer = QgsVectorLayer(dest_filename, layer_name, 'ogr')
     if layer.isValid():
         if add_to_legend:

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -867,7 +867,7 @@ def save_layer_as(orig_layer, dest_path, save_format, crs=None):
             writer_error = QgsVectorFileWriter.writeAsVectorFormatV3(
                 orig_layer, dest_path, ctc, options)
     locale.setlocale(locale.LC_NUMERIC, old_lc_numeric)
-    return writer_error
+    check_writer_error(writer_error)
 
 
 def _check_type(
@@ -1044,11 +1044,7 @@ def import_layer_from_csv(parent,
                 dest_filename += fmt
         else:
             return
-        writer_error = save_layer_as(
-            layer, dest_filename, save_format)
-        if writer_error != QgsVectorFileWriter.WriterError.NoError:
-            raise RuntimeError(
-                'Could not save layer. Error code: %s' % writer_error)
+        save_layer_as(layer, dest_filename, save_format)
         layer = QgsVectorLayer(dest_filename, layer_name, 'ogr')
     if layer.isValid():
         if add_to_legend:
@@ -1064,6 +1060,17 @@ def import_layer_from_csv(parent,
     else:
         raise RuntimeError('Unable to load layer')
     return layer
+
+
+def check_writer_error(writer_error):
+    if hasattr(QgsVectorFileWriter.WriterError, 'NoError'):
+        if writer_error != QgsVectorFileWriter.WriterError.NoError:
+            raise RuntimeError(
+                'Could not save layer. Error code: %s' % writer_error)
+    else:
+        if writer_error:
+            raise RuntimeError(
+                'Could not save layer. %s: %s' % writer_error)
 
 
 def listdir_fullpath(path):

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1044,12 +1044,10 @@ def import_layer_from_csv(parent,
                 dest_filename += fmt
         else:
             return
-        writer_error, error_msg = save_layer_as(
+        writer_error = save_layer_as(
             layer, dest_filename, save_format)
-        if writer_error:
-            raise RuntimeError(
-                'Could not save layer. %s: %s' % (writer_error,
-                                                  error_msg))
+        if writer_error != QgsVectorFileWriter.NoError:
+            raise RuntimeError('Could not save layer: %s' % writer_error)
         layer = QgsVectorLayer(dest_filename, layer_name, 'ogr')
     if layer.isValid():
         if add_to_legend:


### PR DESCRIPTION
The change between V2 and V3 seems to be all internal to QGIS, whereas V2 changed the required parameters with respect to the previous version. However, the return value seems to be in a different format, so it is more complicated than it looked like initially.

Fixes https://github.com/gem/oq-irmt-qgis/issues/784