### PR TITLE
Test on qgis ltr and latest using Xvfb

### DIFF
--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -24,7 +24,7 @@ jobs:
         ENGINE_BR: ['engine-3.16', 'engine-3.19', 'master']
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
-        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:release-3_34', 'qgis/qgis:release-3_36']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
         DEMOS: ['oqdata', 'risk-oqdata']
     steps:
       - uses: actions/checkout@v2
@@ -33,6 +33,27 @@ jobs:
         with:
           python-version: '3.10'
           ref: ${{ matrix.ENGINE_BR }}
+      - name: Prepare Start file for docker
+        run: |
+          set -x
+          $(cat << EOF  > ./startX.sh
+          apt update --allow-releaseinfo-change
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit python3-pytest python3-pexpect xvfb git expect
+          chmod +x /tests_directory/qgis_startup.py
+          cp /tests_directory/qgis_startup.py /usr/bin/
+          cp /tests_directory/qgis_testrunner.py /usr/bin/
+          export DISPLAY=:1.0
+          Xvfb :1 -screen 0 1024x768x16
+          EOF
+          )
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_setup.sh
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.sh
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.py
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_startup.py
+          chmod +x ./qgis_setup.sh
+          chmod +x ./qgis_testrunner.sh
+          chmod +x ./qgis_testrunner.py
+          chmod +x ./startX.sh
       - name: ⏳ Clone engine and restore oqdata and docker container
         run: |
           set -x
@@ -71,10 +92,9 @@ jobs:
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
           # NOTE: release-3_28 needs to be kept updated to the current LTS
           docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e DISPLAY=:99  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
-          -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }}
-          docker exec qgis bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
-          docker exec qgis bash -c "python3 -m pip install pytest"
-          # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
+            -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
+            bash -c "/tests_directory/startX.sh"
+          sleep 10
       - name: ℧ Run unit test
         run: |
           set -x
@@ -82,7 +102,8 @@ jobs:
           IRMT_BR=$ENGINE_BR
           git fetch
           git checkout $IRMT_BR
-          docker exec -t qgis bash -c "export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete pytest -v /tests_directory/svir/test/unit/"
+          # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
+          docker exec -t qgis bash -c "export DISPLAY=:1.0; export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete pytest -v /tests_directory/svir/test/unit/"
       - name: ⨕ Run Integration test
         run: |
           set -x
@@ -107,10 +128,10 @@ jobs:
           echo "OQ_CHECK_MISSING_OUTPUTS: ${OQ_CHECK_MISSING_OUTPUTS}"
           echo "OQ_TEST_RUN_CALC: ${OQ_TEST_RUN_CALC}"
           # NOTE: the check on the existence of the engine branch is already done in the previous step
-          docker exec qgis sh -c "echo 'Running against oq-engine on branch ${ENGINE_BR}'"
-          docker exec qgis sh -c "qgis_setup.sh svir"
+          docker exec qgis sh -c "export DISPLAY=:1.0; echo 'Running against oq-engine on branch ${ENGINE_BR}'"
+          docker exec qgis sh -c "export DISPLAY=:1.0; qgis_setup.sh svir"
           docker exec -e OQ_CHECK_MISSING_OUTPUTS=${OQ_CHECK_MISSING_OUTPUTS} -e OQ_TEST_RUN_CALC=${OQ_TEST_RUN_CALC} \
-          -t qgis sh -c "env && cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+          -t qgis sh -c "export DISPLAY=:1.0; env && cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -24,7 +24,7 @@ jobs:
         ENGINE_BR: ['engine-3.16', 'engine-3.19', 'master']
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
-        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:stable']
         DEMOS: ['oqdata', 'risk-oqdata']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -90,7 +90,6 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
-          # NOTE: release-3_28 needs to be kept updated to the current LTS
           docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e DISPLAY=:99  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
             -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
             bash -c "/tests_directory/startX.sh"
@@ -129,9 +128,9 @@ jobs:
           echo "OQ_TEST_RUN_CALC: ${OQ_TEST_RUN_CALC}"
           # NOTE: the check on the existence of the engine branch is already done in the previous step
           docker exec qgis sh -c "export DISPLAY=:1.0; echo 'Running against oq-engine on branch ${ENGINE_BR}'"
