### PR TITLE
Add a check raising an error if qgis:joinbylocationsummary was not retrieved correctly

### DIFF
--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -92,6 +92,10 @@ def calculate_zonal_stats(callback, zonal_layer, points_layer, join_fields,
     processing.Processing.initialize()
     alg = QgsApplication.processingRegistry().algorithmById(
         'qgis:joinbylocationsummary')
+    if not isinstance(
+            alg, processing.algs.qgis.SpatialJoinSummary.SpatialJoinSummary):
+        raise ImportError('Unable to retrieve processing algorithm'
+                          ' qgis:joinbylocationsummary')
     # make sure to use the actual lists of predicates and summaries as defined
     # in the algorithm when it is instantiated
     predicate_keys = [predicate[0] for predicate in alg.predicates]


### PR DESCRIPTION
For some reason, it looks like the algorithm SpatialJoinSummary suddenly disappeared from QGIS processing algorithms, therefore we have a broken unit test when running tests with the latest QGIS docker image.
I've written to the QGIS developers mailing list asking about this, to understand if the algorithm was recently replaced by something else or if it was perhaps deleted accidentally.

The additional check introduced by this PR should produce a clearer error message than https://github.com/gem/oq-irmt-qgis/actions/runs/6394447410/job/17356510404?pr=842#step:5:183