### PR TITLE
Do not force min_mag=6.5 when loading ruptures in tests

### DIFF
--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -524,7 +524,7 @@ class LoadOqEngineOutputsTestCase(unittest.TestCase):
                 self.irmt.drive_oq_engine_server_dlg, self.irmt.iface,
                 self.irmt.viewer_dock,
                 self.irmt.drive_oq_engine_server_dlg.session,
-                self.hostname, calc_id, output_type, min_mag=6.5,
+                self.hostname, calc_id, output_type,
                 calculation_mode=calculation_mode,
                 mode='testing')
             self.loading_completed[dlg] = False


### PR DESCRIPTION
This should avoid the following:
https://github.com/gem/oq-irmt-qgis/actions/runs/6387469847/job/17335848919#step:6:1546

See https://github.com/gem/oq-irmt-qgis/pull/843 about the broken unit test with QGIS LATEST.