### PR TITLE
When loading damages-rlzs or damages-stats, make it possible to select damage or consequences

### DIFF
--- a/svir/dialogs/load_avg_losses_as_layer_dialog.py
+++ b/svir/dialogs/load_avg_losses_as_layer_dialog.py
@@ -169,6 +169,8 @@ class LoadAvgLossesAsLayerDialog(LoadOutputAsLayerDialog):
         return self.layer
 
     def load_from_npz(self):
+        # when aggregating by zone, create the point layer but keep it unchecked
+        set_visible = not self.zonal_layer_gbx.isChecked()
         for rlz_or_stat in self.rlzs_or_stats:
             if (self.load_selected_only_ckb.isChecked()
                     and rlz_or_stat != self.rlz_or_stat_cbx.currentData()):
@@ -188,7 +190,7 @@ class LoadAvgLossesAsLayerDialog(LoadOutputAsLayerDialog):
                             self.iface.messageBar()):
                         self.layer = self.build_layer(
                             rlz_or_stat, taxonomy=taxonomy,
-                            loss_type=loss_type)
+                            loss_type=loss_type, set_visible=set_visible)
                         self.style_maps(self.layer,
                                         self.default_field_name,
                                         self.iface, self.output_type)

--- a/svir/dialogs/load_damages_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_as_layer_dialog.py
@@ -373,7 +373,7 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                             rlz_or_stat, taxonomy, loss_type, dmg_state)):
                         self.layer = self.build_layer(
                             rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
-                            dmg_state=dmg_state, visible=False)
+                            dmg_state=dmg_state, set_visible=False)
                 else:  # 'Consequences'
                     with WaitCursorManager(
                         'Creating layer for "%s", taxonomy "%s", loss type "%s"'
@@ -381,7 +381,7 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                             rlz_or_stat, taxonomy, loss_type, consequence)):
                         self.layer = self.build_layer(
                             rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
-                            consequence=consequence, visible=False)
+                            consequence=consequence, set_visible=False)
                 self.style_maps(self.layer, self.default_field_name,
                                 self.iface, self.output_type)
 

--- a/svir/dialogs/load_damages_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_as_layer_dialog.py
@@ -373,7 +373,7 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                             rlz_or_stat, taxonomy, loss_type, dmg_state)):
                         self.layer = self.build_layer(
                             rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
-                            dmg_state=dmg_state)
+                            dmg_state=dmg_state, visible=False)
                 else:  # 'Consequences'
                     with WaitCursorManager(
                         'Creating layer for "%s", taxonomy "%s", loss type "%s"'
@@ -381,7 +381,7 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                             rlz_or_stat, taxonomy, loss_type, consequence)):
                         self.layer = self.build_layer(
                             rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
-                            consequence=consequence)
+                            consequence=consequence, visible=False)
                 self.style_maps(self.layer, self.default_field_name,
                                 self.iface, self.output_type)
 

--- a/svir/dialogs/load_damages_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_as_layer_dialog.py
@@ -96,7 +96,7 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
         self.init_done.emit(self)
 
     def set_ok_button(self):
-        if self.kind == 'Damage':
+        if self.damage_or_consequences == 'Damage':
             self.ok_button.setEnabled(self.dmg_state_cbx.currentIndex() != -1
                                       and self.loss_type_cbx.currentIndex() != -1)
         else:  # 'Consequences'

--- a/svir/dialogs/load_damages_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_as_layer_dialog.py
@@ -96,6 +96,9 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
         self.init_done.emit(self)
 
     def set_ok_button(self):
+        if not hasattr(self, 'damage_or_consequences'):
+            self.ok_button.setEnabled(False)
+            return
         if self.damage_or_consequences == 'Damage':
             self.ok_button.setEnabled(self.dmg_state_cbx.currentIndex() != -1
                                       and self.loss_type_cbx.currentIndex() != -1)

--- a/svir/dialogs/load_damages_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_as_layer_dialog.py
@@ -27,16 +27,14 @@ import collections
 from qgis.core import (
     QgsFeature, QgsGeometry, QgsPointXY, edit, QgsTask, QgsApplication)
 from svir.dialogs.load_output_as_layer_dialog import LoadOutputAsLayerDialog