-          docker exec qgis sh -c "export DISPLAY=:1.0; qgis_setup.sh svir"
+          docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
           docker exec -e OQ_CHECK_MISSING_OUTPUTS=${OQ_CHECK_MISSING_OUTPUTS} -e OQ_TEST_RUN_CALC=${OQ_TEST_RUN_CALC} \
-          -t qgis sh -c "export DISPLAY=:1.0; env && cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+          -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -22,8 +22,8 @@ jobs:
         # NOTE: it would be better to point to lts and latest if possible
         # NOTE: checking also master to make sure risk workshop demos keep working also on master
         ENGINE_BR: ['engine-3.16', 'engine-3.19', 'master']
-        # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
+        # NOTE: qgis:stable points to the latest release, wheread qgis:latest points to qgis master
         QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:stable']
         DEMOS: ['oqdata', 'risk-oqdata']
     steps:

--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -90,8 +90,8 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
-          docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e DISPLAY=:99  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
-            -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
+          docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+            -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
             bash -c "/tests_directory/startX.sh"
           sleep 10
       - name: ℧ Run unit test
@@ -102,7 +102,7 @@ jobs:
           git fetch
           git checkout $IRMT_BR
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
-          docker exec -t qgis bash -c "export DISPLAY=:1.0; export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete pytest -v /tests_directory/svir/test/unit/"
+          docker exec -t qgis bash -c "export DISPLAY=:1.0; export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete python3 -m pytest -v /tests_directory/svir/test/unit/"
       - name: ⨕ Run Integration test
         run: |
           set -x
@@ -130,7 +130,7 @@ jobs:
           docker exec qgis sh -c "export DISPLAY=:1.0; echo 'Running against oq-engine on branch ${ENGINE_BR}'"
           docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
           docker exec -e OQ_CHECK_MISSING_OUTPUTS=${OQ_CHECK_MISSING_OUTPUTS} -e OQ_TEST_RUN_CALC=${OQ_TEST_RUN_CALC} \
-          -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+            -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && ./qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,8 +113,8 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          # NOTE: the check on the existence of the engine branch is already done in the previous step
-          docker exec qgis sh -c "export DISPLAY=:1.0; echo 'Running against oq-engine/$GITHUB_BR'"
+          # NOTE: cloning the engine is needed to find the demos directory, therefore being able to test running a calculation
+          docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
           docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && ./qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Prepare Start file for docker
         run: |
-          cat << EOF > ./startX.sh
           set -x
+          cat > ./startX.sh << EOF
           apt update --allow-releaseinfo-change
           DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
           python3 -m pip install pytest
@@ -41,6 +41,7 @@ jobs:
           EOF 
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |
+          cat startX.sh
           PY_VER=${{ matrix.PYTHON_VERSION }}
           echo "Python version to use: $PY_VER"
           python3 --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest]
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
-        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:stable']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,15 +66,22 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
+          tee startX.sh <<EOF
+          apt update --allow-releaseinfo-change
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+          python3 -m pip install pytest
+          export DISPLAY=:1.0 
+          Xvfb :1 -screen 0 1024x768x16
+EOF 
+          chmod +x startX.sh
           docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
-              bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb tini; \
-              python3 -m pip install pytest; DISPLAY=:1.0; export DISPLAY; tini -v -- Xvfb :1 -screen 0 1024x768x16"
+              bash -c "/tests_directory/startX.sh"
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |
           set -x
-          docker exec -t qgis bash -c "export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete python3 -m pytest -v /tests_directory/svir/test/unit/"
+          docker exec -t qgis bash -c "export DISPLAY=:1.0; export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete python3 -m pytest -v /tests_directory/svir/test/unit/"
       - name: ⨕ Run Integration test
         run: |
           set -x
@@ -92,14 +99,14 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          docker exec qgis sh -c "git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
-          docker exec qgis sh -c "qgis_setup.sh svir"
-          docker exec -t qgis sh -c "cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+          docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
+          docker exec qgis sh -c "export DISPLAY=:1.0; qgis_setup.sh svir"
+          docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation
         run: |
           set -x
-          docker exec qgis sh -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
-          docker exec -t qgis sh -c "export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir/help; make latexpdf; make html"
+          docker exec qgis sh -c "export DISPLAY=:1.0; apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y latexmk texlive-latex-extra python3-matplotlib python3-sphinx python3-sphinx-rtd-theme dvipng"
+          docker exec -t qgis sh -c "export DISPLAY=:1.0; export PYTHONPATH=$PYTHONPATH:/tests_directory; cd /tests_directory/svir/help; make latexpdf; make html"
       - name: ㏒ Display web logs
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
           fi
           docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
