### PR TITLE
Improve makefile

### DIFF
--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -x
           docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make doc"
+          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -x
           docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make latexpdf; make html"
+          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir/help; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_latest.yml
+++ b/.github/workflows/qgis_latest.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -x
           docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make latexpdf; make html"
+          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir/help; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_latest.yml
+++ b/.github/workflows/qgis_latest.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -x
           docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make doc"
+          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_ltr.yml
+++ b/.github/workflows/qgis_ltr.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -x
           docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make doc"
+          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_ltr.yml
+++ b/.github/workflows/qgis_ltr.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -x
           docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir; make latexpdf; make html"
+          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir/help; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/README.md
+++ b/README.md
@@ -71,11 +71,6 @@ Some users reported issues about `upgrading` the plugin to its latest version.
 We recommend to `reinstall` the plugin instead, in order to make sure the new installation is
 done in a clean folder.
 
-## Mirror
-
-A mirror of this repository, hosted in Pavia (Italy), is available at
-[https://mirror.openquake.org/git/GEM/oq-irmt-qgis.git](https://mirror.openquake.org/git/GEM/oq-irmt-qgis.git).
-
 ## User manual
 
 The user manual for each of the released versions of this plugin is available

--- a/scripts/doc_upload.sh
+++ b/scripts/doc_upload.sh
@@ -1,5 +1,3 @@
-set -x
-
 EXPERIMENTAL=$(grep 'experimental=' ../svir/metadata.txt | cut -d '=' -f 2)
 if [$EXPERIMENTAL == True]
 then

--- a/scripts/doc_upload.sh
+++ b/scripts/doc_upload.sh
@@ -1,9 +1,27 @@
-USER=docs
-HOST=$USER@docs.openquake.org
-HOST_PATH="~/oq-irmt-qgis/$VERSION"
-if ["$GEM_QGIS_DOCS" != ""]; then
-    # path of ssh key must be referred to oq-irmt-qgis root
-    SSH_KEY="-i ../$GEM_QGIS_DOCS"
+set -x
+
+EXPERIMENTAL=$(grep 'experimental=' ../svir/metadata.txt | cut -d '=' -f 2)
+if [$EXPERIMENTAL == True]
+then
+    BUILD=latest
+else
+    BUILD=LTS
 fi
+echo BUILD=$BUILD
+
+VERSION="v$(grep 'version=' ../svir/metadata.txt | cut -d '=' -f 2)"
+echo VERSION=$VERSION
+
+USER=docs
+HOST=$USER@docs.gem.lan
+BASE_PATH="~/oq-irmt-qgis"
+HOST_PATH="$BASE_PATH/$VERSION"
+# If user is ptormene don't need other keys
+#if ["$GEM_QGIS_DOCS" != ""]; then
+#    # path of ssh key must be referred to oq-irmt-qgis root
+#    SSH_KEY="-i ../$GEM_QGIS_DOCS"
+#fi
 ssh $SSH_KEY $HOST 'mkdir -p ' $HOST_PATH
 scp $SSH_KEY -r ../svir/help/build/html/* $HOST:$HOST_PATH
+
+ssh $SSH_KEY $HOST "bash -cx 'cd ${BASE_PATH}; ln -snf \"$VERSION\" $BUILD'"

--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-/usr/bin/docker rm -f qgis || true
+docker rm -f qgis || true
 docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/oq-irmt-qgis \
  -e DISPLAY=:99 \
@@ -10,5 +10,4 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
 
 docker exec -it qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
 
-# docker exec -it qgis sh -c "export PYTHONPATH=$PYTHONPATH:/oq-irmt-qgis; cd /oq-irmt-qgis/svir; make doc"
 docker exec -it qgis sh -c "export PYTHONPATH=$PYTHONPATH:/oq-irmt-qgis; cd /oq-irmt-qgis/svir/help; make latexpdf; make html"

--- a/scripts/make_doc.sh
+++ b/scripts/make_doc.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-docker rm -f qgis || true
+/usr/bin/docker rm -f qgis || true
 docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
  -v `pwd`/../.:/oq-irmt-qgis \
  -e DISPLAY=:99 \
@@ -10,4 +10,5 @@ docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix \
 
 docker exec -it qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
 
-docker exec -it qgis sh -c "export PYTHONPATH=$PYTHONPATH:/oq-irmt-qgis; cd /oq-irmt-qgis/svir; make doc"
+# docker exec -it qgis sh -c "export PYTHONPATH=$PYTHONPATH:/oq-irmt-qgis; cd /oq-irmt-qgis/svir; make doc"
+docker exec -it qgis sh -c "export PYTHONPATH=$PYTHONPATH:/oq-irmt-qgis; cd /oq-irmt-qgis/svir/help; make latexpdf; make html"

--- a/svir/Makefile
+++ b/svir/Makefile
@@ -198,21 +198,27 @@ clean:
 # build documentation with sphinx
 doc: build_manual  # build_apidoc
 
-build_manual: build_manual_latex build_manual_html
-
-build_manual_html:
+build_manual: # build_manual_latex build_manual_html
+# build_manual:
 	@echo
-	@echo "-------------------------------------------------"
-	@echo "Building html version of the manual using sphinx."
-	@echo "-------------------------------------------------"
-	cd help; make html
+	@echo "---------------------------------------"
+	@echo "Building the manual inside QGIS docker."
+	@echo "---------------------------------------"
+	cd ../scripts; ./make_doc.sh
 
-build_manual_latex:
-	@echo
-	@echo "----------------------------------------------------------"
-	@echo "Building pdf version of the manual using sphinx and latex."
-	@echo "----------------------------------------------------------"
-	cd help; make latexpdf
+# build_manual_html:
+# 	@echo
+# 	@echo "-------------------------------------------------"
+# 	@echo "Building html version of the manual using sphinx."
+# 	@echo "-------------------------------------------------"
+# 	cd help; make html
+
+# build_manual_latex:
+# 	@echo
+# 	@echo "----------------------------------------------------------"
+# 	@echo "Building pdf version of the manual using sphinx and latex."
+# 	@echo "----------------------------------------------------------"
+# 	cd help; make latexpdf
 
 build_apidoc:
 	@echo

--- a/svir/Makefile
+++ b/svir/Makefile
@@ -41,7 +41,7 @@ PLUGIN_UPLOAD = ../scripts/plugin_upload.py
 QGISDIR=.qgis2
 
 ifndef VERSION
-	VERSION=HEAD
+	VERSION="v$(shell grep 'version=' metadata.txt | cut -d '=' -f 2)"
 endif
 
 default: compile
@@ -117,8 +117,8 @@ package: compile doc
 	rm -f $(PLUGINNAME)/$(PLUGINNAME).zip
 	git archive --prefix=$(PLUGINNAME)/ -o $(PLUGINNAME).zip $(VERSION)
 	# to save more space, we can use /ebook instead of /printer (but it would reduce the resolution of images)
-	gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -dNOPAUSE -dQUIET -dBATCH -sOutputFile=help/build/html/_downloads/resized-irmt.pdf help/build/latex/irmt.pdf;
-	mv -f help/build/html/_downloads/resized-irmt.pdf help/build/html/_downloads/irmt.pdf
+	gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -dNOPAUSE -dQUIET -dBATCH -sOutputFile=resized-irmt.pdf help/build/latex/irmt.pdf
+	mv -f resized-irmt.pdf $(shell ls -d help/build/html/_downloads/*/)irmt.pdf
 	mkdir -p $(PLUGINNAME)/help/build; rm -r $(PLUGINNAME)/help/build/html; cp -r help/build/html $(PLUGINNAME)/help/build/html;
 	# mkdir -p $(PLUGINNAME)/apidoc/_build; rm -r $(PLUGINNAME)/apidoc/_build/html; cp -r apidoc/_build/html $(PLUGINNAME)/apidoc/_build/html
 	zip -r $(PLUGINNAME).zip $(PLUGINNAME)/help/build/html
