### PR TITLE
Fix visualization of OQ-Engine outputs needed for risk workshops

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -121,8 +121,11 @@ OUTPUT_TYPE_LOADERS = {
     'events': LoadCsvAsLayerDialog,
     'risk_by_event': LoadCsvAsLayerDialog,
     'aggrisk': LoadCsvAsLayerDialog,
+    'aggrisk-stats': LoadCsvAsLayerDialog,
     'agg_risk': LoadCsvAsLayerDialog,
     'damages-rlzs': LoadDamagesRlzsAsLayerDialog,
+    # NOTE: counterintuitive difference between damages-rlzs and damages-stats
+    'damages-stats': LoadCsvAsLayerDialog,
     'gmf_data': LoadGmfDataAsLayerDialog,
     'hmaps': LoadHazardMapsAsLayerDialog,
     'hcurves': LoadHazardCurvesAsLayerDialog,

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -124,7 +124,7 @@ OUTPUT_TYPE_LOADERS = {
     'aggrisk-stats': LoadCsvAsLayerDialog,
     'agg_risk': LoadCsvAsLayerDialog,
     'damages-rlzs': LoadDamagesRlzsAsLayerDialog,
-    # NOTE: counterintuitive difference between damages-rlzs and damages-stats
+    # NOTE: damages-rlzs and damages-stats are handled completely differently
     'damages-stats': LoadCsvAsLayerDialog,
     'gmf_data': LoadGmfDataAsLayerDialog,
     'hmaps': LoadHazardMapsAsLayerDialog,
@@ -861,12 +861,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 num_actions += 1
             max_actions = max(max_actions, num_actions)
 
-        # NOTE: avg_losses-rlzs must be handled as a special case:
-        #       if avg_losses-stats is available, avg_losses-rlzs should allow
-        #       only to download the csv, but should not allow 'Load layer' nor
-        #       'aggregate'. This is because the OQ engine extract api returns
-        #       rlzs only if stats are not available, otherwise it returns
-        #       stats even if rlzs are requested
+        # NOTE: if avg_losses-stats is available, avg_losses-rlzs should allow
+        #       only to download the csv. It should not allow 'Load layer' nor
+        #       'aggregate', becasue the OQ engine extract api returns rlzs
+        #       only if stats are not available, otherwise it returns stats
+        #       even if rlzs are requested
         output_types = [output['type'] for output in output_list]
 
         self.output_list_tbl.setRowCount(len(output_list))

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -885,7 +885,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             for col, outtype in enumerate(outtypes, len(selected_keys)):
                 # Additional buttons with respect to the webui
                 if (not load_action_button_was_added and
-                        not (output['type'] == 'aggcurves'
+                        not (output['type'] in ('aggcurves', 'aggcurves-stats')
                              and calculation_mode == 'event_based_damage') and
                         output['type'] in (OQ_TO_LAYER_TYPES |
                                            OQ_RST_TYPES |

--- a/svir/dialogs/load_csv_as_layer_dialog.py
+++ b/svir/dialogs/load_csv_as_layer_dialog.py
@@ -53,7 +53,15 @@ class LoadCsvAsLayerDialog(LoadOutputAsLayerDialog):
         # TODO: add a warning in case the file size exceeds a threshold
         # self.show()
         if self.ok_button.isEnabled():
-            self.accept()
+            if os.stat(self.path).st_size < 10485760:  # 10 MB
+                self.accept()
+            else:
+                lbl = self.file_size_lbl.text()
+                lbl += (f'\n\n{self.path} is bigger than 10 MB. Are you sure'
+                        f' you want to load it anyway?')
+                self.file_size_lbl.setText(lbl)
+                self.show()
+                self.adjustSize()
         else:
             self.show()
 

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -158,7 +158,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             ('', ''),
             ('hcurves', 'Hazard Curves'),
             ('uhs', 'Uniform Hazard Spectra'),
-            ('aggcurves', 'Aggregate loss curves'),
+            ('aggcurves', 'Aggregate loss curves (realizations)'),
             ('aggcurves-stats', 'Aggregate loss curves (statistics)'),
             ('damages-rlzs_aggr', 'Damage distribution'),
             ('avg_losses-rlzs_aggr', 'Loss distribution'),
@@ -929,7 +929,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.aggregate_by = None
         if 'aggregate_by' in oqparam and len(oqparam['aggregate_by']):
             self._build_tags()
-            self.aggregate_by = oqparam['aggregate_by']
+            self.aggregate_by = oqparam['aggregate_by'][0]
             for tag_name in self.aggregate_by:
                 tag_values = self.tags[tag_name]['values'].keys()
                 self.create_tag_values_selector(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1123,8 +1123,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         # TODO: re-add error bars when stddev will become available again
         # means = self.damages_rlzs_aggr['array'][rlz]['mean']
         # stddevs = self.damages_rlzs_aggr['array'][rlz]['stddev']
-        D = len(self.dmg_states)  # including 'no damage' (FIXME it should be
-                                  # called self.limit_states)
+
+        # including 'no damage' (FIXME it should be called self.limit_states)
+        D = len(self.dmg_states)
         means = self.damages_rlzs_aggr['array'][rlz][:D]
         if (means < 0).any():
             msg = ('The results displayed include negative damage estimates'
@@ -1163,8 +1164,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.plot.yaxis.grid()
         self.plot_canvas.draw()
         if self.consequences:
-            self.table.show()
-            consequences_array = self.damages_rlzs_aggr['array'][rlz]
+            consequences_array = self.damages_rlzs_aggr['array'][rlz][D:]
             nrows = 1
             ncols = len(self.consequences)
             self.table.setRowCount(nrows)
@@ -1182,6 +1182,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             # as a workaround (hack)
             self.table.resizeColumnsToContents()
             self.table.resizeRowsToContents()
+            self.table.show()
             # FIXME: the table occupies a lot of useless vertical space
 
     def _to_2d(self, array):
@@ -1998,7 +1999,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 csv_file.write(
                     "# Tags: %s\r\n" % (
                         self.get_list_selected_tags_str() or 'None'))
-                headers = self.dmg_states
+                headers = list(self.dmg_states)
+                if self.consequences:
+                    headers.extend(self.consequences)
                 writer.writerow(headers)
                 values = self.damages_rlzs_aggr[
                     'array'][self.rlz_cbx.currentIndex()]

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -681,7 +681,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.aggregate_by = None
         self.dmg_states = None
         self.exposure_metadata = None
-        self.current_selection = None
+        self.current_selection = {}
         self.was_imt_switched = None
         self.was_poe_switched = None
         self.was_loss_type_switched = None

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -637,13 +637,17 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 self.filter_agg_curves()
 
     def get_list_selected_tags_str(self):
+        selected_tags = {tag_name: self.tags[tag_name]['values']
+                         for tag_name in self.tags
+                         if self.tags[tag_name]['selected']}
         selected_tags_str = ''
-        if not hasattr(self, 'aggregate_by') or self.aggregate_by is None:
-            return selected_tags_str
-        for tag_name in self.aggregate_by:
-            for tag_value in self.tags[tag_name]['values']:
-                if self.tags[tag_name]['values'][tag_value]:
-                    selected_tags_str += '%s="%s" ' % (tag_name, tag_value)
+        for tag_name in selected_tags:
+            selected_tags_str += f'{tag_name}="'
+            tag_values = selected_tags[tag_name]
+            for tag_value in tag_values:
+                if tag_values[tag_value]:
+                    selected_tags_str += f'{tag_value}" '
+                    continue
         return selected_tags_str
 
     def refresh_feature_selection(self):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -673,7 +673,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
     def set_output_type_and_its_gui(self, new_output_type):
         self.rlzs = None
         self.stats = None
-        self.rlzs_or_stats = None
         self.selected_rlzs_or_stats = None
         self.consequences = None
         self.agg_curves = None
@@ -681,7 +680,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.aggregate_by = None
         self.dmg_states = None
         self.exposure_metadata = None
-        # self.current_selection = {}
         self.was_imt_switched = None
         self.was_poe_switched = None
         self.was_loss_type_switched = None

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1045,7 +1045,14 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         abscissa = self.agg_curves['return_period']
         rlzs_or_stats_idxs, tag_name_idxs, tag_value_idxs = \
             self._get_idxs(output_type)
-        ordinates = self.agg_curves['array']
+        try:
+            ordinates = self.agg_curves['array']
+        except KeyError:
+            msg = 'No data corresponds to the current selection'
+            log_msg(msg, level='W', message_bar=self.iface.messageBar(),
+                    duration=5)
+            self.clear_plot()
+            return
         loss_type_idx = self.loss_type_cbx.currentIndex()
         unit = self.agg_curves['units'][loss_type_idx]
         self.plot.clear()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -681,7 +681,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.aggregate_by = None
         self.dmg_states = None
         self.exposure_metadata = None
-        self.current_selection = {}
+        # self.current_selection = {}
         self.was_imt_switched = None
         self.was_poe_switched = None
         self.was_loss_type_switched = None

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -671,6 +671,21 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 delattr(self, widget_name)
 
     def set_output_type_and_its_gui(self, new_output_type):
+        self.rlzs = None
+        self.stats = None
+        self.rlzs_or_stats = None
+        self.selected_rlzs_or_stats = None
+        self.consequences = None
+        self.agg_curves = None
+        self.damages_rlzs_aggr = None
+        self.aggregate_by = None
+        self.dmg_states = None
+        self.exposure_metadata = None
+        self.current_selection = None
+        self.was_imt_switched = None
+        self.was_poe_switched = None
+        self.was_loss_type_switched = None
+
         # clear type dependent widgets
         # NOTE: typeDepVLayout contains typeDepHLayout1 and typeDepHLayout2,
         #       that will be cleared recursively
@@ -1167,6 +1182,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             consequences_array = self.damages_rlzs_aggr['array'][rlz][D:]
             nrows = 1
             ncols = len(self.consequences)
+            self.table.clear()
             self.table.setRowCount(nrows)
             self.table.setColumnCount(ncols)
             # FIXME: perhaps write measurement unit instead of total? If so,
@@ -1193,7 +1209,6 @@ class ViewerDock(QDockWidget, FORM_CLASS):
 
     def draw_avg_losses_rlzs_aggr(self):
         self.plot_canvas.hide()
-        self.table.show()
         losses_array = self.avg_losses_rlzs_aggr['array']
         losses_array = self._to_2d(losses_array)
         tags = None
@@ -1205,6 +1220,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             # NOTE: case without '*'
             pass
         nrows, ncols = losses_array.shape
+        self.table.clear()
         self.table.setRowCount(nrows)
         self.table.setColumnCount(ncols)
         if self.output_type == 'avg_losses-rlzs_aggr':
@@ -1242,6 +1258,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         # to fix it, so I am adding a tail of 2 spaces to each header as a
         # workaround (hack)
         self.table.resizeColumnsToContents()
+        self.table.show()
 
     def draw(self):
         self.plot.clear()

--- a/svir/help/source/15_viewer_dock.rst
+++ b/svir/help/source/15_viewer_dock.rst
@@ -26,7 +26,7 @@ modifying markers, labels, axes, zooming level and other parameters, saving the
 plot to file and exporting the selected curves into a csv format.
 
 
-Visulalizing outputs of hazard calculations
+Visualizing outputs of hazard calculations
 ===========================================
 
 This section describes how to drive the user interface of the plugin to visualize

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.15.2
+version=3.16.0
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,11 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.16.0
+    * For 'Asset Risk Distributions', also a table of consequences is shown if available
+    * The visualization of 'aggcurves' and 'aggcurves-stats' was updated according to changes in the OQ-Engine extract API
+    * The 'Load table' button was added also for OQ-Engine outputs 'damages-stats' and 'aggrisk-stats'
+ Disable Load layer and Aggregate buttons for avg_losses-rlzs in case avg_losses-stats is present
     3.15.2
     * The user manual is built via docker and the makefile was improved to retrieve plugin version and experimental tag from metadata and update the online documentation accordingly
     3.15.1
@@ -251,7 +256,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=True
+experimental=False
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.16.0
+version=3.15.3
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,7 +23,7 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    3.16.0
+    3.15.3
     * When exporting data from the Data Viewer, selected tags (if present) are correctly reported in the output csv
     * When loading a csv as layer, the user is asked to confirm in case the csv is bigger than 10 MB
     * For 'Asset Risk Distributions', also a table of consequences is shown if available
@@ -258,7 +258,7 @@ tracker=https://github.com/gem/oq-irmt-qgis/issues
 repository=https://github.com/gem/oq-irmt-qgis
 icon=resources/icon.svg
 # experimental flag
-experimental=False
+experimental=True
 
 # deprecated flag (applies to the whole plugin, not just a single version
 deprecated=False

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.16.0
+    * When loading a csv as layer, the user is asked to confirm in case the csv is bigger than 10 MB
     * For 'Asset Risk Distributions', also a table of consequences is shown if available
     * The visualization of 'aggcurves' and 'aggcurves-stats' was updated according to changes in the OQ-Engine extract API
     * The 'Load table' button was added also for OQ-Engine outputs 'damages-stats' and 'aggrisk-stats'

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.16.0
+    * When exporting data from the Data Viewer, selected tags (if present) are correctly reported in the output csv
     * When loading a csv as layer, the user is asked to confirm in case the csv is bigger than 10 MB
     * For 'Asset Risk Distributions', also a table of consequences is shown if available
     * The visualization of 'aggcurves' and 'aggcurves-stats' was updated according to changes in the OQ-Engine extract API

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -257,6 +257,7 @@ OQ_RST_TYPES = set([
 ])
 OQ_EXTRACT_TO_VIEW_TYPES = set([
      'aggcurves',
+     'aggcurves-stats',
      'damages-rlzs_aggr',
      'avg_losses-rlzs_aggr',
      'avg_losses-stats_aggr',

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -228,8 +228,10 @@ RECOVERY_DEFAULTS['n_recovery_based_dmg_states'] = len(
 
 
 OQ_CSV_TO_LAYER_TYPES = set([
+    'damages-stats',
     'agg_risk',
     'aggrisk',
+    'aggrisk-stats',
     'risk_by_event',
     'events',
     'realizations',


### PR DESCRIPTION
- [x] For Asset Risk Distributions, show also a table of consequences if they are available (fixes https://github.com/gem/oq-irmt-qgis/issues/808)
- [x] Fix visualization of aggcurves and aggcurves-stats (fixes https://github.com/gem/oq-irmt-qgis/issues/809)
- [x] Disable `Load layer` and `Aggregate` buttons for `avg_losses-rlzs` in case `avg_losses-stats` is present (because the engine, in case stats are available, does not extract rlzs)
- [x] Add `Load table` button for `damages-stats` and `aggrisk-stats` (it was easy to add them though not requested)
- [x] Warn the user (and ask for confirmation) in case the 'Load csv as table' dialog would load a csv bigger than 10 MB (some OQ-engine outputs can be very big)
- [x] Fix list of selected tags reported in the commented header of the csv exported by the Data Viewer

Companion of some engine-side changes:
- https://github.com/gem/oq-engine/pull/8394
- https://github.com/gem/oq-engine/pull/8390
- https://github.com/gem/oq-engine/pull/8397

