### PR TITLE
While extracting npz in numpy.load use max_header_size=100000 to fix e.g. some hcurves

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.18.0
+    * Increased numpy.load parameter max_header_size to 100000 in order to prevent errors extracting some hazard curves
     * Added visualization of OEP and AEP for event-based risk and damage calculations
     3.17.8
     * The extent of layers having at least one feature but empty extent is increased by a small delta in order to allow zooming to layer

--- a/svir/tasks/download_oq_output_task.py
+++ b/svir/tasks/download_oq_output_task.py
@@ -111,7 +111,7 @@ class DownloadOqOutputTask(QgsTask):
                 # actually kill the get, so the machine remains busy until a
                 # response is produced
                 # self.download_thread.deleteLater()
-                del(self.download_thread)
+                del self.download_thread
                 raise TaskCanceled
 
     @pyqtSlot(float)

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -108,7 +108,7 @@ class ExtractNpzTask(QgsTask):
                 # actually kill the get, so the machine remains busy until a
                 # response is produced
                 # self.extract_thread.deleteLater()
-                del(self.extract_thread)
+                del self.extract_thread
                 raise TaskCanceled
 
     @pyqtSlot(float)
@@ -179,7 +179,8 @@ class ExtractThread(QThread):
             return
         try:
             extracted_npz = numpy.load(
-                io.BytesIO(resp.content), allow_pickle=False)
+                io.BytesIO(resp.content), allow_pickle=False,
+                max_header_size=100000)
         except Exception as exc:
             self.exception_sig.emit(exc)
             return

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -178,6 +178,11 @@ class ExtractThread(QThread):
                 "%s: returned an empty content" % err_msg))
             return
         try:
+            # NOTE: on numpy versions >= 1.24 we could use allow_pickle=False
+            # and add the parameter max_header_size=100000 (the default value
+            # is 10000). We must be careful avoiding to put pickled objects
+            # engine-side in the extractors, otherwise we can easily fall into
+            # compatibility issues.
             extracted_npz = numpy.load(
                 io.BytesIO(resp.content), allow_pickle=True)
         except Exception as exc:

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -179,8 +179,7 @@ class ExtractThread(QThread):
             return
         try:
             extracted_npz = numpy.load(
-                io.BytesIO(resp.content), allow_pickle=False,
-                max_header_size=100000)
+                io.BytesIO(resp.content), allow_pickle=True)
         except Exception as exc:
             self.exception_sig.emit(exc)
             return

--- a/svir/tasks/extract_npz_task.py
+++ b/svir/tasks/extract_npz_task.py
@@ -178,13 +178,13 @@ class ExtractThread(QThread):
                 "%s: returned an empty content" % err_msg))
             return
         try:
-            # NOTE: on numpy versions >= 1.24 we could use allow_pickle=False
-            # and add the parameter max_header_size=100000 (the default value
-            # is 10000). We must be careful avoiding to put pickled objects
-            # engine-side in the extractors, otherwise we can easily fall into
-            # compatibility issues.
-            extracted_npz = numpy.load(
-                io.BytesIO(resp.content), allow_pickle=True)
+            if numpy.__version__ >= '1.24.0':
+                extracted_npz = numpy.load(
+                    io.BytesIO(resp.content), allow_pickle=False,
+                    max_header_size=100000)
+            else:
+                extracted_npz = numpy.load(
+                    io.BytesIO(resp.content), allow_pickle=False)
         except Exception as exc:
             self.exception_sig.emit(exc)
             return


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/840

The stacktrace was misleading. Actually the plugin was unable to load hcurves from the npz successfully downloaded through the engine API, because numpy.load complained about max_header_size being too small for that specific calculation.
Raising that parameter default by 10 times, it should be sufficient in our use cases.
@alejocaldeGEM I've just tried also with the Croatia use case, successfully.

This change needs to be backported to 3.16 and 3.17.