### PR TITLE
Raise an error if Pillow is missing when loading the plugin

### DIFF
--- a/svir/__init__.py
+++ b/svir/__init__.py
@@ -51,3 +51,11 @@ except ImportError:
     IS_MATPLOTLIB_INSTALLED = False
 else:
     IS_MATPLOTLIB_INSTALLED = True
+
+IS_PILLOW_INSTALLED = None
+try:
+    import PIL  # NOQA
+except ImportError:
+    IS_PILLOW_INSTALLED = False
+else:
+    IS_PILLOW_INSTALLED = True

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -56,7 +56,7 @@ from svir.utilities.shared import (
 from svir.utilities.utils import (get_ui_class,
                                   log_msg,
                                   clear_widgets_from_layout,
-                                  warn_missing_package,
+                                  warn_missing_packages,
                                   extract_npz,
                                   get_loss_types,
                                   get_irmt_version,
@@ -708,7 +708,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self.refresh_feature_selection)
         elif new_output_type == 'recovery_curves':
             if not IS_SCIPY_INSTALLED:
-                warn_missing_package('scipy', self.iface.messageBar())
+                warn_missing_packages(['scipy'], self.iface.messageBar())
                 self.output_type = None
                 return
             self.create_approach_selector()

--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -93,7 +93,7 @@ from svir.utilities.utils import (tr,
                                   save_layer_as,
                                   get_style,
                                   get_checksum,
-                                  warn_missing_package,
+                                  warn_missing_packages,
                                   import_layer_from_csv,
                                   )
 from svir.utilities.shared import (DEBUG,
@@ -109,13 +109,19 @@ from svir.processing_provider.provider import Provider
 # noinspection PyUnresolvedReferences
 import svir.resources_rc  # pylint: disable=unused-import  # NOQA
 
-from svir import IS_SCIPY_INSTALLED, IS_MATPLOTLIB_INSTALLED
+from svir import (
+    IS_SCIPY_INSTALLED, IS_MATPLOTLIB_INSTALLED, IS_PILLOW_INSTALLED)
 
 
 class Irmt(object):
     def __init__(self, iface):
+        missing_packages = []
         if not IS_MATPLOTLIB_INSTALLED:
-            warn_missing_package('matplotlib')
+            missing_packages.append('matplotlib')
+        if not IS_PILLOW_INSTALLED:
+            missing_packages.append('Pillow')
+        if missing_packages:
+            warn_missing_packages(missing_packages)
             return
 
         # Save reference to the QGIS interface
@@ -189,7 +195,7 @@ class Irmt(object):
         QgsApplication.processingRegistry().addProvider(self.provider)
 
     def initGui(self):
-        if not IS_MATPLOTLIB_INSTALLED:
+        if not IS_MATPLOTLIB_INSTALLED or not IS_PILLOW_INSTALLED:
             # the warning should have already been displayed by the __init__
             return
         self.initProcessing()
@@ -354,7 +360,7 @@ class Irmt(object):
             dlg = RecoveryModelingDialog(self.iface)
             dlg.exec_()
         else:
-            warn_missing_package('scipy', self.iface.messageBar())
+            warn_missing_packages(['scipy'], self.iface.messageBar())
 
     def recovery_settings(self):
         dlg = RecoverySettingsDialog(self.iface)
@@ -595,7 +601,7 @@ class Irmt(object):
         """
         Remove all plugin's actions and corresponding buttons and connects
         """
-        if not IS_MATPLOTLIB_INSTALLED:
+        if not IS_MATPLOTLIB_INSTALLED or not IS_PILLOW_INSTALLED:
             return
         # stop any running timers
         if self.drive_oq_engine_server_dlg is not None:

--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -34,14 +34,14 @@ from svir.utilities.utils import (
                                   clear_progress_message_bar,
                                   get_layer_setting,
                                   WaitCursorManager,
-                                  warn_missing_package,
+                                  warn_missing_packages,
                                   )
 from svir.utilities.shared import NUMERIC_FIELD_TYPES, RECOVERY_DEFAULTS
 
 try:
     import matplotlib
 except ImportError:
-    warn_missing_package('matplotlib')
+    warn_missing_packages(['matplotlib'])
 matplotlib.use('Qt5Agg')
 import matplotlib.pyplot as plt  # NOQA
 

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1131,13 +1131,14 @@ def get_params_from_comment_line(comment_line):
     return params_dict
 
 
-def warn_missing_package(package_name, message_bar=None):
+def warn_missing_packages(package_names, message_bar=None):
     if message_bar is None:
         message_bar = iface.messageBar()
-    msg = ("%s (for Python3) is required."
+    msg = ("Packages %s (for Python3) are required."
            " Please follow the instructions in the user manual of the plugin"
            " (see https://docs.openquake.org/oq-irmt-qgis/)"
-           " to install %s, then restart QGIS." % (package_name, package_name))
+           " to install the missing dependencies, then restart QGIS."
+           % package_names)
     log_msg(msg, level='C', message_bar=message_bar)
 
 


### PR DESCRIPTION
We already had a clear error message in case other packages were missing. We are doing the same for `Pillow`, which is never explicitly used by the plugin, but it required anyway.