-          docker exec -t qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+          docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory; ./qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          sudo apt-get purge --auto-remove git
+          apt-get purge --auto-remove git
           curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
           ls -lrt install.py
           echo "Engine branch: ${ENGINE_BR}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,9 +67,9 @@ jobs:
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
           docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
-              -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
+              -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb tini; \
-              DISPLAY=:1.0; export DISPLAY; tini -v -- Xvfb :1 -screen 0 1024x768x16 &> xvfb.log &"
+              python3 -m pip install pytest; DISPLAY=:1.0; export DISPLAY; tini -v -- Xvfb :1 -screen 0 1024x768x16"
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
+          apt-get purge --auto-remove git
           curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
           ls -lrt install.py
           echo "Engine branch: ${ENGINE_BR}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,19 +33,21 @@ jobs:
           set -x
           $(cat << EOF  > ./startX.sh
           apt update --allow-releaseinfo-change
-          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb git
-          python3 -m pip install pytest
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit python3-pytest python3-pexpect xvfb git expect
           chmod +x /tests_directory/qgis_startup.py
           cp /tests_directory/qgis_startup.py /usr/bin/
+          cp /tests_directory/qgis_testrunner.py /usr/bin/
           export DISPLAY=:1.0 
           Xvfb :1 -screen 0 1024x768x16
           EOF
           ) 
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_setup.sh
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.sh
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.py
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_startup.py
           chmod +x ./qgis_setup.sh
           chmod +x ./qgis_testrunner.sh
+          chmod +x ./qgis_testrunner.py
           chmod +x ./startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |
@@ -89,7 +91,7 @@ jobs:
           docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
-          sleep 20
+          sleep 10
           docker ps -a
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,7 @@ jobs:
           apt update --allow-releaseinfo-change
           DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb git
           python3 -m pip install pytest
+          chmod +x /tests_directory/qgis_startup.py
           cp /tests_directory/qgis_startup.py /usr/bin/
           export DISPLAY=:1.0 
           Xvfb :1 -screen 0 1024x768x16
@@ -45,7 +46,6 @@ jobs:
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_startup.py
           chmod +x ./qgis_setup.sh
           chmod +x ./qgis_testrunner.sh
-          chmod +x ./qgis_startup.sh
           chmod +x ./startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          apt-get purge --auto-remove git
+          sudo apt-get purge --auto-remove git
           curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
           ls -lrt install.py
           echo "Engine branch: ${ENGINE_BR}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,7 +115,7 @@ jobs:
           fi
           docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
-          docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory; ./qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+          docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && ./qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,14 +32,20 @@ jobs:
         run: |
           set -x
           #cat > ./startX.sh << EOF
