### PR TITLE
Fix zonal aggregation for damages_rlzs and automatically create special indices

### DIFF
--- a/svir/dialogs/load_damages_rlzs_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_rlzs_as_layer_dialog.py
@@ -159,7 +159,7 @@ class LoadDamagesRlzsAsLayerDialog(LoadOutputAsLayerDialog):
         else:
             field_names = list(self.dataset.dtype.names)
         if self.zonal_layer_gbx.isChecked():
-            self.default_field_name = "%s_%s" % (
+            self.default_field_name = "%s-%s" % (
                 self.loss_type_cbx.currentText(),
                 self.dmg_state_cbx.currentText())
         if self.aggregate_by_site_ckb.isChecked():

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -1021,11 +1021,16 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         if not have_same_projection:
             log_msg(check_projection_msg, level='W',
                     message_bar=self.iface.messageBar())
-        try:
-            [self.loss_attr_name] = [
-                field.name() for field in loss_layer.fields()]
-        except ValueError:
+        loss_layer_fieldnames = [field.name() for field in loss_layer.fields()]
+        if len(loss_layer_fieldnames) == 1:
+            self.loss_attr_name = loss_layer_fieldnames[0]
+        elif self.default_field_name in loss_layer_fieldnames:
             self.loss_attr_name = self.default_field_name
+        else:
+            msg = (f'Field {self.default_field_name} to be used for the'
+                   f' aggregation was not found')
+            log_msg(msg, level='C', message_bar=self.iface.messageBar())
+            return
         zonal_layer_plus_sum_name = "%s: %s_sum" % (
             zonal_layer.name(), self.loss_attr_name)
         discard_nonmatching = self.discard_nonmatching_chk.isChecked()

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -474,7 +474,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                     loss_type=None, dmg_state=None, gsim=None, imt=None,
                     boundaries=None, geometry_type='point', wkt_geom_type=None,
                     row_wkt_geom_types=None, add_to_group=None,
-                    add_to_map=True):
+                    add_to_map=True, create_spatial_index=True):
         layer_name = self.build_layer_name(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt,
@@ -567,6 +567,8 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 self.iface.zoomToActiveLayer()
             log_msg('Layer %s was created successfully' % layer_name,
                     level='S', message_bar=self.iface.messageBar())
+        if create_spatial_index:
+            self.layer.dataProvider().createSpatialIndex()
         return self.layer
 
     @staticmethod


### PR DESCRIPTION
It would be important to know since which version of the engine the convention `losstype_dmgstate` changed to `losstype-dmgstate`, and backport this fix to all versions that need this change.