### PR TITLE
Make Pillow not strictly required to install the plugin

### DIFF
--- a/svir/irmt.py
+++ b/svir/irmt.py
@@ -122,6 +122,7 @@ class Irmt(object):
             missing_packages.append('Pillow')
         if missing_packages:
             warn_missing_packages(missing_packages)
+        if not IS_MATPLOTLIB_INSTALLED:
             return
 
         # Save reference to the QGIS interface
@@ -195,7 +196,7 @@ class Irmt(object):
         QgsApplication.processingRegistry().addProvider(self.provider)
 
     def initGui(self):
-        if not IS_MATPLOTLIB_INSTALLED or not IS_PILLOW_INSTALLED:
+        if not IS_MATPLOTLIB_INSTALLED:
             # the warning should have already been displayed by the __init__
             return
         self.initProcessing()
@@ -329,7 +330,8 @@ class Irmt(object):
                            enable=True,
                            add_to_toolbar=True)
 
-        self._create_viewer_dock()
+        if IS_MATPLOTLIB_INSTALLED:
+            self._create_viewer_dock()
 
         # Action to open the plugin's manual
         self.add_menu_item("help",
@@ -601,7 +603,7 @@ class Irmt(object):
         """
         Remove all plugin's actions and corresponding buttons and connects
         """
-        if not IS_MATPLOTLIB_INSTALLED or not IS_PILLOW_INSTALLED:
+        if not IS_MATPLOTLIB_INSTALLED:
             return
         # stop any running timers
         if self.drive_oq_engine_server_dlg is not None:

--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -34,16 +34,14 @@ from svir.utilities.utils import (
                                   clear_progress_message_bar,
                                   get_layer_setting,
                                   WaitCursorManager,
-                                  warn_missing_packages,
                                   )
 from svir.utilities.shared import NUMERIC_FIELD_TYPES, RECOVERY_DEFAULTS
+from svir import IS_MATPLOTLIB_INSTALLED
 
-try:
+if IS_MATPLOTLIB_INSTALLED:
     import matplotlib
-except ImportError:
-    warn_missing_packages(['matplotlib'])
-matplotlib.use('Qt5Agg')
-import matplotlib.pyplot as plt  # NOQA
+    matplotlib.use('Qt5Agg')
+    import matplotlib.pyplot as plt  # NOQA
 
 DAYS_BEFORE_EVENT = 0
 MARGIN_DAYS_AFTER = 400


### PR DESCRIPTION
UPDATE (after checking with AE): On wksptormene, if pillow is removed and matplotlib is kept, matplotlib complains about PIL missing. Therefore we should probably only check matplotlib and ignore pillow.

Pillow is used only by the social vulnerability widget, so it might be ignored by most of our current OQ users.
Therefore, I am now allowing the plugin to be installed even if this dependency is missing.

NOTE: integration tests fail because this is aligned with Engine 3.11, but tests are versus Engine master