-          {
-            apt update --allow-releaseinfo-change
-            DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
-            python3 -m pip install pytest
-            export DISPLAY=:1.0 
-            Xvfb :1 -screen 0 1024x768x16 &
-            ps -aux | grep X
-          } >> startX.sh
+          $(cat << EOF  > ./startX.sh
+          first line
+          second line
+          third line
+          EOF
+          ) 
+          #{
+          #  apt update --allow-releaseinfo-change
+          #  DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+          #  python3 -m pip install pytest
+          #  export DISPLAY=:1.0 
+          #  Xvfb :1 -screen 0 1024x768x16 &
+          #  ps -aux | grep X
+          #} >> startX.sh
           ls -lrt startX.sh
           cat startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           set -x
           $(cat << EOF  > ./startX.sh
           apt update --allow-releaseinfo-change
-          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb git
           python3 -m pip install pytest
           export DISPLAY=:1.0 
           Xvfb :1 -screen 0 1024x768x16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,8 @@ jobs:
           ps -aux | grep X
           EOF 
           chmod +x startX.sh
-          docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+          cat startX.sh
+          docker run -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
           docker ps -a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
           chmod +x startX.sh
           cat startX.sh
-          docker run -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+          docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
           docker ps -a

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,11 +69,13 @@ jobs:
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
           tee startX.sh <<EOF
+          set -x
           apt update --allow-releaseinfo-change
           DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
           python3 -m pip install pytest
           export DISPLAY=:1.0 
-          Xvfb :1 -screen 0 1024x768x16
+          Xvfb :1 -screen 0 1024x768x16 &
+          ps -aux | grep X
           EOF 
           chmod +x startX.sh
           docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,21 +31,14 @@ jobs:
       - name: Prepare Start file for docker
         run: |
           set -x
-          #cat > ./startX.sh << EOF
           $(cat << EOF  > ./startX.sh
-          first line
-          second line
-          third line
+          apt update --allow-releaseinfo-change
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+          python3 -m pip install pytest
+          export DISPLAY=:1.0 
+          Xvfb :1 -screen 0 1024x768x16
           EOF
           ) 
-          #{
-          #  apt update --allow-releaseinfo-change
-          #  DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
-          #  python3 -m pip install pytest
-          #  export DISPLAY=:1.0 
-          #  Xvfb :1 -screen 0 1024x768x16 &
-          #  ps -aux | grep X
-          #} >> startX.sh
           ls -lrt startX.sh
           cat startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,14 +31,17 @@ jobs:
       - name: Prepare Start file for docker
         run: |
           set -x
-          cat > ./startX.sh << EOF
-          apt update --allow-releaseinfo-change
-          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
-          python3 -m pip install pytest
-          export DISPLAY=:1.0 
-          Xvfb :1 -screen 0 1024x768x16 &
-          ps -aux | grep X
-          EOF 
+          #cat > ./startX.sh << EOF
+          {
+            apt update --allow-releaseinfo-change
+            DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+            python3 -m pip install pytest
+            export DISPLAY=:1.0 
+            Xvfb :1 -screen 0 1024x768x16 &
+            ps -aux | grep X
+          } >> startX.sh
+          ls -lrt startX.sh
+          cat startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |
           cat startX.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
         # QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
-        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_34', 'qgis/qgis:release-3_36']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:latest']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
@@ -39,11 +39,11 @@ jobs:
           Xvfb :1 -screen 0 1024x768x16
           EOF
           ) 
-          ls -lrt startX.sh
-          cat startX.sh
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_setup.sh
+          chmod +x ./qgis_setup.sh
+          chmod +x ./startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |
-          cat startX.sh
           PY_VER=${{ matrix.PYTHON_VERSION }}
           echo "Python version to use: $PY_VER"
           python3 --version
@@ -81,14 +81,9 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
-          chmod +x startX.sh
-          cat startX.sh
           docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
-          docker ps -a
-          sleep 20
-          docker ps -a
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |
@@ -112,7 +107,7 @@ jobs:
               ENGINE_BR='master';
           fi
           docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
-          docker exec qgis sh -c "export DISPLAY=:1.0; qgis_setup.sh svir"
+          docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
           docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: ℧ Run unit test
         run: |
           set -x
-          docker exec -t qgis bash -c "export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete pytest -v /tests_directory/svir/test/unit/"
+          docker exec -t qgis bash -c "export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete python3 -m pytest -v /tests_directory/svir/test/unit/"
       - name: ⨕ Run Integration test
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,8 @@ jobs:
         # NOTE: macos complains about wheels; windows complains about script syntax
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ubuntu-latest]
-        # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
+        # NOTE: qgis:stable points to the latest release, wheread qgis:latest points to qgis master
         QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:stable']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,9 @@ jobs:
           EOF
           ) 
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_setup.sh
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.sh
           chmod +x ./qgis_setup.sh
+          chmod +x ./qgis_testrunner.sh
           chmod +x ./startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,17 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.PYTHON_VERSION }}
+      - name: Prepare Start file for docker
+        run: |
+          cat << EOF > ./startX.sh
+          set -x
+          apt update --allow-releaseinfo-change
+          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+          python3 -m pip install pytest
+          export DISPLAY=:1.0 
+          Xvfb :1 -screen 0 1024x768x16 &
+          ps -aux | grep X
+          EOF 
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |
           PY_VER=${{ matrix.PYTHON_VERSION }}
@@ -67,15 +78,6 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
-          cat <<EOF > ./startX.sh
-           set -x
-           apt update --allow-releaseinfo-change
-           DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
-           python3 -m pip install pytest
-           export DISPLAY=:1.0 
-           Xvfb :1 -screen 0 1024x768x16 &
-           ps -aux | grep X
-          EOF 
           chmod +x startX.sh
           cat startX.sh
           docker run -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,10 @@ jobs:
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
         # QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
