### PR TITLE
Adding OEP and AEP for event-based risk and damage calculations

### DIFF
--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -268,6 +268,18 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.add_widget_to_type_dep_layout(
             self.imt_cbx, 'imt_cbx', self.typeDepHLayout1)
 
+    def create_ep_selector(self):
+        self.ep_lbl = QLabel('Exceedance Probability')
+        self.ep_lbl.setSizePolicy(
+            QSizePolicy.Minimum, QSizePolicy.Minimum)
+        self.ep_cbx = QComboBox()
+        self.ep_cbx.currentIndexChanged['QString'].connect(
+            self.on_ep_changed)
+        self.add_widget_to_type_dep_layout(
+            self.ep_lbl, "ep_lbl", self.typeDepVLayout)
+        self.add_widget_to_type_dep_layout(
+            self.ep_cbx, "ep_cbx", self.typeDepVLayout)
+
     def create_abs_rel_selector(self):
         self.abs_rel_lbl = QLabel('Absolute or relative')
         self.abs_rel_lbl.setSizePolicy(
@@ -708,6 +720,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         elif new_output_type == 'aggcurves':
             self.create_loss_type_selector()
             self.create_rlzs_multiselect()
+            self.create_ep_selector()
             self.create_abs_rel_selector()
             # NOTE: tag_names_multiselect is created dynamically afterwards
             self.rlzs_multiselect.selection_changed.connect(
@@ -716,6 +729,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         elif new_output_type == 'aggcurves-stats':
             self.create_loss_type_selector()
             self.create_stats_multiselect()
+            self.create_ep_selector()
             self.create_abs_rel_selector()
             # NOTE: tag_names_multiselect is created dynamically afterwards
             self.stats_multiselect.selection_changed.connect(
@@ -971,6 +985,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             self.agg_curves = extract_npz(
                 session, hostname, calc_id, 'agg_curves',
                 message_bar=self.iface.messageBar(), params=params)
+        self.ep_cbx.blockSignals(True)
+        self.ep_cbx.clear()
+        self.ep_cbx.addItems(self.agg_curves['ep_field'])
+        self.ep_cbx.blockSignals(False)
         if output_type == 'aggcurves':
             self.rlzs = self.agg_curves['kind']
             if oqparam['collect_rlzs']:
@@ -1060,6 +1078,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             return
         loss_type = self.loss_type_cbx.currentText()
         loss_type_idx = self.loss_type_cbx.currentIndex()
+        ep_idx = self.ep_cbx.currentIndex()
         unit = self.agg_curves['units'][loss_type_idx]
         self.plot.clear()
         # if not ordinates.any():  # too much filtering
@@ -1097,13 +1116,15 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 color = QColor(color_name)
                 color_hex[rlz_or_stat_idx] = color.darker(120).name()
                 line_style[rlz_or_stat_idx] = "-"  # solid
-        tup = (slice(None), rlzs_or_stats_idxs)
+        # chosen rlz or stat index, all return periods, all ep_fields
+        tup = (rlzs_or_stats_idxs, slice(None), ep_idx)
+        # add to the tuple the indices of chosen tag values
         if tag_value_idxs is not None:
             value_idxs = tag_value_idxs.values()
             tup += tuple(value_idxs)
         ordinates = self.agg_curves['array'][tup]
         for ys, rlz_or_stat in zip(
-                ordinates.T, rlzs_or_stats):
+                ordinates, rlzs_or_stats):
             rlz_or_stat_idx = rlzs_or_stats.index(rlz_or_stat)
             label = rlz_or_stat
             self.plot.plot(
@@ -1795,6 +1816,9 @@ class ViewerDock(QDockWidget, FORM_CLASS):
     def on_imt_changed(self):
         self.was_imt_switched = True
         self.redraw_current_selection()
+
+    def on_ep_changed(self):
+        self.filter_agg_curves()
 
     @pyqtSlot(str)
     def on_loss_type_changed(self, loss_type):

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -2021,10 +2021,13 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 else:
                     stats = list(self.stats_multiselect.get_selected_items())
                 loss_type = self.loss_type_cbx.currentText()
+                ep = self.ep_cbx.currentText()
+                ep_idx = self.ep_cbx.currentIndex()
                 abs_rel = self.abs_rel_cbx.currentText()
                 loss_type_idx = self.loss_type_cbx.currentIndex()
                 unit = self.agg_curves['units'][loss_type_idx]
                 csv_file.write("# Loss type: %s\r\n" % loss_type)
+                csv_file.write("# Exceedance Probability: %s\r\n" % ep)
                 csv_file.write("# Absolute or relative: %s\r\n" % abs_rel)
                 csv_file.write("# Measurement unit: %s\r\n" % unit)
                 if self.aggregate_by is not None and len(self.aggregate_by):
@@ -2057,7 +2060,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                         self.agg_curves['return_period']):
                     row = [return_period]
                     if has_single_tag_value or has_single_tag_value is None:
-                        tup = (return_period_idx, rlzs_or_stats_idxs)
+                        tup = (rlzs_or_stats_idxs, return_period_idx, ep_idx)
                     else:
                         # FIXME: using only the first stat
                         tup = (return_period_idx, rlzs_or_stats_idxs[0])

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.17.7
+version=3.18.0
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.18.0
+    * Added visualization of OEP and AEP for event-based risk and damage calculations
     3.17.7
     * A clear error message is displayed if recovery modeling runs with an incompatible number of damage states with respect to what's specified in the recovery modeling settings
     * Measurement units for oq-engine loss data types 'residents' and 'occupants' were fixed


### PR DESCRIPTION
Companion of https://github.com/gem/oq-engine/pull/9016
Addressing https://github.com/gem/oq-engine/issues/8971

Before the addition of the AEP and OEP curves, the plugin displayed multiple curves, one per each realization or statistic selected with a multi-select widget.
Now that also AEP and OEP curves are available, I've added a selector allowing to pick either `loss`, `loss_aep` or `loss_oep` and to display the corresponding curve for each of the realizations or statistics selected. The label for this selector is `Exceedance Probability`, but perhaps another better name could be given instead.

We may want to display AEP and OEP curves together instead of realizations/statistics. Or we may even want to display everything together (all realizations/statistics and all ep/aep/oep) in a plot that would become a bit noisy. In that case, labels and styles should be properly set for each curve.

My proposal is to merge into master the implemented approach, that fixes the integration tests and that is already enough to visualize all curves, even if perhaps in a sub-optimal way. We can further refine things in a later pull request.