### PR TITLE
When loading gmfs, include secondary perils (if available) to the imt selector

### DIFF
--- a/svir/dialogs/load_gmf_data_as_layer_dialog.py
+++ b/svir/dialogs/load_gmf_data_as_layer_dialog.py
@@ -186,6 +186,9 @@ class LoadGmfDataAsLayerDialog(LoadOutputAsLayerDialog):
             imts = list(self.oqparam['hazard_imtls'])
         except KeyError:
             imts = list(self.oqparam['risk_imtls'])
+        if 'sec_imts' in self.oqparam:
+            # add secondary perils (if present) to the list of imts
+            imts.extend(self.oqparam['sec_imts'])
         self.imt_cbx.clear()
         self.imt_cbx.setEnabled(True)
         self.imt_cbx.addItems(imts)

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.20.1
+    * When loading ground motion fields from an OpenQuake calculation, secondary perils (if available) are added to the selectable IMTs
     3.20.0
     * Aligned with oq-engine 3.20
     3.19.2

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, to develop composite indicators and integrate them with physical risk estimations, and to predict building recovery times following an earthquake
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided. The toolkit also enables users to develop composite indicators to measure and quantify social characteristics, and combine them with estimates of human or infrastructure loss. A post-earthquake recovery modeling framework is incorporated into the toolkit, to produce building level and/or community level recovery functions.
-version=3.20.0
+version=3.21.0
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,7 +23,7 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    3.20.1
+    3.21.0
     * When loading ground motion fields from an OpenQuake calculation, secondary perils (if available) are added to the selectable IMTs
     3.20.0
     * Aligned with oq-engine 3.20


### PR DESCRIPTION
Companion of https://github.com/gem/oq-engine/pull/9915