-        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:latest']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
-        PYTHON_VERSION: ['3.9', '3.10', '3.11']
+        # PYTHON_VERSION: ['3.9', '3.10', '3.11']
+        PYTHON_VERSION: ['3.11']
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_DEF_BR: master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
           while ! nc -z 172.17.0.1 8800; do
-            tail -10 webui.log
+            cat webui.log
             sleep 5
           done
           curl http://172.17.0.1:8800/v1/engine_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |
-          set -x
           PY_VER=${{ matrix.PYTHON_VERSION }}
           echo "Python version to use: $PY_VER"
           python3 --version
@@ -78,9 +77,12 @@ jobs:
           ps -aux | grep X
           EOF 
           chmod +x startX.sh
-          docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+          docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
+          docker ps -a
+          sleep 20
+          docker ps -a
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,17 @@ jobs:
           apt update --allow-releaseinfo-change
           DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb git
           python3 -m pip install pytest
+          cp /tests_directory/qgis_startup.py /usr/bin/
           export DISPLAY=:1.0 
           Xvfb :1 -screen 0 1024x768x16
           EOF
           ) 
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_setup.sh
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.sh
+          curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_startup.py
           chmod +x ./qgis_setup.sh
           chmod +x ./qgis_testrunner.sh
+          chmod +x ./qgis_startup.sh
           chmod +x ./startX.sh
       - name: ⏳ Install engine and restore oqdata and docker container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
         # QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
-        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:latest']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_34', 'qgis/qgis:release-3_36']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,14 +67,14 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
-          tee startX.sh <<EOF
-          set -x
-          apt update --allow-releaseinfo-change
-          DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
-          python3 -m pip install pytest
-          export DISPLAY=:1.0 
-          Xvfb :1 -screen 0 1024x768x16 &
-          ps -aux | grep X
+          cat <<EOF > ./startX.sh
+           set -x
+           apt update --allow-releaseinfo-change
+           DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb 
+           python3 -m pip install pytest
+           export DISPLAY=:1.0 
+           Xvfb :1 -screen 0 1024x768x16 &
+           ps -aux | grep X
           EOF 
           chmod +x startX.sh
           cat startX.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,8 @@ jobs:
           docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
+          sleep 20
+          docker ps -a
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
         os: [ubuntu-latest]
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
-        QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:release-3_34', 'qgis/qgis:release-3_36']
+        # QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:latest']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
@@ -65,10 +66,10 @@ jobs:
           #
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
-          docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e DISPLAY=:99  -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
-          -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }}
-          docker exec qgis bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit"
-          docker exec qgis bash -c "python3 -m pip install pytest"
+          docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+              -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE"  -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
+              bash -c "apt update --allow-releaseinfo-change; DEBIAN_FRONTEND=noninteractive apt install -y python3-scipy python3-matplotlib python3-pyqt5.qtwebkit xvfb tini; \
+              DISPLAY=:1.0; export DISPLAY; tini -v -- Xvfb :1 -screen 0 1024x768x16 &> xvfb.log &"
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
           oq reset -y
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq --version
+          oq engine --run /home/runner/openquake/demos/hazard/AreaSourceClassicalPSHA/job.ini
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
           while ! nc -z 172.17.0.1 8800; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,7 +112,7 @@ jobs:
           fi
           docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
-          docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
+          docker exec -t qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation
         run: |
           set -x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,9 +57,11 @@ jobs:
           source $HOME/openquake/bin/activate
           oq reset -y
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
+          oq --version
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
           while ! nc -z 172.17.0.1 8800; do
+            tail -10 webui.log
             sleep 5
           done
           curl http://172.17.0.1:8800/v1/engine_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,6 @@ jobs:
           oq reset -y
           oq restore https://artifacts.openquake.org/travis/oqdata-${ENGINE_BR}.zip ~/oqdata
           oq --version
-          oq engine --run /home/runner/openquake/demos/hazard/AreaSourceClassicalPSHA/job.ini
           oq webui start 172.17.0.1:8800 --skip-browser &> webui.log &
           echo "Waiting WEBUI up on port 8800...."
           while ! nc -z 172.17.0.1 8800; do

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,7 +78,7 @@ jobs:
           ps -aux | grep X
           EOF 
           chmod +x startX.sh
