### PR TITLE
Use qgis:joinbylocationsummary in a way that works both on the python and c++ versions of the algorithm

### DIFF
--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -21,6 +21,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+import sys
 import time
 import processing
 from functools import partial
@@ -92,6 +93,8 @@ def calculate_zonal_stats(callback, zonal_layer, points_layer, join_fields,
     processing.Processing.initialize()
     alg = QgsApplication.processingRegistry().algorithmById(
         'qgis:joinbylocationsummary')
+    sys.stdout.write('Retrieved algorithm: %s' % type(alg))
+    sys.stdout.write('dir(alg): %s' % dir(alg))
     if not isinstance(
             alg, processing.algs.qgis.SpatialJoinSummary.SpatialJoinSummary):
         raise ImportError('Unable to retrieve processing algorithm'

--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -21,7 +21,6 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
-import sys
 import time
 import processing
 from functools import partial

--- a/svir/calculations/aggregate_loss_by_zone.py
+++ b/svir/calculations/aggregate_loss_by_zone.py
@@ -93,17 +93,19 @@ def calculate_zonal_stats(callback, zonal_layer, points_layer, join_fields,
     processing.Processing.initialize()
     alg = QgsApplication.processingRegistry().algorithmById(
         'qgis:joinbylocationsummary')
-    sys.stdout.write('Retrieved algorithm: %s' % type(alg))
-    sys.stdout.write('dir(alg): %s' % dir(alg))
-    if not isinstance(
-            alg, processing.algs.qgis.SpatialJoinSummary.SpatialJoinSummary):
+    if alg is None:
         raise ImportError('Unable to retrieve processing algorithm'
                           ' qgis:joinbylocationsummary')
-    # make sure to use the actual lists of predicates and summaries as defined
-    # in the algorithm when it is instantiated
-    predicate_keys = [predicate[0] for predicate in alg.predicates]
+    # NOTE: predicates are no more retrieavable in the c++ version of the
+    # algorithm, so we can't make sure to use the actual lists of predicates
+    # and summaries as defined in the algorithm when it is instantiated
+    predicate_keys = ['intersects', 'contains', 'isEqual', 'touches',
+                      'overlaps', 'within', 'crosses']
     PREDICATES = dict(zip(predicate_keys, range(len(predicate_keys))))
-    summary_keys = [statistic[0] for statistic in alg.statistics]
+    summary_keys = [
+        'count', 'unique', 'min', 'max', 'range', 'sum', 'mean', 'median',
+        'stddev', 'minority', 'majority', 'q1', 'q3', 'iqr', 'empty', 'filled',
+        'min_length', 'max_length', 'mean_length']
     SUMMARIES = dict(zip(summary_keys, range(len(summary_keys))))
 
     context = QgsProcessingContext()


### PR DESCRIPTION
Addresses part of https://github.com/gem/oq-irmt-qgis/issues/844

Use hardcoded lists of predicates and summaries when runnign the algorithm qgis:joinbylocationsummary, because those lists are no more available after the porting of the algorithm from python to c++.