### PR TITLE
Temporarily remove tests for qgis 3.22

### DIFF
--- a/.github/workflows/qgis_ltr_engine_releases.yml
+++ b/.github/workflows/qgis_ltr_engine_releases.yml
@@ -22,9 +22,9 @@ jobs:
         # NOTE: it would be better to point to lts and latest if possible
         # NOTE: checking also master to make sure risk workshop demos keep working also on master
         ENGINE_BR: ['engine-3.16', 'engine-3.19', 'master']
-        # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
+        # NOTE: we might test also for qgis/qgis:3.22 that is the version of qgis-server that we are currently using in the Geoviewer, but it currently causes a segfault
         # NOTE: qgis:stable points to the latest release, wheread qgis:latest points to qgis master
-        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:stable']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:stable']
         DEMOS: ['oqdata', 'risk-oqdata']
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,9 @@ jobs:
         # NOTE: macos complains about wheels; windows complains about script syntax
         # os: [ubuntu-latest, windows-latest, macos-latest]
         os: [ubuntu-latest]
-        # NOTE: testing also for 3.22 because it is the version of qgis-server that we are currently using in the Geoviewer
+        # NOTE: we might test also for qgis/qgis:3.22 that is the version of qgis-server that we are currently using in the Geoviewer, but it currently causes a segfault
         # NOTE: qgis:stable points to the latest release, wheread qgis:latest points to qgis master
-        QGIS_DOCKER_VERSION: ['qgis/qgis:3.22', 'qgis/qgis:ltr', 'qgis/qgis:stable']
+        QGIS_DOCKER_VERSION: ['qgis/qgis:ltr', 'qgis/qgis:stable']
         # NOTE: qgis uses its own python, but we want to check if there are problems interfacing with the engine while it uses different python versions
         PYTHON_VERSION: ['3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
On qgis 3.22 the segfault sometimes happens, sometimes it does not. I prefer to keep it disabled for now.