### PR TITLE
Do not display the Remove calculation button if the current user is not the owner of the calculation

### DIFF
--- a/svir/dialogs/drive_oq_engine_server_dialog.py
+++ b/svir/dialogs/drive_oq_engine_server_dialog.py
@@ -271,7 +271,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
     def login(self):
         self.session = Session()
         if not self.forced_hostname:
-            self.hostname, username, password = get_credentials()
+            self.hostname, self.username, password = get_credentials()
         # try without authentication (if authentication is disabled server
         # side)
         # NOTE: check_is_lockdown() can raise exceptions,
@@ -282,7 +282,7 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
             return
         with WaitCursorManager('Logging in...', self.message_bar):
             # it can raise exceptions, caught by self.attempt_login
-            engine_login(self.hostname, username, password, self.session)
+            engine_login(self.hostname, self.username, password, self.session)
             # if no exception occurred
             self.is_logged_in = True
             return
@@ -419,6 +419,11 @@ class DriveOqEngineServerDialog(QDialog, FORM_CLASS):
                 if btn_lbl == 'Remove' and calc_status not in ('failed',
                                                                'complete',
                                                                'shared'):
+                    continue
+                # Display the Remove button only if the current user owns the job
+                # (getting the calc owner from something like 'username@machine')
+                calc_owner = calc['owner'].rsplit('@', 1)[0]
+                if btn_lbl == 'Remove' and self.username != calc_owner:
                     continue
 
                 # Display the Outputs and Continue buttons

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,8 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.24.0
+    3.23.2
+    * The 'Remove' calculation button is not shown if the current user is not the owner of the calculation
     3.23.1
     * Fixed zonal aggregation for the damages_rlzs oq-engine output
     * When any layer is created from a oq-engine output, a spatial index is also created for that layer


### PR DESCRIPTION
Even if the button was present, the engine would refuse to remove a calculation without the proper credentials. However the fact that the button was displayed anyway looked a little confusing.