### PR TITLE
When only one realization is extracted from the engine, it is displayed as the 'mean'

### DIFF
--- a/svir/dialogs/load_avg_losses_rlzs_as_layer_dialog.py
+++ b/svir/dialogs/load_avg_losses_rlzs_as_layer_dialog.py
@@ -101,7 +101,7 @@ class LoadAvgLossesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
         self.ok_button.setEnabled(True)
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentData()]
         self.taxonomies = numpy.unique(self.dataset['taxonomy']).tolist()
         self.taxonomies = [taxonomy.decode('utf8')
                            for taxonomy in self.taxonomies]
@@ -171,7 +171,7 @@ class LoadAvgLossesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
     def load_from_npz(self):
         for rlz_or_stat in self.rlzs_or_stats:
             if (self.load_selected_only_ckb.isChecked()
-                    and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):
+                    and rlz_or_stat != self.rlz_or_stat_cbx.currentData()):
                 continue
             for taxonomy in self.taxonomies:
                 if (self.load_selected_only_ckb.isChecked()

--- a/svir/dialogs/load_damages_rlzs_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_rlzs_as_layer_dialog.py
@@ -112,7 +112,7 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
             self.load_selected_only_ckb.setEnabled(True)
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentData()]
         self.taxonomies = numpy.unique(self.dataset['taxonomy']).tolist()
         self.taxonomies = [taxonomy.decode('utf8')
                            for taxonomy in self.taxonomies]
@@ -270,7 +270,7 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
     def load_from_npz(self):
         for rlz_or_stat in self.rlzs_or_stats:
             if (self.load_selected_only_ckb.isChecked()
-                    and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):
+                    and rlz_or_stat != self.rlz_or_stat_cbx.currentData()):
                 continue
             if self.aggregate_by_site_ckb.isChecked():
                 for taxonomy in self.taxonomies:

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -70,7 +70,8 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         self.rlzs_or_stats = [
             name for name in self.npz_file['all'].dtype.names
             if name not in ('custom_site_id', 'lon', 'lat')]
-        self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
+        for rlz_or_stat in self.rlzs_or_stats:
+            self.rlz_or_stat_cbx.addItem(rlz_or_stat, rlz_or_stat)
 
     def on_rlz_or_stat_changed(self):
         rlz_or_stat = self.rlz_or_stat_cbx.currentData()

--- a/svir/dialogs/load_hcurves_as_layer_dialog.py
+++ b/svir/dialogs/load_hcurves_as_layer_dialog.py
@@ -70,11 +70,10 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         self.rlzs_or_stats = [
             name for name in self.npz_file['all'].dtype.names
             if name not in ('custom_site_id', 'lon', 'lat')]
-        for rlz_or_stat in self.rlzs_or_stats:
-            self.rlz_or_stat_cbx.addItem(rlz_or_stat)
+        self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
 
     def on_rlz_or_stat_changed(self):
-        rlz_or_stat = self.rlz_or_stat_cbx.currentText()
+        rlz_or_stat = self.rlz_or_stat_cbx.currentData()
         dataset = self.npz_file['all'][rlz_or_stat]
         self.imts = [imt for imt in dataset.dtype.names]
         self.imt_cbx.clear()
@@ -102,7 +101,7 @@ class LoadHazardCurvesAsLayerDialog(LoadOutputAsLayerDialog):
         field_types = {}
         for rlz_or_stat in self.rlzs_or_stats:
             if (not self.load_all_rlzs_or_stats_chk.isChecked()
-                    and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):
+                    and rlz_or_stat != self.rlz_or_stat_cbx.currentData()):
                 continue
             for imt in self.dataset[rlz_or_stat].dtype.names:
                 if (not self.load_all_imts_chk.isChecked()

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -120,7 +120,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentData()]
         self.imts = {imt: self.dataset[imt].dtype.names
                      for imt in self.dataset.dtype.names}
         self.imt_cbx.clear()
@@ -134,7 +134,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         #       If different realizations have a different number of sites, we
         #       need to move this block of code inside on_rlz_or_stat_changed()
         rlz_or_stat_data = self.npz_file['all'][
-            self.rlz_or_stat_cbx.currentText()]
+            self.rlz_or_stat_cbx.currentData()]
         self.num_sites_lbl.setText(
             self.num_sites_msg % rlz_or_stat_data.shape)
 
@@ -149,7 +149,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
     def build_layer_name(self, rlz_or_stat=None, **kwargs):
         investigation_time = self.get_investigation_time()
         if self.load_single_layer_ckb.isChecked():
-            rlz_or_stat = self.rlz_or_stat_cbx.currentText()
+            rlz_or_stat = self.rlz_or_stat_cbx.currentData()
             imt = self.imt_cbx.currentText()
             poe = self.poe_cbx.currentText()
             self.default_field_name = '%s-%s-%s' % (rlz_or_stat, imt, poe)
