### PR TITLE
When running tests, wait that the webui becomes available before proceeding

### DIFF
--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -52,7 +52,10 @@ jobs:
           mkdir ~/oqdata
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
-          sleep 10 
+          echo "Waiting WEBUI up on port 8800...."
+          while ! nc -z localhost 8800; do
+            sleep 5
+          done
           curl http://172.17.0.1:8800/v1/engine_version
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`

--- a/.github/workflows/qgis_383.yml
+++ b/.github/workflows/qgis_383.yml
@@ -53,7 +53,7 @@ jobs:
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
-          while ! nc -z localhost 8800; do
+          while ! nc -z 172.17.0.1 8800; do
             sleep 5
           done
           curl http://172.17.0.1:8800/v1/engine_version

--- a/.github/workflows/qgis_latest.yml
+++ b/.github/workflows/qgis_latest.yml
@@ -52,7 +52,10 @@ jobs:
           mkdir ~/oqdata
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
-          sleep 10
+          echo "Waiting WEBUI up on port 8800...."
+          while ! nc -z localhost 8800; do
+            sleep 5
+          done
           curl http://172.17.0.1:8800/v1/engine_version
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`

--- a/.github/workflows/qgis_latest.yml
+++ b/.github/workflows/qgis_latest.yml
@@ -53,7 +53,7 @@ jobs:
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
-          while ! nc -z localhost 8800; do
+          while ! nc -z 172.17.0.1 8800; do
             sleep 5
           done
           curl http://172.17.0.1:8800/v1/engine_version

--- a/.github/workflows/qgis_ltr.yml
+++ b/.github/workflows/qgis_ltr.yml
@@ -52,7 +52,10 @@ jobs:
           mkdir ~/oqdata
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
-          sleep 10 
+          echo "Waiting WEBUI up on port 8800...."
+          while ! nc -z localhost 8800; do
+            sleep 5
+          done
           curl http://172.17.0.1:8800/v1/engine_version
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`

--- a/.github/workflows/qgis_ltr.yml
+++ b/.github/workflows/qgis_ltr.yml
@@ -53,7 +53,7 @@ jobs:
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
-          while ! nc -z localhost 8800; do
+          while ! nc -z 172.17.0.1 8800; do
             sleep 5
           done
           curl http://172.17.0.1:8800/v1/engine_version


### PR DESCRIPTION
This should avoid failures like https://github.com/gem/oq-irmt-qgis/actions/runs/6502845711/job/17662478860#step:4:400