@@ -199,12 +199,12 @@ clean:
 doc: build_manual  # build_apidoc
 
 build_manual: # build_manual_latex build_manual_html
-# build_manual:
 	@echo
 	@echo "---------------------------------------"
 	@echo "Building the manual inside QGIS docker."
 	@echo "---------------------------------------"
 	cd ../scripts; ./make_doc.sh
+	sudo chown -R $(USER) help/build/
 
 # build_manual_html:
 # 	@echo

--- a/svir/Makefile
+++ b/svir/Makefile
@@ -145,10 +145,6 @@ upload_plugin: package tag
 	$(PLUGIN_UPLOAD) $(PLUGINNAME).zip
 
 tag:
-ifndef NEW_VERSION
-	$(error NEW_VERSION is not defined)
-endif
-	$(eval VERSION := $(NEW_VERSION))
 	@echo
 	@echo "------------------------------------------------"
 	@echo "Tagging version $(VERSION).                   "

--- a/svir/Makefile
+++ b/svir/Makefile
@@ -115,9 +115,10 @@ package: compile doc
 	@echo "Exporting plugin to zip package.	"
 	@echo "------------------------------------"
 	rm -f $(PLUGINNAME)/$(PLUGINNAME).zip
-	git archive --prefix=$(PLUGINNAME)/ -o $(PLUGINNAME).zip $(VERSION)
+	git archive --prefix=$(PLUGINNAME)/ -o $(PLUGINNAME).zip HEAD
 	# to save more space, we can use /ebook instead of /printer (but it would reduce the resolution of images)
 	gs -sDEVICE=pdfwrite -dCompatibilityLevel=1.4 -dPDFSETTINGS=/printer -dNOPAUSE -dQUIET -dBATCH -sOutputFile=resized-irmt.pdf help/build/latex/irmt.pdf
