### PR TITLE
Fix loader of `disagg-rlzs`, previously called `disagg`

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -96,7 +96,8 @@ from svir.dialogs.load_hcurves_as_layer_dialog import (
     LoadHazardCurvesAsLayerDialog)
 from svir.dialogs.load_uhs_as_layer_dialog import (
     LoadUhsAsLayerDialog)
-from svir.dialogs.load_disagg_as_layer_dialog import LoadDisaggAsLayerDialog
+from svir.dialogs.load_disagg_rlzs_as_layer_dialog import (
+    LoadDisaggRlzsAsLayerDialog)
 from svir.dialogs.load_avg_losses_rlzs_as_layer_dialog import (
     LoadAvgLossesRlzsAsLayerDialog)
 from svir.dialogs.load_inputs_dialog import LoadInputsDialog
@@ -133,7 +134,7 @@ OUTPUT_TYPE_LOADERS = {
     'avg_losses-rlzs': LoadAvgLossesRlzsAsLayerDialog,
     'avg_losses-stats': LoadAvgLossesRlzsAsLayerDialog,
     'asset_risk': LoadAssetRiskAsLayerDialog,
-    'disagg': LoadDisaggAsLayerDialog,
+    'disagg-rlzs': LoadDisaggRlzsAsLayerDialog,
     'input': LoadInputsDialog,
 }
 assert set(OUTPUT_TYPE_LOADERS) == OQ_TO_LAYER_TYPES, (

--- a/svir/dialogs/load_disagg_rlzs_as_layer_dialog.py
+++ b/svir/dialogs/load_disagg_rlzs_as_layer_dialog.py
@@ -36,15 +36,16 @@ from svir.calculations.calculate_utils import add_attribute
 from svir.tasks.extract_npz_task import ExtractNpzTask
 
 
-class LoadDisaggAsLayerDialog(LoadOutputAsLayerDialog):
+class LoadDisaggRlzsAsLayerDialog(LoadOutputAsLayerDialog):
     """
-    Dialog to load disaggregation from an oq-engine output, as layer
+    Dialog to load disaggregation realizations from an oq-engine output,
+    as layer
     """
 
     def __init__(self, drive_engine_dlg, iface, viewer_dock, session, hostname,
-                 calc_id, output_type='disagg', path=None, mode=None,
+                 calc_id, output_type='disagg-rlzs', path=None, mode=None,
                  engine_version=None, calculation_mode=None):
-        assert output_type == 'disagg'
+        assert output_type == 'disagg-rlzs'
         super().__init__(
             drive_engine_dlg, iface, viewer_dock, session, hostname,
             calc_id, output_type=output_type, path=path, mode=mode,
@@ -54,10 +55,10 @@ class LoadDisaggAsLayerDialog(LoadOutputAsLayerDialog):
         # self.populate_out_dep_widgets()
         # self.adjustSize()
         self.ok_button.setEnabled(True)
-        log_msg('Extracting disagg. Watch progress in QGIS task bar',
+        log_msg('Extracting disagg_layer. Watch progress in QGIS task bar',
                 level='I', message_bar=self.iface.messageBar())
         self.extract_npz_task = ExtractNpzTask(
-            'Extract disagg', QgsTask.CanCancel, self.session,
+            'Extract disagg-rlzs', QgsTask.CanCancel, self.session,
             self.hostname, self.calc_id, 'disagg_layer', self.finalize_init,
             self.on_extract_error)
         QgsApplication.taskManager().addTask(self.extract_npz_task)

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -850,7 +850,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         # NOTE: Cross symbols rendered for OQ-Engine disaggregation outputs are
         # opaque, wider and thicker than those used for other outputs (e.g.
         # hcurves)
-        if self.output_type == 'disagg':
+        if self.output_type == 'disagg-rlzs':
             cross.setSize(3)
             cross.setStrokeWidth(0.5)
             opacity = 1

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.17.0
+version=3.17.1
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.17.1
+    * Fix loader of OQ-Engine disaggregation realizations, that were renamed from 'disagg' to 'disagg-rlzs' in OQ 3.17
     3.17.0
     * Aligned with OQ-Engine 3.17
     3.16.0

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -81,7 +81,7 @@ def run_all():
     suite.addTest(unittest.makeSuite(LoadHmapsTestCase, 'test'))
     suite.addTest(unittest.makeSuite(LoadRupturesTestCase, 'test'))
     suite.addTest(unittest.makeSuite(LoadUhsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadDisaggTestCase, 'test'))
+    suite.addTest(unittest.makeSuite(LoadDisaggRlzsTestCase, 'test'))
     # OQ_ZIPPED_TYPES
     suite.addTest(unittest.makeSuite(LoadInputTestCase, 'test'))
     # OQ_RST_TYPES
@@ -859,12 +859,12 @@ class LoadUhsTestCase(LoadOqEngineOutputsTestCase):
         self.load_output_type('uhs')
 
 
-class LoadDisaggTestCase(LoadOqEngineOutputsTestCase):
+class LoadDisaggRlzsTestCase(LoadOqEngineOutputsTestCase):
     @unittest.skipIf(
-        ONLY_OUTPUT_TYPE and ONLY_OUTPUT_TYPE != 'disagg',
+        ONLY_OUTPUT_TYPE and ONLY_OUTPUT_TYPE != 'disagg-rlzs',
         'only testing output type %s' % ONLY_OUTPUT_TYPE)
-    def test_load_disagg(self):
-        self.load_output_type('disagg')
+    def test_load_disagg_rlzs(self):
+        self.load_output_type('disagg-rlzs')
 
 
 # OQ_ZIPPED_TYPES

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -246,7 +246,7 @@ OQ_EXTRACT_TO_LAYER_TYPES = set([
     'hmaps',
     'ruptures',
     'uhs',
-    'disagg',
+    'disagg-rlzs',
 ])
 OQ_ZIPPED_TYPES = set([
     'input',


### PR DESCRIPTION
In OQ-Engine 3.17 the `disagg` output was split into `disagg-rlzs` and `disagg-stats`. This PR uses the existing loader for `disagg` to load the current `disagg-rlzs` output. 