-from svir.utilities.utils import (WaitCursorManager,
-                                  log_msg,
-                                  get_attrs,
-                                  )
+from svir.utilities.utils import WaitCursorManager, log_msg, get_attrs
 from svir.tasks.extract_npz_task import ExtractNpzTask
 
 
 class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
     """
-    Dialog to load damages-rlzs or damages-stats from an oq-engine output, as layer
+    Dialog to load damages-rlzs or damages-stats from an
+    oq-engine output, as layer
     """
 
     def __init__(self, drive_engine_dlg, iface, viewer_dock, session, hostname,
@@ -50,13 +48,24 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
             zonal_layer_path=zonal_layer_path, engine_version=engine_version,
             calculation_mode=calculation_mode)
 
-        self.setWindowTitle('Load scenario damage by asset as layer')
+        self.setWindowTitle(
+            'Load scenario damages/consequences by asset as layer')
         self.create_load_selected_only_ckb()
         self.create_num_sites_indicator()
         self.create_rlz_or_stat_selector()
         self.create_taxonomy_selector()
+
+        attrs = get_attrs(self.session, self.hostname, self.calc_id,
+                          self.iface.messageBar())
+        self.limit_states = attrs['limit_states']
+        self.loss_types = attrs['loss_types']
+        self.dmg_states = ['no_damage'] + self.limit_states
+        self.consequences = attrs['consequences']
+
         self.create_loss_type_selector()
+        self.create_damage_or_consequences_selector()  # damages or consequences
         self.create_dmg_state_selector()
+        self.create_consequence_selector()
         self.create_aggregate_by_site_ckb()
         self.create_zonal_layer_selector()
 
@@ -75,17 +84,7 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
 
     def finalize_init(self, extracted_npz):
         self.npz_file = extracted_npz
-
-        # NOTE: still running this synchronously, because it's small stuff
-        with WaitCursorManager('Loading loss types and damage states...',
-                               self.iface.messageBar()):
-            attrs = get_attrs(self.session, self.hostname, self.calc_id,
-                              self.iface.messageBar())
-            self.loss_types = attrs['loss_types']
-            self.dmg_states = ['no_damage'] + attrs['limit_states']
-
         self.populate_out_dep_widgets()
-
         if self.zonal_layer_path:
             zonal_layer = self.load_zonal_layer(self.zonal_layer_path)
             self.populate_zonal_layer_cbx(zonal_layer)
@@ -97,8 +96,12 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
         self.init_done.emit(self)
 
     def set_ok_button(self):
-        self.ok_button.setEnabled(self.dmg_state_cbx.currentIndex() != -1
-                                  and self.loss_type_cbx.currentIndex() != -1)
+        if self.kind == 'Damage':
+            self.ok_button.setEnabled(self.dmg_state_cbx.currentIndex() != -1
+                                      and self.loss_type_cbx.currentIndex() != -1)
+        else:  # 'Consequences'
+            self.ok_button.setEnabled(self.consequence_cbx.currentIndex() != -1
+                                      and self.loss_type_cbx.currentIndex() != -1)
 
     def on_aggregate_by_site_ckb_toggled(self, on):
         if on:
@@ -123,8 +126,29 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
     def populate_out_dep_widgets(self):
         self.populate_rlz_or_stat_cbx()
         self.populate_loss_type_cbx(self.loss_types)
+        self.populate_damage_or_consequences_cbx()
         self.populate_dmg_state_cbx()
+        self.populate_consequence_cbx()
         self.show_num_sites()
+
+    def populate_damage_or_consequences_cbx(self):
+        items = ['Damage']
+        if self.consequences:
+            items.append('Consequences')
+        self.damage_or_consequences_cbx.addItems(items)
+
+    def on_damage_or_consequences_changed(self, text):
+        self.damage_or_consequences = text
+        if self.damage_or_consequences == 'Damage':
+            self.consequence_lbl.hide()
+            self.consequence_cbx.hide()
+            self.dmg_state_lbl.show()
+            self.dmg_state_cbx.show()
+        else:
+            self.dmg_state_lbl.hide()
+            self.dmg_state_cbx.hide()
+            self.consequence_lbl.show()
+            self.consequence_cbx.show()
 
     def populate_taxonomy_cbx(self, taxonomies):
         self.taxonomies.insert(0, 'All')