+	# NOTE: assuming that _downloads contains a single folder with a unique name (otherwise you must identify the right folder and delete the others manually)
 	mv -f resized-irmt.pdf $(shell ls -d help/build/html/_downloads/*/)irmt.pdf
 	mkdir -p $(PLUGINNAME)/help/build; rm -r $(PLUGINNAME)/help/build/html; cp -r help/build/html $(PLUGINNAME)/help/build/html;
 	# mkdir -p $(PLUGINNAME)/apidoc/_build; rm -r $(PLUGINNAME)/apidoc/_build/html; cp -r apidoc/_build/html $(PLUGINNAME)/apidoc/_build/html
@@ -128,7 +129,7 @@ package: compile doc
 	echo "Created package: $(PLUGINNAME).zip"
 
 package_no_compile:
-	git archive --prefix=$(PLUGINNAME)/ -o $(PLUGINNAME).zip $(VERSION)
+	git archive --prefix=$(PLUGINNAME)/ -o $(PLUGINNAME).zip HEAD
 
 upload_doc: doc
 	@echo
@@ -194,27 +195,15 @@ clean:
 # build documentation with sphinx
 doc: build_manual  # build_apidoc
 
-build_manual: # build_manual_latex build_manual_html
+build_manual:
 	@echo
 	@echo "---------------------------------------"
 	@echo "Building the manual inside QGIS docker."
 	@echo "---------------------------------------"
 	cd ../scripts; ./make_doc.sh
+	# NOTE: it would be better if we could let the docker create files owned by
+	#       the user launching the script instead of making them owned by root
 	sudo chown -R $(USER) help/build/
-
-# build_manual_html:
-# 	@echo
-# 	@echo "-------------------------------------------------"
-# 	@echo "Building html version of the manual using sphinx."
-# 	@echo "-------------------------------------------------"
-# 	cd help; make html
-
-# build_manual_latex:
-# 	@echo
-# 	@echo "----------------------------------------------------------"
-# 	@echo "Building pdf version of the manual using sphinx and latex."
-# 	@echo "----------------------------------------------------------"
-# 	cd help; make latexpdf
 
 build_apidoc:
 	@echo

--- a/svir/help/source/00_installation.rst
+++ b/svir/help/source/00_installation.rst
@@ -55,13 +55,6 @@ We recommend to `reinstall` the plugin instead, in order to make sure the new in
 done in a clean folder.
 
 
-Mirror
-======
-
-A mirror of this repository, hosted in Pavia (Italy), is available at
-`https://mirror.openquake.org/git/GEM/oq-irmt-qgis.git <https://mirror.openquake.org/git/GEM/oq-irmt-qgis.git>`_.
-
-
 How to run tests and build the documentation
 ============================================
 

--- a/svir/help/source/14_driving_the_oqengine.rst
+++ b/svir/help/source/14_driving_the_oqengine.rst
@@ -110,26 +110,6 @@ processing toolbox, called "Join attributes by location (summary)".
              then do the same on the target persistent layer and select
              :guilabel:`Styles -> Paste Style`.
 
-It is also possible to download the HDF5 datastore corresponding to a chosen
-calculation. When the :guilabel:`Outputs` button is pressed, the
-:guilabel:`Download HDF5 datastore for calculation N` button is enabled (where
-`N` is the calculation ID). By pressing it and selecting a destination folder,
-the file is downloaded and its full path is displayed both in the QGIS message
-bar and in the :guilabel:`Log Messages Panel`.
-
-Another button that becomes available when a calculation identified as `N`
-is selected is :guilabel:`Show parameters of calculation N`. It opens a dialog
-window with a text area displaying the parameters of the calculation
-(see :ref:`fig-calculation-parameters`).
-
-.. _fig-calculation-parameters:
-
-.. figure:: images/calculationParameters.png
-    :align: center
-    :scale: 60%
-
-    Example showing parameters of a OQ-Engine calculation
-
 A hazard map defines the geographic distribution of the values of a scalar IMT
 (see also :ref:`chap-definitions`) characterized by a fixed probability of
 being exceeded at least once in a time span T. For computing a hazard map with
@@ -164,6 +144,27 @@ visualized in the OpenQuake IRMT Data Viewer (see :ref:`chap-viewer-dock`).
     :scale: 60%
 
     Example of a hazard map produced by the OpenQuake Engine
+
+It is also possible to download the HDF5 datastore corresponding to a chosen
+calculation. When the :guilabel:`Outputs` button is pressed, the
+:guilabel:`Download HDF5 datastore for calculation N` button is enabled (where
+`N` is the calculation ID). By pressing it and selecting a destination folder,
+the file is downloaded and its full path is displayed both in the QGIS message
+bar and in the :guilabel:`Log Messages Panel`.
+
+Another button that becomes available when a calculation identified as `N`
+is selected is :guilabel:`Show parameters of calculation N`. It opens a dialog
+window with a text area displaying the parameters of the calculation
+(see :ref:`fig-calculation-parameters`).
+
+.. _fig-calculation-parameters:
+
+.. figure:: images/calculationParameters.png
+    :align: center
+    :scale: 60%
+
+    Example showing parameters of a OQ-Engine calculation
+
 
 
 Run a postprocessing (or risk) calculation on top of a previously computed hazard

--- a/svir/help/source/15_viewer_dock.rst
+++ b/svir/help/source/15_viewer_dock.rst
@@ -37,7 +37,7 @@ the `user manual of the OpenQuake Engine <https://docs.openquake.org/oq-engine/s
 In :ref:`chap-drive-oq-engine` (:ref:`fig-hazard-map`) you can see an example of a hazard map loaded by the
 plugin into a QGIS vector layer. In that case the IRMT Data Viewer is
 not needed to display the data. Other kinds of outputs, such as hazard curves, can not
-be displayed in a map as QGIS layers. The IRMT Data Viewer has the purpose to display
+be displayed in a map as QGIS layers. The IRMT Data Viewer has the purpose of displaying
 multi-dimensional data in an interactive way, linking the selection of sites in the map canvas
 to the plotting of corresponding curves.
 

--- a/svir/help/source/15_viewer_dock.rst
+++ b/svir/help/source/15_viewer_dock.rst
@@ -30,9 +30,16 @@ Visulalizing outputs of hazard calculations
 ===========================================
 
 This section describes how to drive the user interface of the plugin to visualize
+in the IRMT Data Viewer
 some of the hazard outputs produced by OpenQuake Engine calculations. For an extensive
 explanation of those outputs, please refer to
 the `user manual of the OpenQuake Engine <https://docs.openquake.org/oq-engine/stable/>`_.
+In :ref:`chap-drive-oq-engine` (:ref:`fig-hazard-map`) you can see an example of a hazard map loaded by the
+plugin into a QGIS vector layer. In that case the IRMT Data Viewer is
+not needed to display the data. Other kinds of outputs, such as hazard curves, can not
+be displayed in a map as QGIS layers. The IRMT Data Viewer has the purpose to display
+multi-dimensional data in an interactive way, linking the selection of sites in the map canvas
+to the plotting of corresponding curves.
 
 
 Visualizing hazard curves

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.11.7
+version=3.11.8
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.11.8
+    * The user manual is built via docker and the makefile was improved to retrieve plugin version and experimental tag from metadata and update the online documentation accordingly
     3.11.7
     * (backported) Accepting also taxonomies that include the character '='
     3.11.6


### PR DESCRIPTION
Improvements:

- the documentation is built using a docker containing all the necessary dependencies
- the version is read from metadata instead of setting an environmental variable manually
- the documentation is set as LTS or latest depending on the 'experimental' flag read from metadata

To be checked by @vot4anto:

- the docker builds the documentation setting all files as owned by root, so it's not possible to edit the pdf of the manual afterwards without updating permissions with sudo. Is there a better way to do this?

NOTE: integration tests fail because this is aligned with Engine 3.11, but tests are versus Engine master