-          docker run -d --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
+          docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v `pwd`:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
               -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
               bash -c "/tests_directory/startX.sh"
           # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,9 @@ jobs:
         os: [ubuntu-latest]
         # FIXME: ltr and latest tags in April 11 2024 seem to be bugged, so we are using release-3_34 and release-3_36 instead
         # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
-        # QGIS_DOCKER_VERSION: ['qgis/qgis:release-3_22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
-        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:latest']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
-        # PYTHON_VERSION: ['3.9', '3.10', '3.11']
-        PYTHON_VERSION: ['3.11']
+        PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     env:
       GITHUB_DEF_BR: master
@@ -38,10 +36,10 @@ jobs:
           chmod +x /tests_directory/qgis_startup.py
           cp /tests_directory/qgis_startup.py /usr/bin/
           cp /tests_directory/qgis_testrunner.py /usr/bin/
-          export DISPLAY=:1.0 
+          export DISPLAY=:1.0
           Xvfb :1 -screen 0 1024x768x16
           EOF
-          ) 
+          )
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_setup.sh
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.sh
           curl -O https://raw.githubusercontent.com/qgis/QGIS/master/.docker/qgis_resources/test_runner/qgis_testrunner.py
@@ -90,14 +88,13 @@ jobs:
           DOCKER_HOST=`ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+'`
           ENGINE_HOST=`echo http://$DOCKER_HOST:8800`
           docker run -d -t --name qgis -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/tests_directory -e OQ_ENGINE_HOST='http://172.17.0.1:8800' \
-              -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
-              bash -c "/tests_directory/startX.sh"
+            -e BRANCH="$IRMT_BR" -e ONLY_CALC_ID="$ONLY_CALC_ID" -e ONLY_OUTPUT_TYPE="$ONLY_OUTPUT_TYPE" -e GEM_QGIS_TEST=y ${{ matrix.QGIS_DOCKER_VERSION }} \
+            bash -c "/tests_directory/startX.sh"
           sleep 10
-          docker ps -a
-          # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
       - name: ℧ Run unit test
         run: |
           set -x
+          # OGR_SQLITE_JOURNAL=delete prevents QGIS from using WAL, which modifies geopackages even if they are just read
           docker exec -t qgis bash -c "export DISPLAY=:1.0; export PYTHONPATH=/usr/share/qgis/python/plugins/:$PYTHONPATH; OGR_SQLITE_JOURNAL=delete python3 -m pytest -v /tests_directory/svir/test/unit/"
       - name: ⨕ Run Integration test
         run: |
@@ -116,7 +113,8 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          docker exec qgis sh -c "export DISPLAY=:1.0; git clone -q -b $ENGINE_BR --depth=1 https://github.com/gem/oq-engine.git && echo 'Running against oq-engine/$GITHUB_BR'"
+          # NOTE: the check on the existence of the engine branch is already done in the previous step
+          docker exec qgis sh -c "export DISPLAY=:1.0; echo 'Running against oq-engine/$GITHUB_BR'"
           docker exec qgis sh -c "export DISPLAY=:1.0; /tests_directory/qgis_setup.sh svir"
           docker exec -t qgis sh -c "export DISPLAY=:1.0; cd /tests_directory && ./qgis_testrunner.sh svir.test.integration.test_drive_oq_engine"
       - name: 📖 Make documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,6 @@ jobs:
           if [ "$(git ls-remote --heads https://github.com/gem/oq-engine.git ${ENGINE_BR})" == "" ]; then
               ENGINE_BR='master';
           fi
-          apt-get purge --auto-remove git
           curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
           ls -lrt install.py
           echo "Engine branch: ${ENGINE_BR}"

--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -170,7 +170,7 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
         rlz_id = self.events_npz['array'][
             np.where(self.events_npz['array']['id'] == self.eid)]['rlz_id']
         self.rlz_or_stat_cbx.setCurrentIndex(
-            self.rlz_or_stat_cbx.itemData(int(rlz_id)))
+            self.rlz_or_stat_cbx.itemData(rlz_id.item()))
 
     def on_rlz_or_stat_changed(self):
         gmpe = self.rlz_or_stat_cbx.currentText()

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -73,65 +73,52 @@ def run_all():
     print(f'ONLY_OUTPUT_TYPE: {ONLY_OUTPUT_TYPE}')
     print(f'OQ_CHECK_MISSING_OUTPUTS: {OQ_CHECK_MISSING_OUTPUTS}')
     print(f'OQ_TEST_RUN_CALC: {OQ_TEST_RUN_CALC}')
