### PR TITLE
Test with qgis versions 3.22, 3.34 and 3.36

### DIFF
--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -22,8 +22,9 @@ jobs:
         # NOTE: it would be better to point to lts and latest if possible
         # NOTE: checking also master to make sure risk workshop demos keep working also on master
         ENGINE_BR: ['engine-3.16', 'engine-3.19', 'master']
-        # NOTE: keep it updated with QGIS ltr
-        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_34', 'qgis/qgis:latest']
+        # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
+        # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
+        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:release-3_34', 'qgis/qgis:release-3_36']
         DEMOS: ['oqdata', 'risk-oqdata']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
         # NOTE: macos complains about wheels; windows complains about script syntax
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ubuntu-latest]
-        QGIS_DOCKER_VERSION: ['qgis/qgis:final-3_8_3', 'qgis/qgis:release-3_34', 'qgis/qgis:latest']
+        # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
+        # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
+        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:release-3_34', 'qgis/qgis:release-3_36']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
3.22 is the version of qgis-server we are currently using with the Geoviewer.
3.34 and 3.36 are the current ltr and latest, but using qgis/qgis:ltr and qgis/qgis:latest does not seem to work properly at the moment.