@@ -137,40 +161,57 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
         self.dmg_state_cbx.setEnabled(True)
         self.dmg_state_cbx.addItems(self.dmg_states)
 
+    def populate_consequence_cbx(self):
+        self.consequence_cbx.clear()
+        self.consequence_cbx.setEnabled(True)
+        self.consequence_cbx.addItems(self.consequences)
+
     def build_layer_name(self, rlz_or_stat=None, **kwargs):
         taxonomy = kwargs['taxonomy']
         loss_type = kwargs['loss_type']
         dmg_state = kwargs['dmg_state']
+        consequence = kwargs['consequence']
         rlzs_or_stats = 'rlzs' if self.output_type == 'damages-rlzs' else 'stats'
+        layer_name = f'damages-{rlzs_or_stats}_{rlz_or_stat}_'
         if (self.aggregate_by_site_ckb.isChecked() or
                 self.zonal_layer_gbx.isChecked()):
-            layer_name = (f'damages-{rlzs_or_stats}_{rlz_or_stat}_{taxonomy}'
-                          f'_{loss_type}_{dmg_state}')
+            if self.damage_or_consequences == 'Damage':
+                layer_name += f'{taxonomy}_{loss_type}_{dmg_state}'
+            else:
+                layer_name += f'{taxonomy}_{loss_type}_{consequence}'
         else:  # also needed for recovery modeling
-            layer_name = f'damages-{rlzs_or_stats}_{rlz_or_stat}_{loss_type}'
+            layer_name += loss_type
         return layer_name
 
     def get_field_types(self, **kwargs):
         loss_type = kwargs['loss_type']
         dmg_state = kwargs['dmg_state']
+        consequence = kwargs['consequence']
         if self.aggregate_by_site_ckb.isChecked():
-            ltds = "%s_%s_mean" % (loss_type, dmg_state)
+            if self.damage_or_consequences == 'Damage':
+                ltds = "%s_%s_mean" % (loss_type, dmg_state)
+            else:  # 'Consequences'
+                ltds = "%s_%s_mean" % (loss_type, consequence)
             field_names = ['lon', 'lat', ltds]
             self.default_field_name = ltds
         else:
             field_names = list(self.dataset.dtype.names)
         if self.zonal_layer_gbx.isChecked():
-            self.default_field_name = "%s-%s" % (
-                self.loss_type_cbx.currentText(),
-                self.dmg_state_cbx.currentText())
+            if self.damage_or_consequences == 'Damage':
+                self.default_field_name = "%s-%s" % (
+                    self.loss_type_cbx.currentText(),
+                    self.dmg_state_cbx.currentText())
+            else:  # 'Consequences'
+                self.default_field_name = "%s-%s" % (
+                    self.loss_type_cbx.currentText(),
+                    self.consequence_cbx.currentText())
         if self.aggregate_by_site_ckb.isChecked():
             field_types = {field_name: 'F' for field_name in field_names}
         else:
             field_types = {}
             for field_name in field_names:
                 try:
-                    field_types[field_name] = self.dataset.dtype[
-                        field_name].kind
+                    field_types[field_name] = self.dataset.dtype[field_name].kind
                 except KeyError:
                     field_types[field_name] = 'F'
         return field_types
@@ -204,8 +245,8 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                         if isinstance(value, bytes):
                             value = value.decode('utf8').strip('"')
                     else:
-                        value = row[
-                            loss_type][field_name[len(loss_type)+1:]].item()
+                        value = row[loss_type][
+                            field_name[len(loss_type)+1:]].item()
                     feat.setAttribute(field_name, value)
                 feat.setGeometry(QgsGeometry.fromPointXY(
                     QgsPointXY(row['lon'], row['lat'])))
@@ -222,10 +263,11 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
         loss_type = kwargs['loss_type']
         taxonomy = kwargs['taxonomy']
         dmg_state = kwargs['dmg_state']