-    suite = unittest.TestSuite()
-    # OQ_CSV_TO_LAYER_TYPES
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAggRiskTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAggLossesStatsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadDmgByEventTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadEventsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAggLossTableTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadRealizationsTestCase, 'test'))
-    # OQ_EXTRACT_TO_LAYER_TYPES
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAssetRiskTestCase, 'test'))
-    # NOTE: testing recovery curves starting from damages-rlzs
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadDamagesRlzsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAvgLossesRlzsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAvgLossesStatsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadGmfDataTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadHcurvesTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadHmapsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadRupturesTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadUhsTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadDisaggRlzsTestCase, 'test'))
-    # OQ_ZIPPED_TYPES
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadInputTestCase, 'test'))
-    # OQ_RST_TYPES
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadFullReportTestCase, 'test'))
-    # OQ_EXTRACT_TO_VIEW_TYPES
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAggCurvesTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadDamagesRlzsAggrTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAvgLossesRlzsAggrTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        LoadAvgLossesStatsAggrTestCase, 'test'))
-
+    csv_to_layer_test_cases = [
+        LoadAggRiskTestCase,
+        LoadAggLossesStatsTestCase,
+        LoadDmgByEventTestCase,
+        LoadEventsTestCase,
+        LoadAggLossTableTestCase,
+        LoadRealizationsTestCase,
+    ]
+    extract_to_layer_test_cases = [
+        LoadAssetRiskTestCase,
+        # NOTE: testing recovery curves starting from damages-rlzs
+        LoadDamagesRlzsTestCase,
+        LoadAvgLossesRlzsTestCase,
+        LoadAvgLossesStatsTestCase,
+        LoadGmfDataTestCase,
+        LoadHcurvesTestCase,
+        LoadHmapsTestCase,
+        LoadRupturesTestCase,
+        LoadUhsTestCase,
+        LoadDisaggRlzsTestCase,
+    ]
+    zipped_test_cases = [LoadInputTestCase]
+    rst_test_cases = [LoadFullReportTestCase]
+    extract_to_view_test_cases = [
+        LoadAggCurvesTestCase,
+        LoadDamagesRlzsAggrTestCase,
+        LoadAvgLossesRlzsAggrTestCase,
+        LoadAvgLossesStatsAggrTestCase,
+    ]
+    test_cases = []
+    test_cases.extend(csv_to_layer_test_cases)
+    test_cases.extend(extract_to_layer_test_cases)
+    test_cases.extend(zipped_test_cases)
+    test_cases.extend(rst_test_cases)
+    test_cases.extend(extract_to_view_test_cases)
     # Other tests and checks
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        RunCalculationTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        AllLoadableOutputsFoundInDemosTestCase, 'test'))
-    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
-        AllLoadersAreImplementedTestCase, 'test'))
+    test_cases.extend([
+        RunCalculationTestCase,
+        AllLoadableOutputsFoundInDemosTestCase,
+        AllLoadersAreImplementedTestCase,
+    ])
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    for test_class in test_cases:
+        tests = loader.loadTestsFromTestCase(test_class)
+        suite.addTests(tests)
     unittest.TextTestRunner(verbosity=3, stream=sys.stdout).run(suite)
 
 

--- a/svir/test/integration/test_drive_oq_engine.py
+++ b/svir/test/integration/test_drive_oq_engine.py
@@ -75,39 +75,63 @@ def run_all():
     print(f'OQ_TEST_RUN_CALC: {OQ_TEST_RUN_CALC}')
     suite = unittest.TestSuite()
     # OQ_CSV_TO_LAYER_TYPES
-    suite.addTest(unittest.makeSuite(LoadAggRiskTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadAggLossesStatsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadDmgByEventTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadEventsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadAggLossTableTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadRealizationsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAggRiskTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAggLossesStatsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadDmgByEventTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadEventsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAggLossTableTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadRealizationsTestCase, 'test'))
     # OQ_EXTRACT_TO_LAYER_TYPES
-    suite.addTest(unittest.makeSuite(LoadAssetRiskTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAssetRiskTestCase, 'test'))
     # NOTE: testing recovery curves starting from damages-rlzs
