### PR TITLE
Prevent integer fields from being cast to booleans by QGIS when they contain only 0 or 1 values, while loading from CSV

### DIFF
--- a/svir/metadata.txt
+++ b/svir/metadata.txt
@@ -13,7 +13,7 @@ name=OpenQuake Integrated Risk Modelling Toolkit
 qgisMinimumVersion=3.0
 description=Tools to drive the OpenQuake Engine, running calculations and visualizing their parameters and outputs
 about=This plugin allows users to drive OpenQuake Engine calculations (https://github.com/gem/oq-engine) of physical hazard and risk, and to load the corresponding outputs as QGIS layers. For those outputs, data visualization tools are provided.
-version=3.24.0
+version=3.24.1
 author=GEM Foundation
 email=staff.it@globalquakemodel.org
 
@@ -23,6 +23,8 @@ email=staff.it@globalquakemodel.org
 
 # Uncomment the following line and add your changelog entries:
 changelog=
+    3.24.1
+    * When loading oq-engine outputs from CSV, fields containing only zero or one values are treated as integers instead of booleans
     3.24.0
     * Reading multi-peril data is consistent with the recent engine-side renaming of 'multi_peril_csv' to 'multi_peril_file'
     3.23.2

--- a/svir/utilities/utils.py
+++ b/svir/utilities/utils.py
@@ -898,7 +898,7 @@ def clear_widgets_from_layout(layout):
             widget.setParent(None)
 
 
-def convert_to_mem_layer_and_replace_bool_to_int(original_layer):
+def convert_to_mem_layer_and_cast_bool_fields_to_int(original_layer):
     original_fields = original_layer.fields()
     field_names = [f.name() for f in original_fields]
 
@@ -978,7 +978,7 @@ def import_layer_from_csv(parent,
     url.setQuery(url_query)
     layer_uri = url.toString()
     layer = QgsVectorLayer(layer_uri, layer_name, "delimitedtext")
-    layer = convert_to_mem_layer_and_replace_bool_to_int(layer)
+    layer = convert_to_mem_layer_and_cast_bool_fields_to_int(layer)
 
     if save_format:
         if save_format == 'ESRI Shapefile':


### PR DESCRIPTION
Fixes https://github.com/gem/oq-irmt-qgis/issues/836

When QGIS loads data from CSV, if a field contains only 0 or 1 values, its type is automatically set as boolean. When loading data from the engine, we prefer the type to be integer instead. In order to achieve that, I need to replace the automatically created boolean fields with new integer fields, casting the boolean values to int.
The tricky part I did not expect is that the layer data provider used by QGIS to manage csv-based layers does not allow adding new fields in the usual way (it fails silently while attempting to do so), so I had to perform an additional step, copying the csv-based layer into a memory layer that allows managing new features as I needed. I also had to be careful keeping the original order of the fields.