+        consequence = kwargs['consequence']
         with edit(self.layer):
             feats = []
             grouped_by_site = self.group_by_site(
-                self.npz_file, rlz_or_stat, loss_type, dmg_state, taxonomy)
+                self.npz_file, rlz_or_stat, loss_type, dmg_state, consequence, taxonomy)
             for row in grouped_by_site:
                 # add a feature
                 feat = QgsFeature(self.layer.fields())
@@ -245,13 +287,16 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                 log_msg(msg, level='C', message_bar=self.iface.messageBar())
         return self.layer
 
-    def group_by_site(self, npz, rlz_or_stat, loss_type, dmg_state,
+    def group_by_site(self, npz, rlz_or_stat, loss_type, dmg_state, consequence,
                       taxonomy='All'):
         F32 = numpy.float32
         dmg_by_site = collections.defaultdict(float)  # lon, lat -> dmg
         for rec in npz[rlz_or_stat]:
             if taxonomy == 'All' or taxonomy.encode('utf8') == rec['taxonomy']:
-                value = rec[f'{loss_type}-{dmg_state}']
+                if self.damage_or_consequences == 'Damage':
+                    value = rec[f'{loss_type}-{dmg_state}']
+                else:
+                    value = rec[f'{loss_type}-{consequence}']
                 dmg_by_site[rec['lon'], rec['lat']] += value
         data = numpy.zeros(
             len(dmg_by_site),
@@ -274,33 +319,67 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                         if (self.load_selected_only_ckb.isChecked() and
                                 loss_type != self.loss_type_cbx.currentText()):
                             continue
-                        for dmg_state in self.dmg_states:
-                            if (self.load_selected_only_ckb.isChecked() and
-                                    dmg_state != self.dmg_state_cbx.currentText()):  # NOQA
-                                continue
-                            with WaitCursorManager(
-                                    'Creating layer for "%s",'
-                                    ' taxonomy "%s", loss type "%s" and'
-                                    ' damage state "%s"...' % (
-                                    rlz_or_stat, taxonomy, loss_type,
-                                    dmg_state), self.iface.messageBar()):
-                                self.layer = self.build_layer(
-                                    rlz_or_stat, taxonomy=taxonomy,
-                                    loss_type=loss_type, dmg_state=dmg_state)
-                                self.style_maps(self.layer,
-                                                self.default_field_name,
-                                                self.iface, self.output_type)
+                        if self.damage_or_consequences == 'Damage':
+                            for dmg_state in self.dmg_states:
+                                if (self.load_selected_only_ckb.isChecked() and
+                                        dmg_state != self.dmg_state_cbx.currentText()):  # NOQA
+                                    continue
+                                with WaitCursorManager(
+                                        'Creating layer for "%s",'
+                                        ' taxonomy "%s", loss type "%s" and'
+                                        ' damage state "%s"...' % (
+                                            rlz_or_stat, taxonomy, loss_type,
+                                            dmg_state),
+                                        self.iface.messageBar()):
+                                    self.layer = self.build_layer(
+                                        rlz_or_stat, taxonomy=taxonomy,
+                                        loss_type=loss_type,
+                                        dmg_state=dmg_state)
+                                    self.style_maps(
+                                        self.layer, self.default_field_name,
+                                        self.iface, self.output_type)
+                        else:  # 'Consequences'
+                            for consequence in self.consequences:
+                                if (self.load_selected_only_ckb.isChecked() and
+                                        consequence != self.consequence_cbx.currentText()):  # NOQA
+                                    continue
+                                with WaitCursorManager(
+                                        'Creating layer for "%s",'
+                                        ' taxonomy "%s", loss type "%s" and'
+                                        ' consequence "%s"...' % (
+                                            rlz_or_stat, taxonomy, loss_type,
+                                            consequence),
+                                        self.iface.messageBar()):
+                                    self.layer = self.build_layer(
+                                        rlz_or_stat, taxonomy=taxonomy,
+                                        loss_type=loss_type,
+                                        consequence=consequence)
+                                    self.style_maps(
+                                        self.layer, self.default_field_name,
+                                        self.iface, self.output_type)
             elif self.zonal_layer_gbx.isChecked():
                 taxonomy = self.taxonomy_cbx.currentText()
                 loss_type = self.loss_type_cbx.currentText()
                 dmg_state = self.dmg_state_cbx.currentText()
-                with WaitCursorManager(
-                    'Creating layer for "%s", taxonomy "%s", loss type "%s"'
-                    ' and damage state "%s"...' % (
-                        rlz_or_stat, taxonomy, loss_type, dmg_state)):
-                    self.layer = self.build_layer(
-                        rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
-                        dmg_state=dmg_state)
+                consequence = self.consequence_cbx.currentText()
+
+                if self.damage_or_consequences == 'Damage':
+                    with WaitCursorManager(
+                        'Creating layer for "%s", taxonomy "%s", loss type "%s"'
+                        ' and damage state "%s"...' % (
+                            rlz_or_stat, taxonomy, loss_type, dmg_state)):
+                        self.layer = self.build_layer(
+                            rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
+                            dmg_state=dmg_state)
+                else:  # 'Consequences'
+                    with WaitCursorManager(
+                        'Creating layer for "%s", taxonomy "%s", loss type "%s"'
+                        ' and consequence "%s"...' % (
+                            rlz_or_stat, taxonomy, loss_type, consequence)):
+                        self.layer = self.build_layer(
+                            rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
+                            consequence=consequence)
+
             else:  # also needed for recovery modeling
                 for loss_type in self.loss_types:
                     if (self.load_selected_only_ckb.isChecked()

--- a/svir/dialogs/load_damages_as_layer_dialog.py
+++ b/svir/dialogs/load_damages_as_layer_dialog.py
@@ -382,6 +382,8 @@ class LoadDamagesAsLayerDialog(LoadOutputAsLayerDialog):
                         self.layer = self.build_layer(
                             rlz_or_stat, taxonomy=taxonomy, loss_type=loss_type,
                             consequence=consequence)
+                self.style_maps(self.layer, self.default_field_name,
+                                self.iface, self.output_type)
 
             else:  # also needed for recovery modeling
                 for loss_type in self.loss_types:

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -255,13 +255,21 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.poe_cbx.setEnabled(state == Qt.Unchecked)
 
     def create_loss_type_selector(self):
-        self.loss_type_lbl = QLabel('Loss Type')
+        self.loss_type_lbl = QLabel('Loss Category')
         self.loss_type_cbx = QComboBox()
         self.loss_type_cbx.setEnabled(False)
         self.loss_type_cbx.currentIndexChanged['QString'].connect(
             self.on_loss_type_changed)
         self.vlayout.addWidget(self.loss_type_lbl)
         self.vlayout.addWidget(self.loss_type_cbx)
+
+    def create_damage_or_consequences_selector(self):
+        self.damage_or_consequences_lbl = QLabel('Type')
+        self.damage_or_consequences_cbx = QComboBox()
+        self.damage_or_consequences_cbx.currentTextChanged['QString'].connect(
+            self.on_damage_or_consequences_changed)
+        self.vlayout.addWidget(self.damage_or_consequences_lbl)
+        self.vlayout.addWidget(self.damage_or_consequences_cbx)
 
     def create_eid_selector(self):
         self.eid_lbl = QLabel('Event ID')
@@ -271,13 +279,20 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.vlayout.addWidget(self.eid_sbx)
 
     def create_dmg_state_selector(self):
-        self.dmg_state_lbl = QLabel('Damage state')
+        self.dmg_state_lbl = QLabel('Damage State')
         self.dmg_state_cbx = QComboBox()
         self.dmg_state_cbx.setEnabled(False)
         self.dmg_state_cbx.currentIndexChanged['QString'].connect(
             self.on_dmg_state_changed)
         self.vlayout.addWidget(self.dmg_state_lbl)
         self.vlayout.addWidget(self.dmg_state_cbx)
+
+    def create_consequence_selector(self):
+        self.consequence_lbl = QLabel('Consequence Type')
+        self.consequence_cbx = QComboBox()
+        self.consequence_cbx.setEnabled(False)
+        self.vlayout.addWidget(self.consequence_lbl)
+        self.vlayout.addWidget(self.consequence_cbx)
 
     def create_taxonomy_selector(self):
         self.taxonomy_lbl = QLabel('Taxonomy')
@@ -287,7 +302,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
         self.vlayout.addWidget(self.taxonomy_cbx)
 
     def create_style_by_selector(self):
-        self.style_by_lbl = QLabel('Style by')
+        self.style_by_lbl = QLabel('Style By')
         self.style_by_cbx = QComboBox()
         self.vlayout.addWidget(self.style_by_lbl)
         self.vlayout.addWidget(self.style_by_cbx)
@@ -472,16 +487,18 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
 
     def build_layer(self, rlz_or_stat=None, taxonomy=None, poe=None,
                     loss_type=None, dmg_state=None, gsim=None, imt=None,
+                    consequence=None,
                     boundaries=None, geometry_type='point', wkt_geom_type=None,
                     row_wkt_geom_types=None, add_to_group=None,
                     add_to_map=True, create_spatial_index=True):
         layer_name = self.build_layer_name(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt,
+            consequence=consequence,
             geometry_type=geometry_type)
         field_types = self.get_field_types(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
-            loss_type=loss_type, dmg_state=dmg_state, imt=imt)
+            loss_type=loss_type, dmg_state=dmg_state, imt=imt, consequence=consequence)
 
         # create layer
         self.layer = QgsVectorLayer(
@@ -501,7 +518,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
 
         self.layer = self.read_npz_into_layer(
             field_types, rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
-            loss_type=loss_type, dmg_state=dmg_state, imt=imt,
+            loss_type=loss_type, dmg_state=dmg_state, consequence=consequence, imt=imt,
             boundaries=boundaries, geometry_type=geometry_type,
             wkt_geom_type=wkt_geom_type,
             row_wkt_geom_types=row_wkt_geom_types)
@@ -536,6 +553,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                        'poe': poe,
                        'loss_type': loss_type,
                        'dmg_state': dmg_state,
+                       'consequence': consequence,
                        'gsim': gsim,
                        'imt': imt}
         write_metadata_to_layer(

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -490,7 +490,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                     consequence=None,
                     boundaries=None, geometry_type='point', wkt_geom_type=None,
                     row_wkt_geom_types=None, add_to_group=None,
-                    add_to_map=True, create_spatial_index=True, visible=True):
+                    add_to_map=True, create_spatial_index=True, set_visible=True):
         layer_name = self.build_layer_name(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt,
@@ -585,7 +585,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 self.iface.zoomToActiveLayer()
             log_msg('Layer %s was created successfully' % layer_name,
                     level='S', message_bar=self.iface.messageBar())
-            if not visible:
+            if not set_visible:
                 layer_node = tree_node.findLayer(self.layer.id())
                 if layer_node:
                     layer_node.setItemVisibilityChecked(False)

--- a/svir/dialogs/load_output_as_layer_dialog.py
+++ b/svir/dialogs/load_output_as_layer_dialog.py
@@ -490,7 +490,7 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                     consequence=None,
                     boundaries=None, geometry_type='point', wkt_geom_type=None,
                     row_wkt_geom_types=None, add_to_group=None,
-                    add_to_map=True, create_spatial_index=True):
+                    add_to_map=True, create_spatial_index=True, visible=True):
         layer_name = self.build_layer_name(
             rlz_or_stat=rlz_or_stat, taxonomy=taxonomy, poe=poe,
             loss_type=loss_type, dmg_state=dmg_state, gsim=gsim, imt=imt,
@@ -585,6 +585,10 @@ class LoadOutputAsLayerDialog(QDialog, FORM_CLASS):
                 self.iface.zoomToActiveLayer()
             log_msg('Layer %s was created successfully' % layer_name,
                     level='S', message_bar=self.iface.messageBar())
+            if not visible:
+                layer_node = tree_node.findLayer(self.layer.id())
+                if layer_node:
+                    layer_node.setItemVisibilityChecked(False)
         if create_spatial_index:
             self.layer.dataProvider().createSpatialIndex()
         return self.layer

--- a/svir/dialogs/viewer_dock.py
+++ b/svir/dialogs/viewer_dock.py
@@ -154,12 +154,12 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             ('', ''),
             ('hcurves', 'Hazard Curves'),
             ('uhs', 'Uniform Hazard Spectra'),
-            ('aggcurves', 'Aggregate loss curves (realizations)'),
-            ('aggcurves-stats', 'Aggregate loss curves (statistics)'),
-            ('damages-rlzs_aggr', 'Damage distribution (realizations)'),
-            ('damages-stats_aggr', 'Damage distribution (statistics)'),
-            ('avg_losses-rlzs_aggr', 'Loss distribution'),
-            ('avg_losses-stats_aggr', 'Average assets losses (statistics)'),
+            ('aggcurves', 'Aggregate Risk Curves'),
+            ('aggcurves-stats', 'Aggregate Risk Curves Statistics'),
+            ('damages-rlzs_aggr', 'Asset Risk Distributions'),
+            ('damages-stats_aggr', 'Asset Risk Statistics'),
+            ('avg_losses-rlzs_aggr', 'Average Asset Losses'),
+            ('avg_losses-stats_aggr', 'Average Asset Losses Statistics'),
         ])
 
         if QSettings().value('/irmt/experimental_enabled', False, type=bool):