-    suite.addTest(unittest.makeSuite(LoadDamagesRlzsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadAvgLossesRlzsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadAvgLossesStatsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadGmfDataTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadHcurvesTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadHmapsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadRupturesTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadUhsTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadDisaggRlzsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadDamagesRlzsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAvgLossesRlzsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAvgLossesStatsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadGmfDataTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadHcurvesTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadHmapsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadRupturesTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadUhsTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadDisaggRlzsTestCase, 'test'))
     # OQ_ZIPPED_TYPES
-    suite.addTest(unittest.makeSuite(LoadInputTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadInputTestCase, 'test'))
     # OQ_RST_TYPES
-    suite.addTest(unittest.makeSuite(LoadFullReportTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadFullReportTestCase, 'test'))
     # OQ_EXTRACT_TO_VIEW_TYPES
-    suite.addTest(unittest.makeSuite(LoadAggCurvesTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadDamagesRlzsAggrTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadAvgLossesRlzsAggrTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(LoadAvgLossesStatsAggrTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAggCurvesTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadDamagesRlzsAggrTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAvgLossesRlzsAggrTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        LoadAvgLossesStatsAggrTestCase, 'test'))
 
     # Other tests and checks
-    suite.addTest(unittest.makeSuite(RunCalculationTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        RunCalculationTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
         AllLoadableOutputsFoundInDemosTestCase, 'test'))
-    suite.addTest(unittest.makeSuite(AllLoadersAreImplementedTestCase, 'test'))
+    suite.addTest(unittest.TestLoader.loadTestsFromTestCase(
+        AllLoadersAreImplementedTestCase, 'test'))
     unittest.TextTestRunner(verbosity=3, stream=sys.stdout).run(suite)
 
 

--- a/svir/test/unit/test_irmt.py
+++ b/svir/test/unit/test_irmt.py
@@ -61,6 +61,6 @@ class IrmtTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(IrmtTest)
+    suite = unittest.TestLoader.loadTestsFromTestCase(IrmtTest)
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/svir/test/unit/test_irmt.py
+++ b/svir/test/unit/test_irmt.py
@@ -61,6 +61,9 @@ class IrmtTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader.loadTestsFromTestCase(IrmtTest)
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    tests = loader.loadTestsFromTestCase(IrmtTest)
+    suite.addTests(tests)
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/svir/test/unit/test_metadata_utilities.py
+++ b/svir/test/unit/test_metadata_utilities.py
@@ -84,6 +84,6 @@ class TestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    my_suite = unittest.makeSuite(TestCase, 'test')
+    my_suite = unittest.TestLoader.loadTestsFromTestCase(TestCase, 'test')
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(my_suite)

--- a/svir/test/unit/test_metadata_utilities.py
+++ b/svir/test/unit/test_metadata_utilities.py
@@ -84,6 +84,9 @@ class TestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    my_suite = unittest.TestLoader.loadTestsFromTestCase(TestCase, 'test')
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    tests = loader.loadTestsFromTestCase(TestCase)
+    suite.addTests(tests)
     runner = unittest.TextTestRunner(verbosity=2)
-    runner.run(my_suite)
+    runner.run(suite)

--- a/svir/test/unit/test_translations.py
+++ b/svir/test/unit/test_translations.py
@@ -58,6 +58,9 @@ class SafeTranslationsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader.loadTestsFromTestCase(SafeTranslationsTest)
+    suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
+    tests = loader.loadTestsFromTestCase(SafeTranslationsTest)
+    suite.addTests(tests)
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)

--- a/svir/test/unit/test_translations.py
+++ b/svir/test/unit/test_translations.py
@@ -58,6 +58,6 @@ class SafeTranslationsTest(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    suite = unittest.makeSuite(SafeTranslationsTest)
+    suite = unittest.TestLoader.loadTestsFromTestCase(SafeTranslationsTest)
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)


### PR DESCRIPTION
Tests running on qgis 3.22, 3.34 (ltr) and 3.36 (stable) for python 3.9, 3.10 and 3.11 are green: https://github.com/gem/oq-irmt-qgis/actions/runs/9017144804
Tests checking compatibility between corresponding releases of the plugin and of the engine still have a couple of failures to be fixed in a separate PR: https://github.com/gem/oq-irmt-qgis/actions/runs/9017667633/job/24776590661#step:7:1588