### PR TITLE
Backport to master the recent fixes made for 3.19

### DIFF
--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -80,15 +80,11 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             self.eid = self.get_closest_element(self.eid, events['id'])
             ok = True
         elif 'scenario' in self.calculation_mode:
-            range_width = self.oqparam['number_of_ground_motion_fields']
-            ranges = {}
+            ids_str = ''
             for gsim_idx, gsim in enumerate(self.gsims):
-                ranges[gsim] = (gsim_idx * range_width,
-                                gsim_idx * range_width + range_width - 1)
-            ranges_str = ''
-            for gsim in ranges:
-                ranges_str += '\n%s: %s' % (gsim, ranges[gsim])
-            input_msg = "Ranges:%s" % ranges_str
+                ids = events[events['rlz_id'] == gsim_idx]['id']
+                ids_str += '\n%s: %s' % (gsim, ids)
+            input_msg = "Events:%s" % ids_str
         else:
             input_msg = "Range (%s - %s)" % (events[0]['id'], events[-1]['id'])
         if 'GEM_QGIS_TEST' not in os.environ:

--- a/svir/dialogs/load_ruptures_as_layer_dialog.py
+++ b/svir/dialogs/load_ruptures_as_layer_dialog.py
@@ -105,7 +105,8 @@ class LoadRupturesAsLayerDialog(LoadOutputAsLayerDialog):
         return field_types
 
     def load_from_npz(self):
-        boundaries = gzip.decompress(self.npz_file['boundaries']).split(b'\n')
+        boundaries = gzip.decompress(
+            bytes(self.npz_file['boundaries'])).split(b'\n')
         row_wkt_geom_types = {
             row_idx: QgsGeometry.fromWkt(boundary.decode('utf8')).wkbType()
             for row_idx, boundary in enumerate(boundaries)}

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -1272,7 +1272,8 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.table.setRowCount(nrows)
         self.table.setColumnCount(ncols)
         if self.output_type == 'avg_losses-rlzs_aggr':
-            self.table.setHorizontalHeaderLabels(self.rlzs)
+            labels = ['Mean'] if len(self.rlzs) == 1 else self.rlzs
+            self.table.setHorizontalHeaderLabels(labels)
         else:  # self.output_type == 'avg_losses-stats_aggr'
             self.table.setHorizontalHeaderLabels(self.stats)
         if tags is not None:  # NOTE: case with '*'

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,10 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.20.0
+    3.19.1
+    * Fixed the loader for ruptures
+    * Different way to select the event and the GMPE in oq-engine scenario calculations
+    * Fixed the header of aggregated average losses realizations in case of oq-engine parameter collect_rlzs=True
     3.19.0
     * Improved integration tests, checking compatibility with python 3.9, 3.10 and 3.11 and with test cases used in risk workshops
     3.18.0

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -1229,7 +1229,10 @@ def write_metadata_to_layer(
 
 def zoom_to_group(group):
     extent = QgsRectangle()
-    extent.setMinimal()
+    if Qgis.QGIS_VERSION_INT < 33400:
+        extent.setMinimal()
+    else:
+        extent.setNull()
     # Iterate through layers from group and combine their extent
     for child in group.children():
         if isinstance(child, QgsLayerTreeLayer):


### PR DESCRIPTION
    * Fixed the loader for ruptures
    * Different way to select the event and the GMPE in oq-engine scenario calculations
    * Fixed the header of aggregated average losses realizations in case of oq-engine parameter collect_rlzs=True
    * Fixed a deprecation warning