@@ -269,7 +269,7 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
         else:
             for rlz_or_stat in self.rlzs_or_stats:
                 if (not self.load_all_rlzs_or_stats_chk.isChecked()
-                        and rlz_or_stat != self.rlz_or_stat_cbx.currentText()):
+                        and rlz_or_stat != self.rlz_or_stat_cbx.currentData()):
                     continue
                 elif self.load_one_layer_per_stat_ckb.isChecked():
                     with WaitCursorManager(

--- a/svir/dialogs/load_hmaps_as_layer_dialog.py
+++ b/svir/dialogs/load_hmaps_as_layer_dialog.py
@@ -117,7 +117,8 @@ class LoadHazardMapsAsLayerDialog(LoadOutputAsLayerDialog):
             if name not in ('custom_site_id', 'lon', 'lat', 'vs30')]
         self.rlz_or_stat_cbx.clear()
         self.rlz_or_stat_cbx.setEnabled(True)
-        self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
+        for rlz_or_stat in self.rlzs_or_stats:
+            self.rlz_or_stat_cbx.addItem(rlz_or_stat, rlz_or_stat)
 
     def on_rlz_or_stat_changed(self):
         self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentData()]

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -413,7 +413,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         if len(self.rlzs_or_stats) == 1:
             self.rlz_or_stat_cbx.addItem('mean', self.rlzs_or_stats[0])
         else:
-            self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
+            for rlz_or_stat in self.rlzs_or_stats:
+                self.rlz_or_stat_cbx.addItem(rlz_or_stat, rlz_or_stat)
 
     def populate_loss_type_cbx(self, loss_types):
         self.loss_type_cbx.clear()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -380,7 +380,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.set_ok_button()
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.npz_file[self.rlz_or_stat_cbx.currentData()]
         self.set_ok_button()
 
     def on_loss_type_changed(self):
@@ -410,7 +410,10 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                               if key not in ('imtls', 'array', 'extra')]
         self.rlz_or_stat_cbx.clear()
         self.rlz_or_stat_cbx.setEnabled(True)
-        self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
+        if len(self.rlzs_or_stats) == 1:
+            self.rlz_or_stat_cbx.addItem('mean', self.rlzs_or_stats[0])
+        else:
+            self.rlz_or_stat_cbx.addItems(self.rlzs_or_stats)
 
     def populate_loss_type_cbx(self, loss_types):
         self.loss_type_cbx.clear()
@@ -422,7 +425,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         #       which currently is always true.
         #       If different realizations have a different number of sites, we
         #       need to move this block of code inside on_rlz_or_stat_changed()
-        rlz_or_stat_data = self.npz_file[self.rlz_or_stat_cbx.currentText()]
+        rlz_or_stat_data = self.npz_file[self.rlz_or_stat_cbx.currentData()]
         self.num_sites_lbl.setText(
             self.num_sites_msg % rlz_or_stat_data.shape)
 

--- a/svir/dialogs/load_uhs_as_layer_dialog.py
+++ b/svir/dialogs/load_uhs_as_layer_dialog.py
@@ -82,7 +82,7 @@ class LoadUhsAsLayerDialog(LoadOutputAsLayerDialog):
         self.show_num_sites()
 
     def on_rlz_or_stat_changed(self):
-        self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentText()]
+        self.dataset = self.npz_file['all'][self.rlz_or_stat_cbx.currentData()]
         self.poes = self.dataset.dtype.names
         self.poe_cbx.clear()
         self.poe_cbx.setEnabled(True)

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -816,7 +816,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         if len(rlzs) == 1:
             self.rlz_cbx.addItem('mean', rlzs[0])
         else:
-            self.rlz_cbx.addItems(rlzs)
+            for rlz in rlzs:
+                self.rlz_cbx.addItem(rlz, rlz)
         self.rlz_cbx.blockSignals(False)
 
         loss_types = composite_risk_model_attrs['loss_types']
@@ -2077,7 +2078,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     writer.writerow(row)
             elif self.output_type == 'damages-rlzs_aggr':
                 csv_file.write(
-                    "# Realization: %s\r\n" % self.rlz_cbx.currentText())
+                    "# Realization: %s\r\n" % self.rlz_cbx.currentData())
                 csv_file.write(
                     "# Loss type: %s\r\n" % self.loss_type_cbx.currentText())
                 csv_file.write(

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -813,7 +813,10 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             return
         self.rlz_cbx.blockSignals(True)
         self.rlz_cbx.clear()
-        self.rlz_cbx.addItems(rlzs)
+        if len(rlzs) == 1:
+            self.rlz_cbx.addItem('mean', rlzs[0])
+        else:
+            self.rlz_cbx.addItems(rlzs)
         self.rlz_cbx.blockSignals(False)
 
         loss_types = composite_risk_model_attrs['loss_types']

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.18.0
+    * When only one realization is extracted from the engine, it is considered as the mean
     * Increased numpy.load parameter max_header_size to 100000 in order to prevent errors extracting some hazard curves
     * Added visualization of OEP and AEP for event-based risk and damage calculations
     3.17.8


### PR DESCRIPTION
Addresses part of https://github.com/gem/oq-irmt-qgis/issues/839

Especially in the case with `collect_rlzs=true` it is pointless to display individual realizations. In case only one realization is available, it still makes sense to consider it as the mean.