### PR TITLE
Import qgis.testing.unittest instead of importing the standard unittest

### DIFF
--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -108,6 +108,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         # NOTE: recovery modeling is an exprimental feature
         cls.initial_experimental_enabled = QSettings().value(
             '/irmt/experimental_enabled',
@@ -152,6 +153,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDownClass()
         QSettings().setValue(
             'irmt/experimental_enabled', cls.initial_experimental_enabled)
         # print("\n\nGLOBAL SUMMARY OF TESTING OQ-ENGINE OUTPUT LOADERS")

--- a/svir/test/unit/test_calculate_indices.py
+++ b/svir/test/unit/test_calculate_indices.py
@@ -22,7 +22,6 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 import os
 import sys
 import tempfile
@@ -39,7 +38,7 @@ from svir.utilities.utils import (set_operator,
                                   save_layer_as,
                                   )
 from svir.utilities.shared import OPERATORS_DICT, DiscardedFeature
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()

--- a/svir/test/unit/test_calculate_indices.py
+++ b/svir/test/unit/test_calculate_indices.py
@@ -134,6 +134,7 @@ class CalculateCompositeVariableTestCase(unittest.TestCase):
     REBUILD_OUTPUTS = False
 
     def setUp(self):
+        super().setUp()
 
         self.project_definition = PROJ_DEF_STD_OPERATORS
 

--- a/svir/test/unit/test_dumb.py
+++ b/svir/test/unit/test_dumb.py
@@ -36,11 +36,11 @@ class DumbTest(unittest.TestCase):
 
     def setUp(self):
         """Runs before each test."""
-        pass
+        super().setUp()
 
     def tearDown(self):
         """Runs after each test."""
-        pass
+        super().tearDown()
 
     def test_dumb(self):
         pass

--- a/svir/test/unit/test_dumb.py
+++ b/svir/test/unit/test_dumb.py
@@ -24,9 +24,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()

--- a/svir/test/unit/test_init.py
+++ b/svir/test/unit/test_init.py
@@ -1,7 +1,7 @@
 import os
-import unittest
 import logging
 import configparser
+from qgis.testing import unittest, start_app
 
 # coding=utf-8
 """Tests for map creation in QGIS plugin."""
@@ -14,6 +14,8 @@ __copyright__ = 'Copyright 2012, Australia Indonesia Facility for '
 __copyright__ += 'Disaster Reduction'
 
 LOGGER = logging.getLogger('OpenQuake')
+
+start_app()
 
 
 class TestInit(unittest.TestCase):

--- a/svir/test/unit/test_irmt.py
+++ b/svir/test/unit/test_irmt.py
@@ -42,11 +42,11 @@ class IrmtTest(unittest.TestCase):
 
     def setUp(self):
         """Runs before each test."""
-        pass
+        super().setUp()
 
     def tearDown(self):
         """Runs after each test."""
-        pass
+        super().tearDown()
 
     def test_icon_png(self):
         """Test we can click OK."""

--- a/svir/test/unit/test_irmt.py
+++ b/svir/test/unit/test_irmt.py
@@ -24,11 +24,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 from qgis.PyQt.QtGui import QIcon
 
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()

--- a/svir/test/unit/test_loss_aggreagation.py
+++ b/svir/test/unit/test_loss_aggreagation.py
@@ -41,6 +41,7 @@ IFACE = get_iface()
 class AggregateLossByZoneTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         # Load dummy layers
         curr_dir_name = os.path.dirname(__file__)
         self.data_dir_name = os.path.join(

--- a/svir/test/unit/test_loss_aggreagation.py
+++ b/svir/test/unit/test_loss_aggreagation.py
@@ -24,7 +24,6 @@
 
 # import qgis libs so that we set the correct sip api version
 import os.path
-import unittest
 import tempfile
 import shutil
 import time
@@ -32,7 +31,7 @@ from qgis.core import QgsVectorLayer
 from svir.calculations.process_layer import ProcessLayer
 from svir.calculations.aggregate_loss_by_zone import calculate_zonal_stats
 
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()

--- a/svir/test/unit/test_multi_select_combo_box.py
+++ b/svir/test/unit/test_multi_select_combo_box.py
@@ -33,10 +33,12 @@ class MultiSelectComboBoxMultiTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.wdg = QWidget()
         cls.mscb = MultiSelectComboBox(cls.wdg)
 
     def setUp(self):
+        super().setUp()
         self.mscb.clear()
 
     def test_addItem(self):
@@ -159,10 +161,12 @@ class MultiSelectComboBoxMonoTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUpClass()
         cls.wdg = QWidget()
         cls.mscb = MultiSelectComboBox(cls.wdg, mono=True)
 
     def setUp(self):
+        super().setUp()
         self.mscb.clear()
 
     def test_addItem(self):

--- a/svir/test/unit/test_multi_select_combo_box.py
+++ b/svir/test/unit/test_multi_select_combo_box.py
@@ -22,9 +22,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 from qgis.PyQt.QtWidgets import QWidget
+from qgis.testing import unittest, start_app
 from svir.ui.multi_select_combo_box import MultiSelectComboBox
+
+start_app()
 
 
 class MultiSelectComboBoxMultiTestCase(unittest.TestCase):

--- a/svir/test/unit/test_process_layer.py
+++ b/svir/test/unit/test_process_layer.py
@@ -24,7 +24,6 @@
 
 # import qgis libs so that we set the correct sip api version
 import os.path
-import unittest
 from qgis.core import QgsVectorLayer, QgsField
 
 from qgis.PyQt.QtCore import QVariant
@@ -33,8 +32,7 @@ from svir.calculations.process_layer import ProcessLayer
 from svir.utilities.shared import (INT_FIELD_TYPE_NAME,
                                    STRING_FIELD_TYPE_NAME)
 
-
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()

--- a/svir/test/unit/test_process_layer.py
+++ b/svir/test/unit/test_process_layer.py
@@ -41,6 +41,7 @@ IFACE = get_iface()
 
 class CheckProjectionsTestCase(unittest.TestCase):
     def setUp(self):
+        super().setUp()
         curr_dir_name = os.path.dirname(__file__)
         data_dir_name = os.path.join(
             curr_dir_name, os.pardir,
@@ -76,6 +77,7 @@ class CheckProjectionsTestCase(unittest.TestCase):
 class CompareLayerContentTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         # a and b are equal
         # c is longer than a and b but they have the same partial content
         # d is different with respect to all the others
@@ -111,6 +113,7 @@ class CompareLayerContentTestCase(unittest.TestCase):
 class AddAttributesTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         uri = 'Point?crs=epsg:4326'
         self.layer = QgsVectorLayer(uri, 'TestLayer', 'memory')
 

--- a/svir/test/unit/test_qgis_environment.py
+++ b/svir/test/unit/test_qgis_environment.py
@@ -17,13 +17,8 @@ __date__ = '20/01/2011'
 __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
                  'Disaster Reduction')
 
-import unittest
-
 from qgis.core import QgsProviderRegistry
-
-
-
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()

--- a/svir/test/unit/test_transformations.py
+++ b/svir/test/unit/test_transformations.py
@@ -66,6 +66,7 @@ class MissingValuesTestCase(unittest.TestCase):
 class RankTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.alg = TRANSFORMATION_ALGS["RANK"]
         self.input_list = [2, 0, 2, 1, 2, 3, 2]
 
@@ -123,6 +124,7 @@ class RankTestCase(unittest.TestCase):
 class MinMaxTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.alg = TRANSFORMATION_ALGS["MIN_MAX"]
         self.input_list = [2, 0, 2, 1, 2, 3, 2]
 
@@ -150,6 +152,7 @@ class MinMaxTestCase(unittest.TestCase):
 class ZScoreTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.alg = TRANSFORMATION_ALGS["Z_SCORE"]
         self.input_list = [2, 0, 2, 1, 2, 3, 2]
 
@@ -181,6 +184,7 @@ class ZScoreTestCase(unittest.TestCase):
 class Log10TestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.alg = TRANSFORMATION_ALGS["LOG10"]
 
     def test_log10_all_positive_values(self):
@@ -272,6 +276,7 @@ class Log10TestCase(unittest.TestCase):
 class QuadraticTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.alg = TRANSFORMATION_ALGS["QUADRATIC"]
         self.input_list = [80089,
                            83696,
@@ -331,6 +336,7 @@ class QuadraticTestCase(unittest.TestCase):
 class SigmoidTestCase(unittest.TestCase):
 
     def setUp(self):
+        super().setUp()
         self.alg = TRANSFORMATION_ALGS["SIGMOID"]
 
     def test_sigmoid_direct(self):

--- a/svir/test/unit/test_transformations.py
+++ b/svir/test/unit/test_transformations.py
@@ -22,13 +22,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 import numpy as np
 
 from svir.calculations.transformation_algs import (
     transform,
     TRANSFORMATION_ALGS)
 from qgis.core import NULL
+from qgis.testing import unittest, start_app
+
+start_app()
 
 
 class MissingValuesTestCase(unittest.TestCase):

--- a/svir/test/unit/test_translations.py
+++ b/svir/test/unit/test_translations.py
@@ -31,11 +31,13 @@ class SafeTranslationsTest(unittest.TestCase):
 
     def setUp(self):
         """Runs before each test."""
+        super().setUp()
         if 'LANG' in iter(os.environ.keys()):
             os.environ.__delitem__('LANG')
 
     def tearDown(self):
         """Runs after each test."""
+        super().tearDown()
         if 'LANG' in iter(os.environ.keys()):
             os.environ.__delitem__('LANG')
 

--- a/svir/test/unit/test_translations.py
+++ b/svir/test/unit/test_translations.py
@@ -16,12 +16,10 @@ __author__ = 'ismailsunni@yahoo.co.id'
 __date__ = '12/10/2011'
 __copyright__ = ('Copyright 2012, Australia Indonesia Facility for '
                  'Disaster Reduction')
-import unittest
 import os
 
 from qgis.PyQt.QtCore import QCoreApplication, QTranslator
-
-from qgis.testing import start_app
+from qgis.testing import unittest, start_app
 from qgis.testing.mocked import get_iface
 
 QGIS_APP = start_app()


### PR DESCRIPTION
...and use super().setUp() or similar when overriding methods of qgis.testing.unittest

It fixes the `AttributeError: type object 'MultiSelectComboBoxMonoTestCase' has no attribute 'report'` happening using the latest qgis docker image.