### PR TITLE
Catch exception in case of incompatible damage states for recovery modeling

### DIFF
--- a/svir/dialogs/recovery_modeling_dialog.py
+++ b/svir/dialogs/recovery_modeling_dialog.py
@@ -71,6 +71,7 @@ class RecoveryModelingDialog(QDialog, FORM_CLASS):
         self.n_simulations_lbl.setToolTip(simulations_explanation)
         self.n_simulations_sbx.setToolTip(simulations_explanation)
         self.save_bldg_curves_check.setChecked(False)
+        self.svi_layer = None
         self.populate_layers_in_combos()
         self.restore_state()
         self.set_ok_button()

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1607,6 +1607,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             recovery.generate_community_level_recovery_curve(
                 'ALL', zonal_damages_rlzs_probs, zonal_asset_refs,
                 n_simulations=n_simulations)
+        if not recovery_function:
+            return
         self.current_abscissa = list(range(len(recovery_function)))
         color = QColor('black')
         color_hex = color.name()

--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -170,7 +170,11 @@ class RecoveryModeling(object):
         if self.n_recovery_based_dmg_states != len(damages_rlzs_probs[0]):
             # NOTE: in the GUI this should normally be displayed as an error,
             # but in the tests it can be accepted as the desired behavior
+            log_msg(f"GEM_QGIS_TEST: {'GEM_QGIS_TEST' in os.environ}",
+                    level='I', message_bar=self.iface.messageBar())
             log_level = 'W' if 'GEM_QGIS_TEST' in os.environ else 'C'
+            log_msg(f'log_level: {log_level}', level='I',
+                    message_bar=self.iface.messageBar())
             msg = (f'Incompatible number of recovery-based damage states'
                    f' (please set the correct parameters'
                    f' via the "Recovery Modeling Settings" dialog).\n'

--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -170,19 +170,17 @@ class RecoveryModeling(object):
         if self.n_recovery_based_dmg_states != len(damages_rlzs_probs[0]):
             # NOTE: in the GUI this should normally be displayed as an error,
             # but in the tests it can be accepted as the desired behavior
-            log_msg(f"GEM_QGIS_TEST: {'GEM_QGIS_TEST' in os.environ}",
-                    level='I', message_bar=self.iface.messageBar())
             log_level = 'W' if 'GEM_QGIS_TEST' in os.environ else 'C'
-            log_msg(f'log_level: {log_level}', level='I',
-                    message_bar=self.iface.messageBar())
-            msg = (f'Incompatible number of recovery-based damage states'
-                   f' (please set the correct parameters'
-                   f' via the "Recovery Modeling Settings" dialog).\n'
-                   f'Transfer probabilities:\n{self.transferProbabilities}\n'
-                   f'Damages_rlzs_probs:\n{damages_rlzs_probs}\n'
-                   f'Expected number of recovery-based damage states:'
-                   f' {self.n_recovery_based_dmg_states}\n'
-                   f'Got: {len(damages_rlzs_probs[0])}')
+            msg = 'Incompatible number of recovery-based damage states'
+            if log_level == 'C':
+                msg += (f' (please set the correct parameters'
+                        f' via the "Recovery Modeling Settings" dialog).\n'
+                        f'Transfer probabilities:\n'
+                        f'{self.transferProbabilities}\n'
+                        f'Damages_rlzs_probs:\n{damages_rlzs_probs}\n'
+                        f'Expected number of recovery-based damage states:'
+                        f' {self.n_recovery_based_dmg_states}\n'
+                        f'Got: {len(damages_rlzs_probs[0])}')
             log_msg(msg, level=log_level, message_bar=self.iface.messageBar())
             return
 

--- a/svir/recovery_modeling/recovery_modeling.py
+++ b/svir/recovery_modeling/recovery_modeling.py
@@ -183,10 +183,14 @@ class RecoveryModeling(object):
                 self.loss_based_to_recovery_based_probs(damages_rlzs_probs)
         except IndexError:
             msg = ('Incompatible number of loss-based or recovery-based'
-                   ' limit states (please use the "Recovery Modeling'
-                   ' Settings dialog to set it correctly.\n%s'
+                   ' limit states (please set the correct parameters'
+                   ' via the "Recovery Modeling Settings" dialog).\n%s'
                    % traceback.format_exc())
-            log_msg(msg, level='C', message_bar=self.iface.messageBar())
+            # NOTE: in the GUI this should normally be displayed as an error,
+            # but in the tests it can be accepted as the desired behavior
+            log_level = 'W' if 'GEM_QGIS_TEST' in os.environ else 'C'
+            log_msg(msg, level=log_level, message_bar=self.iface.messageBar())
+            return
 
         # FIXME self.svi_field_name is temporarily ignored
         # svi_value = svi_by_zone[zone_id] if integrate_svi else None

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -625,7 +625,6 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                         aggregate_by_site=aggregate_by_site)
                 # for damages-rlzs also test recovery modeling
                 if selected_output_type == 'damages-rlzs':