@@ -202,7 +202,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
         self.annot.get_bbox_patch().set_alpha(0.4)
 
     def create_loss_type_selector(self):
-        self.loss_type_lbl = QLabel('Loss Type')
+        self.loss_type_lbl = QLabel('Loss Category')
         self.loss_type_lbl.setSizePolicy(
             QSizePolicy.Minimum, QSizePolicy.Minimum)
         self.loss_type_cbx = QComboBox()
@@ -1150,7 +1150,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             else:
                 ylabel = 'Economic loss ratio'
         self.plot.set_ylabel(ylabel)
-        title = 'Loss type: %s' % self.loss_type_cbx.currentText()
+        title = 'Loss category: %s' % self.loss_type_cbx.currentText()
         self.plot.set_title(title)
         self.plot.grid(which='both')
         if 1 <= len(rlzs_or_stats) <= 20:
@@ -1897,7 +1897,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                     unit = self.agg_curves['units'][loss_type_idx]
                 except IndexError:
                     unit = self.get_total_loss_unit(loss_type)
-                csv_file.write("# Loss type: %s\r\n" % loss_type)
+                csv_file.write("# Loss category: %s\r\n" % loss_type)
                 csv_file.write("# Exceedance Probability: %s\r\n" % ep)
                 csv_file.write("# Absolute or relative: %s\r\n" % abs_rel)
                 csv_file.write("# Measurement unit: %s\r\n" % unit)
