### PR TITLE
Increase the extent of layers having an empty extent in order to allow zooming to layer

### DIFF
--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -503,7 +503,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             row_wkt_geom_types=row_wkt_geom_types)
         # if we are creating a layer with empty extent, increase the
         # extent by a small delta in order to allow zooming to layer
-        if self.layer.extent().area() == 0.0:
+        if (self.layer.featureCount() > 0
+                and self.layer.extent().area() == 0.0):
             delta = 0.1
             ext = self.layer.extent()
             xmax = ext.xMaximum()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -47,6 +47,7 @@ from qgis.core import (QgsVectorLayer,
                        NULL,
                        QgsSimpleMarkerSymbolLayerBase,
                        Qgis,
+                       QgsRectangle,
                        )
 from qgis.gui import QgsSublayersDialog
 from qgis.PyQt.QtCore import pyqtSignal, QDir, QSettings, QFileInfo, Qt
@@ -500,6 +501,19 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             boundaries=boundaries, geometry_type=geometry_type,
             wkt_geom_type=wkt_geom_type,
             row_wkt_geom_types=row_wkt_geom_types)
+        # if we are creating a Point layer with empty extent, increase the
+        # extent by a small delta in order to allow zooming to layer
+        if (self.layer.geometryType() == 0  # Point
+                and self.layer.extent().area() == 0.0):
+            delta = 0.1
+            ext = self.layer.extent()
+            xmax = ext.xMaximum()
+            xmin = ext.xMinimum()
+            ymax = ext.yMaximum()
+            ymin = ext.yMinimum()
+            grown_extent = QgsRectangle(
+                xmin - delta, ymin - delta, xmax + delta, ymax + delta)
+            self.layer.setExtent(grown_extent)
         if (self.output_type == 'damages-rlzs' and
                 not self.aggregate_by_site_ckb.isChecked()):
             self.layer.setCustomProperty('output_type', 'recovery_curves')

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -501,10 +501,9 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
             boundaries=boundaries, geometry_type=geometry_type,
             wkt_geom_type=wkt_geom_type,
             row_wkt_geom_types=row_wkt_geom_types)
-        # if we are creating a Point layer with empty extent, increase the
+        # if we are creating a layer with empty extent, increase the
         # extent by a small delta in order to allow zooming to layer
-        if (self.layer.geometryType() == 0  # Point
-                and self.layer.extent().area() == 0.0):
+        if self.layer.extent().area() == 0.0:
             delta = 0.1
             ext = self.layer.extent()
             xmax = ext.xMaximum()

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. The plugin can interact with the OpenQuake Platform (https://platform.openquake.org), to browse and download socio-economic data or existing projects, edit projects locally in QGIS and upload and share them with the scientific community. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.17.7
+version=3.17.8
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.17.8
+    * The extent of layers having at least one feature but empty extent is increased by a small delta in order to allow zooming to layer
     3.17.7
     * A clear error message is displayed if recovery modeling runs with an incompatible number of damage states with respect to what's specified in the recovery modeling settings
     * Measurement units for oq-engine loss data types 'residents' and 'occupants' were fixed


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/206

I am doing it when creating layers of any kind, because the extent is always a rectangle and, even if in the properties it is displayed as empty, the object actually contains the coordinates. Therefore we can just increase the rectangle by a small delta.
With this fix, the plugin automatically (and correctly) zooms to layer also when loading a layer with only one point.

What we obtain is something more usable than before, although we introduce a little inconsistency, because we are declaring that the extent of our layer is bigger than its actual extent (that in fact is just a point). I believe the benefits justify the little inconsistency.