-                    # FIXME
                     for approach in ['Disaggregate', 'Aggregate']:
                         self.load_calc_output(
                             calc, selected_output_type,

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -715,10 +715,11 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                     "The following line of the exported file %s has"
                     " only %s columns:\n%s" % (
                         exported_file_path, n_cols, got_line))
-            self.assertGreaterEqual(
-                n_rows, 2,
-                "The exported file %s has only %s rows" % (
-                    exported_file_path, n_rows))
+            if not empty_is_ok:
+                self.assertGreaterEqual(
+                    n_rows, 2,
+                    "The exported file %s has only %s rows" % (
+                        exported_file_path, n_rows))
 
     def _set_output_type(self, output_type):
         self.irmt.viewer_dock.output_type_cbx.setCurrentIndex(-1)

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -669,7 +669,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
             self.irmt.viewer_dock.approach_cbx.findText(approach))
         self.irmt.viewer_dock.n_simulations_sbx.setValue(n_simulations)
         self._change_selection()
-        self._test_export()
+        self._test_export(empty_is_ok=True)
         dlg.loading_completed.emit(dlg)
 
     def load_uhs(self):
@@ -685,9 +685,14 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
         self._change_selection()
         self._test_export()
 
-    def _test_export(self):
+    def _test_export(self, empty_is_ok=False):
+        # NOTE: param empty_is_ok is to handle a corner case in which recovery
+        # curves can not be computed due to an incompatible setting of
+        # recover-based damage states. In this case, the plugin correctly
+        # gives instructions to the user and the plot area remains empty.
         _, exported_file_path = tempfile.mkstemp(suffix=".csv")
-        self.irmt.viewer_dock.write_export_file(exported_file_path)
+        self.irmt.viewer_dock.write_export_file(exported_file_path,
+                                                empty_is_ok)
         # NOTE: we are only checking that the exported CSV has at least 2 rows
         # and 3 columns per row. We are avoiding more precise checks, because
         # CSV tests are very fragile. On different platforms the numbers could

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -625,6 +625,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                         aggregate_by_site=aggregate_by_site)
                 # for damages-rlzs also test recovery modeling
                 if selected_output_type == 'damages-rlzs':
+                    # FIXME
                     for approach in ['Disaggregate', 'Aggregate']:
                         self.load_calc_output(
                             calc, selected_output_type,

--- a/svir/utilities/shared.py
+++ b/svir/utilities/shared.py
@@ -237,6 +237,14 @@ OQ_CSV_TO_LAYER_TYPES = set([
     'realizations',
     'mean_rates_by_src',
     'mean_disagg_by_src',
+    'infra-avg_loss',
+    'infra-node_el',
+    'infra-taz_cl',
+    'infra-dem_cl',
+    'infra-event_ccl',
+    'infra-event_pcl',
+    'infra-event_wcl',
+    'infra-event_efl',
 ])
 OQ_EXTRACT_TO_LAYER_TYPES = set([
     'asset_risk',


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/834

The new Infrastructure Risk Demos produce damages_rlzs that are used in integration tests for recovery modeling. The Water Supply Demo has a number of damages states compatible with the default settings of recovery modeling, but the Road Network Demo is incompatible. In that case, the plugin should return a clear error message instead of crashing.

I'm also adding the possibility to load the new csv outputs of infrastructure risk assessment as tables.