@@ -1947,7 +1947,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
                 csv_file.write(
                     "# Realization or statistic: %s\r\n" % self.rlz_or_stat_cbx.currentData())
                 csv_file.write(
-                    "# Loss type: %s\r\n" % self.loss_type_cbx.currentText())
+                    "# Loss category: %s\r\n" % self.loss_type_cbx.currentText())
                 csv_file.write(
                     "# Tags: %s\r\n" % (
                         self.get_list_selected_tags_str() or 'None'))
@@ -1960,7 +1960,7 @@ class ViewerDock(QDockWidget, FORM_CLASS):
             elif self.output_type in ('avg_losses-rlzs_aggr',
                                       'avg_losses-stats_aggr'):
                 csv_file.write(
-                    "# Loss type: %s\r\n" % self.loss_type_cbx.currentText())
+                    "# Loss category: %s\r\n" % self.loss_type_cbx.currentText())
                 csv_file.write(
                     "# Tags: %s\r\n" % (
                         self.get_list_selected_tags_str() or 'None'))

--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -24,6 +24,7 @@ email=staff.it@globalquakemodel.org
 # Uncomment the following line and add your changelog entries:
 changelog=
     3.24.1
+    * Loaders for damages-rlzs and damages-stats were improved, giving the possibility to choose between damage and consequences
     * A loader for the oq-engine output damages-stats (Asset Risk Statistics) similar to the existing one for damages-rlzs (Asset Risk Distributions) was added
     3.24.0
     * Reading multi-peril data is consistent with the recent engine-side renaming of 'multi_peril_csv' to 'multi_peril_file'


### PR DESCRIPTION
I've also uniformed some display names of output types visualized in the Data Viewer, to the same names used in the engine.

(NOTE: based on https://github.com/gem/oq-irmt-qgis/pull/887)