### PR TITLE
Load csv as layer also for `rates_by_src` and `mean_disagg_bysrc`

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -118,6 +118,8 @@ BUTTON_WIDTH = 75
 
 OUTPUT_TYPE_LOADERS = {
     'ruptures': LoadRupturesAsLayerDialog,
+    'rates_by_src': LoadCsvAsLayerDialog,
+    'mean_disagg_bysrc': LoadCsvAsLayerDialog,
     'realizations': LoadCsvAsLayerDialog,
     'events': LoadCsvAsLayerDialog,
     'risk_by_event': LoadCsvAsLayerDialog,

--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -118,17 +118,8 @@ BUTTON_WIDTH = 75
 
 OUTPUT_TYPE_LOADERS = {
     'ruptures': LoadRupturesAsLayerDialog,
-    'rates_by_src': LoadCsvAsLayerDialog,
-    'mean_disagg_bysrc': LoadCsvAsLayerDialog,
-    'realizations': LoadCsvAsLayerDialog,
-    'events': LoadCsvAsLayerDialog,
-    'risk_by_event': LoadCsvAsLayerDialog,
-    'aggrisk': LoadCsvAsLayerDialog,
-    'aggrisk-stats': LoadCsvAsLayerDialog,
-    'agg_risk': LoadCsvAsLayerDialog,
-    'damages-rlzs': LoadDamagesRlzsAsLayerDialog,
     # NOTE: damages-rlzs and damages-stats are handled completely differently
-    'damages-stats': LoadCsvAsLayerDialog,
+    'damages-rlzs': LoadDamagesRlzsAsLayerDialog,
     'gmf_data': LoadGmfDataAsLayerDialog,
     'hmaps': LoadHazardMapsAsLayerDialog,
     'hcurves': LoadHazardCurvesAsLayerDialog,
@@ -139,6 +130,9 @@ OUTPUT_TYPE_LOADERS = {
     'disagg-rlzs': LoadDisaggRlzsAsLayerDialog,
     'input': LoadInputsDialog,
 }
+for output_type in OQ_CSV_TO_LAYER_TYPES:
+    OUTPUT_TYPE_LOADERS[output_type] = LoadCsvAsLayerDialog
+
 assert set(OUTPUT_TYPE_LOADERS) == OQ_TO_LAYER_TYPES, (
     OUTPUT_TYPE_LOADERS, OQ_TO_LAYER_TYPES)
 

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,7 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.17.4
-    * Also OQ-Engine outputs 'rates_by_src' and 'mean_disagg_bysrc' are loadable automatically as layers
+    * Also OQ-Engine outputs 'mean_rates_by_src' and 'mean_disagg_by_src' are loadable automatically as layers
     * The dialog displaying OQ-Engine calculation reports or logs does not wrap text and contains Courier monospace font for better compatibility across operating systems
     * Layer groups for hazard maps are created only when they will contain at least one layer
     * The title of the IRMT Settings dialog now displays also the plugin version

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.17.4
+    * Also OQ-Engine outputs 'rates_by_src' and 'mean_disagg_bysrc' are loadable automatically as layers
     * The title of the IRMT Settings dialog now displays also the plugin version
     3.17.3
     * The button to retrieve the OQ Engine calculation parameters is properly reset similarly to what was already correctly done for the button to download the datastore

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -954,16 +954,24 @@ class AllLoadableOutputsFoundInDemosTestCase(LoadOqEngineOutputsTestCase):
         if loadable_output_types_not_found:
             print("\nOutput_types not found in any demo:\n\t%s" %
                   "\n\t".join(loadable_output_types_not_found))
-            if all([output_type.endswith('_aggr')
-                    for output_type in loadable_output_types_not_found]):
-                print("\nThe only missing output types are '_aggr', which are"
-                      " not actual outputs exposed by the engine, but"
-                      " derived outputs accessed through the extract API."
-                      " Therefore, is is ok.")
+            if (all([output_type.endswith('_aggr') or
+                    output_type in OQ_CSV_TO_LAYER_TYPES
+                    for output_type in loadable_output_types_not_found])
+                and (any([output_type in OQ_CSV_TO_LAYER_TYPES
+                          for output_type in loadable_output_types_not_found])
+                     and any([output_type in OQ_CSV_TO_LAYER_TYPES
+                              for output_type in
+                              loadable_output_types_found]))):
+                print("\nThe only missing output types are '_aggr',"
+                      " which are not actual outputs exposed by the"
+                      " engine, but derived outputs accessed through"
+                      " the extract API, or CSV outputs that are"
+                      " loaded in a commmon way. Therefore, it is ok.")
             else:
                 print("\nSome missing output types are '_aggr', which are"
                       " not actual outputs exposed by the engine, but"
-                      " derived outputs accessed through the extract API."
+                      " derived outputs accessed through the extract API,"
+                      " or CSV outputs that are loaded in a common way."
                       " Therefore, is is ok:\n\t%s" % "\n\t".join([
                           output_type
                           for output_type in loadable_output_types_not_found

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -954,14 +954,11 @@ class AllLoadableOutputsFoundInDemosTestCase(LoadOqEngineOutputsTestCase):
         if loadable_output_types_not_found:
             print("\nOutput_types not found in any demo:\n\t%s" %
                   "\n\t".join(loadable_output_types_not_found))
-            if (all([output_type.endswith('_aggr') or
-                    output_type in OQ_CSV_TO_LAYER_TYPES
-                    for output_type in loadable_output_types_not_found])
-                and (any([output_type in OQ_CSV_TO_LAYER_TYPES
-                          for output_type in loadable_output_types_not_found])
-                     and any([output_type in OQ_CSV_TO_LAYER_TYPES
-                              for output_type in
-                              loadable_output_types_found]))):
+            if (all([output_type.endswith('_aggr')
+                     or (output_type in OQ_CSV_TO_LAYER_TYPES
+                         and any([otype in OQ_CSV_TO_LAYER_TYPES
+                                  for otype in loadable_output_types_found]))
+                     for output_type in loadable_output_types_not_found])):
                 print("\nThe only missing output types are '_aggr',"
                       " which are not actual outputs exposed by the"
                       " engine, but derived outputs accessed through"

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -235,8 +235,8 @@ OQ_CSV_TO_LAYER_TYPES = set([
     'risk_by_event',
     'events',
     'realizations',
-    'rates_by_src',
-    'mean_disagg_bysrc',
+    'mean_rates_by_src',
+    'mean_disagg_by_src',
 ])
 OQ_EXTRACT_TO_LAYER_TYPES = set([
     'asset_risk',

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -235,6 +235,8 @@ OQ_CSV_TO_LAYER_TYPES = set([
     'risk_by_event',
     'events',
     'realizations',
+    'rates_by_src',
+    'mean_disagg_bysrc',
 ])
 OQ_EXTRACT_TO_LAYER_TYPES = set([
     'asset_risk',


### PR DESCRIPTION
@micheles, please note that `mean_disagg_bysrc` is actually spelled like this, but I suppose it should be `mean_disagg_by_src`. If this is something recent that does not break any external tool, perhaps we could rename it engine-side.