### PR TITLE
Read 'lon' and 'lat' from 'row' using field names instead of positionally as first and second item

### DIFF
--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -256,7 +256,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
                         value = value.decode('utf8')
                     feat.setAttribute(layer_field_name, value)
                 feat.setGeometry(QgsGeometry.fromPointXY(
-                    QgsPointXY(row[0], row[1])))
+                    QgsPointXY(row['lon'], row['lat'])))
                 feats.append(feat)
             added_ok = self.layer.addFeatures(feats)
             if not added_ok:

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -65,7 +65,7 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
     def populate_dataset(self):
         self.rlzs_or_stats = [
             key for key in sorted(self.npz_file['all'].dtype.names)
-            if key not in ('lon', 'lat')]
+            if key not in ('custom_site_id', 'lon', 'lat')]
         self.dataset = self.npz_file['all']
         self.poes = self.dataset[self.rlzs_or_stats[0]].dtype.names
         self.poe_cbx.clear()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.14.2
+    * Ground motion fields are read identifying site coordinates through field names instead of positionally, making it robust to the addition of fields such as 'custom_site_id'
     * A clearer error message is given if Pillow is missing when loading the plugin
     * If any hazard curve is flat with all zeros values, a warning is displayed and the curve is excluded from the plot. If no hazard curve can be plotted, the plot is reset.
     3.14.1


### PR DESCRIPTION
Fixes reading GMFs when 'custom-site-id' is present as first column.